### PR TITLE
Release 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.4 (2018-05-20)
+*   _Bugfix_: When the plugin is uninstalled, the default avatar image is really
+    reset to `mystery` if necessary.
+*   _Bugfix_: The `use_gravatar` checkbox is compatible with more themes now.
+
 ## 1.0.3 (2018-05-17)
 *   _Bugfix_: The plugin no longer fails with a fatal error on PHP 5.6.
 
@@ -29,14 +34,12 @@
 *   raised minimum WordPress version to 4.2
 *   checked compatibility with WP 4.9.5
 
-
 ## 0.3 (2013-02-24)
 *   used transients API to cache results of requests to gravatar.com for a small
     amount of time
 *   added two previously untranslated strings to the translation files
 *   added a link to the label of the checkbox in the comment and user profile forms
 *   checked compatibility with WP 3.5.1
-
 
 ## 0.2 (2012-06-11)
 *   _Bugfix_: lower-case and trim E-Mail addresses before hashing to produce a
@@ -55,7 +58,6 @@
 *   added screenshots
 *   tested with WP 3.4
 *   tested with plugins User Photo and Twitter Avatar Reloaded
-
 
 ## 0.1 (2012-02-14)
 *   initial release

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -29,7 +29,7 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer, Johannes Freudendahl
  * Author URI: https://code.mundschenk.at
- * Version: 1.0.3
+ * Version: 1.0.4
  * License: GNU General Public License v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: avatar-privacy

--- a/includes/avatar-privacy/components/class-setup.php
+++ b/includes/avatar-privacy/components/class-setup.php
@@ -245,8 +245,11 @@ class Setup implements \Avatar_Privacy\Component {
 		switch ( $options->get( 'avatar_default', null, true ) ) {
 			case 'rings':
 			case 'comment':
+			case 'bubble':
 			case 'im-user-offline':
+			case 'bowling-pin':
 			case 'view-media-artist':
+			case 'silhouette':
 				$options->set( 'avatar_default', 'mystery', true, true );
 				break;
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,8 +36,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -320,15 +319,17 @@
             "chalk": "^2.4.1",
             "source-map": "^0.6.1",
             "supports-color": "^5.4.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.4.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+              "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         }
       }
@@ -666,8 +667,7 @@
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-      "dev": true
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -1136,8 +1136,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "esprima": {
       "version": "2.7.3",
@@ -1689,23 +1688,20 @@
       "dev": true
     },
     "grunt-legacy-log": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.1.tgz",
-      "integrity": "sha512-rwuyqNKlI0IPz0DvxzJjcEiQEBaBNVeb1LFoZKxSmHLETFUwhwUrqOsPIxURTKSwNZHZ4ht1YLBYmVU0YZAzHQ==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.2.tgz",
+      "integrity": "sha512-WdedTJ/6zCXnI/coaouzqvkI19uwqbcPkdsXiDRKJyB5rOUlOxnCnTVbpeUdEckKVir2uHF3rDBYppj2p6N3+g==",
       "requires": {
         "colors": "~1.1.2",
         "grunt-legacy-log-utils": "~1.0.0",
         "hooker": "~0.2.3",
-        "lodash": "~4.17.5",
-        "underscore.string": "~3.3.4"
+        "lodash": "~4.17.5"
       }
     },
     "grunt-legacy-log-utils": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
       "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
-      "dev": true,
       "requires": {
         "chalk": "~1.1.1",
         "lodash": "~4.3.0"
@@ -1714,14 +1710,12 @@
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -1733,14 +1727,12 @@
         "lodash": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
-          "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
-          "dev": true
+          "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ="
         },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -1907,7 +1899,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -1951,8 +1942,7 @@
     "hooker": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
-      "dev": true
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk="
     },
     "hosted-git-info": {
       "version": "2.6.0",
@@ -2186,9 +2176,9 @@
       "dev": true
     },
     "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz",
+      "integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ==",
       "dev": true
     },
     "js-yaml": {
@@ -2548,8 +2538,7 @@
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-      "dev": true
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -2616,9 +2605,9 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
@@ -2841,9 +2830,9 @@
       }
     },
     "node-sass": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
-      "integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
+      "integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -2858,7 +2847,7 @@
         "lodash.mergewith": "^4.6.0",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
-        "nan": "^2.3.2",
+        "nan": "^2.10.0",
         "node-gyp": "^3.3.1",
         "npmlog": "^4.0.0",
         "request": "~2.79.0",
@@ -3400,16 +3389,6 @@
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
         }
       }
     },
@@ -3603,9 +3582,9 @@
       }
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.86.0.tgz",
+      "integrity": "sha512-BQZih67o9r+Ys94tcIW4S7Uu8pthjrQVxhsZ/weOwHbDfACxvIyvnAbzFQxjy1jMtvFSzv5zf4my6cZsJBbVzw==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -3626,7 +3605,6 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.1",
         "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
         "tough-cookie": "~2.3.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.1.0"
@@ -3843,12 +3821,6 @@
       "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
       "dev": true
     },
-    "sprintf-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
-      "dev": true
-    },
     "sshpk": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
@@ -3887,9 +3859,9 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3897,14 +3869,14 @@
             "isarray": "~1.0.0",
             "process-nextick-args": "~2.0.0",
             "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
+            "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -3945,16 +3917,15 @@
       "dev": true
     },
     "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
       "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -4176,16 +4147,6 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
       "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
       "dev": true
-    },
-    "underscore.string": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
-      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "^1.0.3",
-        "util-deprecate": "^1.0.2"
-      }
     },
     "uri-path": {
       "version": "1.0.0",

--- a/public/partials/comments/use-gravatar.php
+++ b/public/partials/comments/use-gravatar.php
@@ -53,8 +53,7 @@ if ( isset( $_POST[ Comments::CHECKBOX_FIELD_NAME ] ) ) { // WPCS: CSRF ok, Inpu
 }
 ?>
 <p class="comment-form-use-gravatar">
-	<input id="<?php echo \esc_attr( Comments::CHECKBOX_FIELD_NAME ); ?>" name="<?php echo \esc_attr( Comments::CHECKBOX_FIELD_NAME ); ?>" type="checkbox" value="true" <?php \checked( $is_checked, true, false ); ?> />
-	<label
+	<input id="<?php echo \esc_attr( Comments::CHECKBOX_FIELD_NAME ); ?>" name="<?php echo \esc_attr( Comments::CHECKBOX_FIELD_NAME ); ?>" type="checkbox" value="true" <?php \checked( $is_checked, true, false ); ?> /><label
 	<?php if ( ! $disable_style ) : ?>
 		style="display:inline;"
 	<?php endif; ?>

--- a/readme.txt
+++ b/readme.txt
@@ -133,6 +133,10 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 == Changelog ==
 
+= 1.0.4 (2018-05-20) =
+* _Bugfix_: When the plugin is uninstalled, the default avatar image is really reset to `mystery` if necessary.
+* _Bugfix_: The `use_gravatar` checkbox is compatible with more themes now.
+
 = 1.0.3 (2018-05-17) =
 * _Bugfix_: The plugin no longer fails with a fatal error on PHP 5.6.
 

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: gravatar, avatar, privacy
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 4.9
-Stable tag: 1.0.3
+Stable tag: 1.0.4
 License: GPLv2 or later
 
 Adds options to enhance the privacy when using avatars.

--- a/readme.txt
+++ b/readme.txt
@@ -123,7 +123,8 @@ No, for registered users the user profile is checked, not the table for the comm
 
 I used Avatar Privacy together with these plugins:
 
-* [AntiSpam Bee](http://wordpress.org/extend/plugins/antispam-bee/)
+* [AntiSpam Bee](https://wordpress.org/plugins/antispam-bee/)
+* [EWWW Image Optimizer](https://wordpress.org/plugins/ewww-image-optimizer/)
 
 If you find any problems with particular plugins, please tell me!
 

--- a/readme.txt
+++ b/readme.txt
@@ -46,12 +46,10 @@ Avatar Privacy is based on the original plugin by [Johannes Freudendahl](http://
 
 == Installation ==
 
-= Installation =
-
-You can either install it automatically from the WordPress admin, or do it manually:
-
-1. Unzip the archive and put the 'avatar-privacy' folder into your plugins folder (/wp-content/plugins/).
-1. Activate the plugin from the Plugins menu.
+= Requirements =
+Avatar Privacy has the following additional requirements beyond those of WordPress itself:
+* Your server must run PHP 5.6.0 or later, and
+* the PHP installation must include the GD extension (most do).
 
 = Uninstallation =
 

--- a/readme.txt
+++ b/readme.txt
@@ -51,24 +51,6 @@ Avatar Privacy has the following additional requirements beyond those of WordPre
 * Your server must run PHP 5.6.0 or later, and
 * the PHP installation must include the GD extension (most do).
 
-= Uninstallation =
-
-There is a difference between deactivating the plugin and uninstalling it. The plugin gets deactivated if you do so on the plugins page or if you simply delete the plugin files via FTP. No uninstallation tasks are performed then, so you can activate and deactivate the plugin as you want without losing the plugin's settings.
-
-If you deactivate the plugin und have gravatars turned on, they will again show up for everybody, even those commenters and users who opted out of displaying gravatars. If you changed the default avatar to one of the new local avatar images, the gravatars will not be displayed until you change the default avatar image back.
-
-If you want to completely uninstall the plugin and get rid of any data in the database, you should properly uninstall it: Deactivate the plugin first via the WordPress plugins page and then click 'delete' (same page, next to the plugin). For multisite installations, this has to be done by the network administrator on the network plugins page.
-
-The plugin saves additional data about whether commenters and users want to display a gravatar or not (if you select that mode in the settings). The following data are saved and deleted upon uninstallation:
-
-* custom table(s) `[prefix]_avatar_privacy` (global or per blog on new multisite installations)
-* `usermeta` values per user: `use_gravatar`, `avatar_privacy_hash`, `avatar_privacy_user_avatar`
-* `option` per blog: `avatar_privacy_settings`
-* option per network (`sitemeta`) on multisite installations: `avatar_privacy_salt`
-* `transient` per commenter: `avapr_check_[mail hash]`
-
-The default avatar image is set to the mystery man if you selected one of the new local default avatar images.
-
 
 == Screenshots ==
 
@@ -127,6 +109,26 @@ I used Avatar Privacy together with these plugins:
 * [EWWW Image Optimizer](https://wordpress.org/plugins/ewww-image-optimizer/)
 
 If you find any problems with particular plugins, please tell me!
+
+= What happens if I remove the plugin? =
+
+There is a difference between deactivating the plugin and uninstalling it. The plugin gets deactivated if you do so on the plugins page or if you simply delete the plugin files via FTP. No uninstallation tasks are performed then, so you can activate and deactivate the plugin as you want without losing the plugin's settings.
+
+If you deactivate the plugin und have gravatars turned on, they will again show up for everybody, even those commenters and users who opted out of displaying gravatars. If you changed the default avatar to one of the new local avatar images, the gravatars will not be displayed until you change the default avatar image back.
+
+= OK, but I really want to get rid of everything. How do I that? =
+
+If you want to completely uninstall the plugin and get rid of any data in the database, you should properly uninstall it: Deactivate the plugin first via the WordPress plugins page and then click 'delete' (same page, next to the plugin). For multisite installations, this has to be done by the network administrator on the network plugins page.
+
+The plugin saves additional data about whether commenters and users want to display a gravatar or not (if you select that mode in the settings). The following data are stored by the plugin and deleted upon uninstallation:
+
+* custom table(s) `[prefix]_avatar_privacy` (global or per blog on new multisite installations)
+* `usermeta` values per user: `use_gravatar`, `avatar_privacy_hash`, `avatar_privacy_user_avatar`
+* `option` per blog: `avatar_privacy_settings`
+* option per network (`sitemeta`) on multisite installations: `avatar_privacy_salt`
+* `transient` per commenter: `avapr_check_[mail hash]`
+
+The default avatar image is set to the mystery man if you selected one of the new local default avatar images.
 
 
 == Changelog ==

--- a/todo.txt
+++ b/todo.txt
@@ -1,6 +1,0 @@
-Ideas for future development (ideas only, no promises, tell me if you'd like anything else):
-* display an explanatory text/link below the comment form, let the admin change this text in the options
-* let the admin upload a different local default image
-* check if not storing the checkbox value for spam comments works with other anti-spam plugins
-* test the plugin with more themes (some common frameworks)
-* add automated tests


### PR DESCRIPTION
- After uninstallation, the default avatar setting was invalid if one of the static default images was selected before (fixes #8).
- Themes with custom `comment_form()` calls did not display the `use_gravatar` checkbox (fixes #13).