### PR TITLE
Release 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.5 (2018-05-22)
+
+*   _Bugfix_: Prefer GD-based implementations of `WP_Image_Editor` to work around
+    [trac ticket #42663](https://core.trac.wordpress.org/ticket/42663).
+*   _Bugfix_: The `rel` and `target` attributes are allowed in `use_gravatar`
+    checkbox labels and by the default, the `noopener` and `nofollow` values for
+    the `rel` attribute are added to the Gravatar.com link.
+*   _Bugfix_: Invalid 0-byte image files are not saved anymore.
+
 ## 1.0.4 (2018-05-20)
 *   _Bugfix_: When the plugin is uninstalled, the default avatar image is really
     reset to `mystery` if necessary.

--- a/admin/partials/profile/use-gravatar.php
+++ b/admin/partials/profile/use-gravatar.php
@@ -46,7 +46,7 @@ $allowed_html = [
 			value="true"
 			<?php checked( $value ); ?>
 		/>
-		<label for="<?php echo esc_attr( self::CHECKBOX_FIELD_NAME ); ?>"><?php echo wp_kses( sprintf( /* translators: gravatar.com URL */ __( 'Display a <a href="%s">Gravatar</a> image for my e-mail address.', 'avatar-privacy' ), __( 'https://gravatar.com', 'avatar-privacy' ) ), $allowed_html ); ?></label><br />
+		<label for="<?php echo esc_attr( self::CHECKBOX_FIELD_NAME ); ?>"><?php echo wp_kses( sprintf( /* translators: gravatar.com URL */ __( 'Display a <a href="%s" rel="noopener nofollow">Gravatar</a> image for my e-mail address.', 'avatar-privacy' ), __( 'https://gravatar.com', 'avatar-privacy' ) ), $allowed_html ); ?></label><br />
 		<p class="description">
 			<?php esc_html_e( "Uncheck this box if you don't want to display the gravatar for your e-mail address (or don't have an account on Gravatar.com).", 'avatar-privacy' ); ?>
 			<?php esc_html_e( 'This setting will only take effect if you have not uploaded a local profile picture.', 'avatar-privacy' ); ?>

--- a/admin/partials/profile/use-gravatar.php
+++ b/admin/partials/profile/use-gravatar.php
@@ -46,7 +46,7 @@ $allowed_html = [
 			value="true"
 			<?php checked( $value ); ?>
 		/>
-		<label for="<?php echo esc_attr( self::CHECKBOX_FIELD_NAME ); ?>"><?php echo wp_kses( sprintf( /* translators: gravatar.com URL */ __( 'Display a <a href="%s" rel="noopener nofollow">Gravatar</a> image for my e-mail address.', 'avatar-privacy' ), __( 'https://gravatar.com', 'avatar-privacy' ) ), $allowed_html ); ?></label><br />
+		<label for="<?php echo esc_attr( self::CHECKBOX_FIELD_NAME ); ?>"><?php echo wp_kses( sprintf( /* translators: gravatar.com URL */ __( 'Display a <a href="%s" rel="noopener nofollow">Gravatar</a> image for my e-mail address.', 'avatar-privacy' ), __( 'https://en.gravatar.com/', 'avatar-privacy' ) ), $allowed_html ); ?></label><br />
 		<p class="description">
 			<?php esc_html_e( "Uncheck this box if you don't want to display the gravatar for your e-mail address (or don't have an account on Gravatar.com).", 'avatar-privacy' ); ?>
 			<?php esc_html_e( 'This setting will only take effect if you have not uploaded a local profile picture.', 'avatar-privacy' ); ?>

--- a/admin/partials/profile/use-gravatar.php
+++ b/admin/partials/profile/use-gravatar.php
@@ -46,7 +46,7 @@ $allowed_html = [
 			value="true"
 			<?php checked( $value ); ?>
 		/>
-		<label for="<?php echo esc_attr( self::CHECKBOX_FIELD_NAME ); ?>"><?php echo wp_kses( __( 'Display a <a href="https://gravatar.com">Gravatar</a> image for my e-mail address.', 'avatar-privacy' ), $allowed_html ); ?></label><br />
+		<label for="<?php echo esc_attr( self::CHECKBOX_FIELD_NAME ); ?>"><?php echo wp_kses( sprintf( /* translators: gravatar.com URL */ __( 'Display a <a href="%s">Gravatar</a> image for my e-mail address.', 'avatar-privacy' ), __( 'https://gravatar.com', 'avatar-privacy' ) ), $allowed_html ); ?></label><br />
 		<p class="description">
 			<?php esc_html_e( "Uncheck this box if you don't want to display the gravatar for your e-mail address (or don't have an account on Gravatar.com).", 'avatar-privacy' ); ?>
 			<?php esc_html_e( 'This setting will only take effect if you have not uploaded a local profile picture.', 'avatar-privacy' ); ?>

--- a/admin/partials/profile/use-gravatar.php
+++ b/admin/partials/profile/use-gravatar.php
@@ -25,6 +25,15 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
+// Allowed HTML tags in the checkbox label.
+$allowed_html = [
+	'a' => [
+		'href'   => true,
+		'rel'    => true,
+		'target' => true,
+	],
+];
+
 ?>
 <tr class"avatar-privacy-use-gravatar">
 	<th scope="row"><?php esc_html_e( 'Gravatars', 'avatar-privacy' ); ?></th>
@@ -37,7 +46,7 @@
 			value="true"
 			<?php checked( $value ); ?>
 		/>
-		<label for="<?php echo esc_attr( self::CHECKBOX_FIELD_NAME ); ?>"><?php echo wp_kses( __( 'Display a <a href="https://gravatar.com">Gravatar</a> image for my e-mail address.', 'avatar-privacy' ), [ 'a' => [ 'href' => true ] ] ); ?></label><br />
+		<label for="<?php echo esc_attr( self::CHECKBOX_FIELD_NAME ); ?>"><?php echo wp_kses( __( 'Display a <a href="https://gravatar.com">Gravatar</a> image for my e-mail address.', 'avatar-privacy' ), $allowed_html ); ?></label><br />
 		<p class="description">
 			<?php esc_html_e( "Uncheck this box if you don't want to display the gravatar for your e-mail address (or don't have an account on Gravatar.com).", 'avatar-privacy' ); ?>
 			<?php esc_html_e( 'This setting will only take effect if you have not uploaded a local profile picture.', 'avatar-privacy' ); ?>

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -29,7 +29,7 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer, Johannes Freudendahl
  * Author URI: https://code.mundschenk.at
- * Version: 1.0.4
+ * Version: 1.0.5
  * License: GNU General Public License v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: avatar-privacy

--- a/includes/avatar-privacy/data-storage/class-filesystem-cache.php
+++ b/includes/avatar-privacy/data-storage/class-filesystem-cache.php
@@ -138,7 +138,7 @@ class Filesystem_Cache {
 			return true;
 		}
 
-		if ( ! \wp_mkdir_p( \dirname( $file ) ) || false === \file_put_contents( $file, $data, LOCK_EX ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
+		if ( 0 === \strlen( $data ) || ! \wp_mkdir_p( \dirname( $file ) ) || false === \file_put_contents( $file, $data, LOCK_EX ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
 			return false;
 		} else {
 			return true;

--- a/public/partials/comments/use-gravatar.php
+++ b/public/partials/comments/use-gravatar.php
@@ -60,6 +60,6 @@ if ( isset( $_POST[ Comments::CHECKBOX_FIELD_NAME ] ) ) { // WPCS: CSRF ok, Inpu
 		style="display:inline;"
 	<?php endif; ?>
 		for="<?php echo \esc_attr( Comments::CHECKBOX_FIELD_NAME ); ?>"
-	><?php \printf( /* translators: gravatar.com URL */ \wp_kses( \__( 'Display a <a href="%s">Gravatar</a> image next to my comments.', 'avatar-privacy' ), $allowed_html ), 'https://gravatar.com' ); ?></label>
+	><?php \printf( /* translators: gravatar.com URL */ \wp_kses( \__( 'Display a <a href="%s" rel="noopener nofollow">Gravatar</a> image next to my comments.', 'avatar-privacy' ), $allowed_html ), 'https://gravatar.com' ); ?></label>
 </p>
 <?php

--- a/public/partials/comments/use-gravatar.php
+++ b/public/partials/comments/use-gravatar.php
@@ -30,7 +30,9 @@ use Avatar_Privacy\Components\Comments;
 // Allowed HTML tags in the checkbox label.
 $allowed_html = [
 	'a' => [
-		'href' => true,
+		'href'   => true,
+		'rel'    => true,
+		'target' => true,
 	],
 ];
 

--- a/public/partials/comments/use-gravatar.php
+++ b/public/partials/comments/use-gravatar.php
@@ -60,6 +60,6 @@ if ( isset( $_POST[ Comments::CHECKBOX_FIELD_NAME ] ) ) { // WPCS: CSRF ok, Inpu
 		style="display:inline;"
 	<?php endif; ?>
 		for="<?php echo \esc_attr( Comments::CHECKBOX_FIELD_NAME ); ?>"
-	><?php \printf( /* translators: gravatar.com URL */ \wp_kses( \__( 'Display a <a href="%s" rel="noopener nofollow">Gravatar</a> image next to my comments.', 'avatar-privacy' ), $allowed_html ), 'https://gravatar.com' ); ?></label>
+	><?php \printf( /* translators: gravatar.com URL */ \wp_kses( \__( 'Display a <a href="%s" rel="noopener nofollow">Gravatar</a> image next to my comments.', 'avatar-privacy' ), $allowed_html ), 'https://en.gravatar.com/' ); ?></label>
 </p>
 <?php

--- a/readme.txt
+++ b/readme.txt
@@ -31,7 +31,7 @@ A more detailed examination of the [reasons for using Avatar Privacy](https://co
 
 = Feedback =
 
-The plugin is still quite new. Please use it with caution and report any problems. You can use the contact form on [my code site](https://code.mundschenk.at/avatar-privacy/) or  create a forum topic on https://wordpress.org/support/plugin/avatar-privacy. I'll see these pop up in my feed reader and hopefully will reply shortly. ;-) You can contact me in German or English.
+The plugin is still quite new. Please use it with caution and report any problems. You can use the contact form on [my code site](https://code.mundschenk.at/avatar-privacy/) or [create a topic in the support forum](https://wordpress.org/support/plugin/avatar-privacy). I'll see these pop up in my feed reader and hopefully will reply shortly. ;-) You can contact me in German or English.
 
 = Credits =
 

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: gravatar, avatar, privacy
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 4.9
-Stable tag: 1.0.4
+Stable tag: 1.0.5
 License: GPLv2 or later
 
 Adds options to enhance the privacy when using avatars.
@@ -132,6 +132,11 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 
 == Changelog ==
+
+= 1.0.5 (2018-05-22) =
+* _Bugfix_: Prefer GD-based implementations of `WP_Image_Editor` to work around [trac ticket #42663](https://core.trac.wordpress.org/ticket/42663).
+* _Bugfix_: The `rel` and `target` attributes are allowed in `use_gravatar` checkbox labels and by the default, the `noopener` and `nofollow` values for the `rel` attribute are added to the Gravatar.com link.
+* _Bugfix_: Invalid 0-byte image files are not saved anymore.
 
 = 1.0.4 (2018-05-20) =
 * _Bugfix_: When the plugin is uninstalled, the default avatar image is really reset to `mystery` if necessary.


### PR DESCRIPTION
- Prefer GD-based implementations of `WP_Image_Editor` to work around [trac ticket #42663](https://core.trac.wordpress.org/ticket/42663).
- Allow `rel` and `target` attributes for Gravatar.com links in `use_gravatar` checkbox label, add `noopener` and `nofollow` to Gravatar.com links.
- Do not save invalid 0-byte image files.