### PR TITLE
Release 1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
-## 1.0.5 (2018-05-22)
+## 1.0.6 (2018-05-29)
+*   _Bugfix_: Only valid response codes from Gravatar.com are cached (200 and 404).
+*   _Bugfix_: Plugin transients are cleared on plugin upgrades.
+*   _Bugfix_: The workaround for [trac ticket #42663](https://core.trac.wordpress.org/ticket/42663)
+    introduced in 1.0.5 is expanded to all uses of `wp_get_image_editor()`.
 
+## 1.0.5 (2018-05-22)
 *   _Bugfix_: Prefer GD-based implementations of `WP_Image_Editor` to work around
     [trac ticket #42663](https://core.trac.wordpress.org/ticket/42663).
 *   _Bugfix_: The `rel` and `target` attributes are allowed in `use_gravatar`

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -29,11 +29,10 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer, Johannes Freudendahl
  * Author URI: https://code.mundschenk.at
- * Version: 1.0.5
+ * Version: 1.0.6
  * License: GNU General Public License v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: avatar-privacy
- * Domain Path: /lang
  */
 
 // Don't do anything if called directly.

--- a/includes/avatar-privacy/class-user-avatar-upload.php
+++ b/includes/avatar-privacy/class-user-avatar-upload.php
@@ -320,7 +320,7 @@ class User_Avatar_Upload {
 
 		if ( $args['force'] || ! \file_exists( $target ) ) {
 			$data = Image_Tools\Editor::get_resized_image_data(
-				\wp_get_image_editor( $args['avatar'] ), $size, $size, true, $args['mimetype']
+				Image_Tools\Editor::get_image_editor( $args['avatar'] ), $size, $size, true, $args['mimetype']
 			);
 			if ( empty( $data ) ) {
 				// Something went wrong..

--- a/includes/avatar-privacy/components/class-avatar-handling.php
+++ b/includes/avatar-privacy/components/class-avatar-handling.php
@@ -395,12 +395,22 @@ class Avatar_Handling implements \Avatar_Privacy\Component {
 			return false; // Don't cache the result.
 		}
 
-		if ( 200 === \wp_remote_retrieve_response_code( $response ) ) {
-			$result = \wp_remote_retrieve_header( $response, 'content-type' );
+		switch ( \wp_remote_retrieve_response_code( $response ) ) {
+			case 200:
+				// Valid image found.
+				$result = \wp_remote_retrieve_header( $response, 'content-type' );
+				if ( null !== $mimetype && ! empty( $result ) ) {
+					$mimetype = $result;
+				}
+				break;
 
-			if ( null !== $mimetype && ! empty( $result ) ) {
-				$mimetype = $result;
-			}
+			case 404:
+				// No image found.
+				$result = 0;
+				break;
+
+			default:
+				return false; // Don't cache the result.
 		}
 
 		// Cache the result across all blogs (a YES for 1 week, a NO for 10 minutes or longer,
@@ -420,7 +430,7 @@ class Avatar_Handling implements \Avatar_Privacy\Component {
 		 */
 		$duration = \apply_filters( 'avatar_privacy_validate_gravatar_interval', $duration, ! empty( $result ), $age );
 
-		$transients->set( $transient_key, ! empty( $result ) ? $result : 0, $duration );
+		$transients->set( $transient_key, $result, $duration );
 		$this->validate_gravatar_cache[ $hash ] = $result;
 
 		return ! empty( $result );

--- a/includes/avatar-privacy/components/class-setup.php
+++ b/includes/avatar-privacy/components/class-setup.php
@@ -171,8 +171,14 @@ class Setup implements \Avatar_Privacy\Component {
 			$installed_version = '';
 		}
 
+		// The current version is (probably) newer than the previously installed one.
 		if ( $this->version !== $installed_version ) {
+			// Update plugin settings if necessary.
 			$this->plugin_updated( $installed_version, $settings );
+
+			// Clear transients.
+			$this->transients->invalidate();
+			$this->site_transients->invalidate();
 		}
 
 		// Check if our database table needs to created or updated.

--- a/includes/avatar-privacy/image-tools/class-editor.php
+++ b/includes/avatar-privacy/image-tools/class-editor.php
@@ -47,9 +47,7 @@ abstract class Editor {
 	 */
 	public static function create_from_stream( $stream ) {
 		// Create image editor instance from stream, but strongly prefer GD implementations.
-		\add_filter( 'wp_image_editors', [ __CLASS__, 'prefer_gd_image_editor' ], 9999 );
-		$result = \wp_get_image_editor( $stream );
-		\remove_filter( 'wp_image_editors', [ __CLASS__, 'prefer_gd_image_editor' ], 9999 );
+		$result = self::get_image_editor( $stream );
 
 		// Clean up stream data.
 		Image_Stream::delete_handle( Image_Stream::get_handle_from_url( $stream ) );
@@ -283,6 +281,24 @@ abstract class Editor {
 		}
 
 		return [ $w, $h ];
+	}
+
+	/**
+	 * Returns a `\WP_Image_Editor` instance and loads file into it. Preference is
+	 * given to stream-capable editor classes (i.e. GD-based ones).
+	 *
+	 * @param  string $path Path to the file to load.
+	 * @param  array  $args Optional. Additional arguments for retrieving the image editor. Default [].
+	 *
+	 * @return \WP_Image_Editor|\WP_Error
+	 */
+	public static function get_image_editor( $path, array $args = [] ) {
+		// Create image editor instance from path, but strongly prefer GD implementations.
+		\add_filter( 'wp_image_editors', [ __CLASS__, 'prefer_gd_image_editor' ], 9999 );
+		$result = \wp_get_image_editor( $path, $args );
+		\remove_filter( 'wp_image_editors', [ __CLASS__, 'prefer_gd_image_editor' ], 9999 );
+
+		return $result;
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,8 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -280,13 +281,13 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.5.0.tgz",
-      "integrity": "sha512-buY1XxFoBrXvLsoFb0jP+niSu1tCj2RwMwHj96+RfQ8DJTgb0vUhh0dg6wjJT3JzsFYBrkSj8/sGtarNdlxTFw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.5.1.tgz",
+      "integrity": "sha512-0zXQ6OqbnVaplQKkKTASxHFPMNy6WfrXS5QRDJ4zTDxEBB3r7NPDSK4h9KCyQi1tq0tX5MsN4RdzChVBn2k/aw==",
       "dev": true,
       "requires": {
-        "browserslist": "^3.2.7",
-        "caniuse-lite": "^1.0.30000839",
+        "browserslist": "^3.2.8",
+        "caniuse-lite": "^1.0.30000846",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
         "postcss": "^6.0.22",
@@ -294,9 +295,9 @@
       },
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30000841",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000841.tgz",
-          "integrity": "sha512-LeOGLEY4hl6xZc/xMYOrVmSrHOybyHWNShFN51qCmDXo69nEGKHTJTfe6jdWe4hLxSJcwEIYtKHFFh93fF/kNA==",
+          "version": "1.0.30000846",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000846.tgz",
+          "integrity": "sha512-qxUOHr5mTaadWH1ap0ueivHd8x42Bnemcn+JutVr7GWmm2bU4zoBhjuv5QdXgALQnnT626lOQros7cCDf8PwCg==",
           "dev": true
         },
         "chalk": {
@@ -319,17 +320,15 @@
             "chalk": "^2.4.1",
             "source-map": "^0.6.1",
             "supports-color": "^5.4.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.4.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-              "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -464,25 +463,25 @@
       }
     },
     "browserslist": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.7.tgz",
-      "integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000835",
-        "electron-to-chromium": "^1.3.45"
+        "caniuse-lite": "^1.0.30000844",
+        "electron-to-chromium": "^1.3.47"
       },
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30000841",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000841.tgz",
-          "integrity": "sha512-LeOGLEY4hl6xZc/xMYOrVmSrHOybyHWNShFN51qCmDXo69nEGKHTJTfe6jdWe4hLxSJcwEIYtKHFFh93fF/kNA==",
+          "version": "1.0.30000846",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000846.tgz",
+          "integrity": "sha512-qxUOHr5mTaadWH1ap0ueivHd8x42Bnemcn+JutVr7GWmm2bU4zoBhjuv5QdXgALQnnT626lOQros7cCDf8PwCg==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.46",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.46.tgz",
-          "integrity": "sha1-AOheIidUFaiHUF5KtJc3GU8YubA=",
+          "version": "1.3.48",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
+          "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA=",
           "dev": true
         }
       }
@@ -667,7 +666,8 @@
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -1136,7 +1136,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "esprima": {
       "version": "2.7.3",
@@ -1691,6 +1692,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.2.tgz",
       "integrity": "sha512-WdedTJ/6zCXnI/coaouzqvkI19uwqbcPkdsXiDRKJyB5rOUlOxnCnTVbpeUdEckKVir2uHF3rDBYppj2p6N3+g==",
+      "dev": true,
       "requires": {
         "colors": "~1.1.2",
         "grunt-legacy-log-utils": "~1.0.0",
@@ -1702,6 +1704,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
       "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
+      "dev": true,
       "requires": {
         "chalk": "~1.1.1",
         "lodash": "~4.3.0"
@@ -1710,12 +1713,14 @@
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -1727,12 +1732,14 @@
         "lodash": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
-          "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ="
+          "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -1861,9 +1868,9 @@
       }
     },
     "grunt-wp-deploy": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/grunt-wp-deploy/-/grunt-wp-deploy-1.2.1.tgz",
-      "integrity": "sha1-fVwoQVehgcEGxFvgUrqapxo8JHQ=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/grunt-wp-deploy/-/grunt-wp-deploy-1.3.0.tgz",
+      "integrity": "sha1-E9nRezJOKcqTueOkBRYNgT+p4EU=",
       "dev": true,
       "requires": {
         "inquirer": "~0.2.1"
@@ -1899,6 +1906,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -1942,7 +1950,8 @@
     "hooker": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk="
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.6.0",
@@ -2538,7 +2547,8 @@
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -3926,6 +3936,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "avatar-privacy",
   "devDependencies": {
-    "autoprefixer": "^8.5.0",
+    "autoprefixer": "^8.5.1",
     "grunt": "^1.0.2",
     "grunt-cli": "^1.2.0",
     "grunt-composer": "^0.4",
@@ -16,7 +16,7 @@
     "grunt-postcss": "^0.9.0",
     "grunt-sass": "^2.1.0",
     "grunt-string-replace": "^1.3",
-    "grunt-wp-deploy": "^1.2.1",
+    "grunt-wp-deploy": "^1.3.0",
     "jshint-stylish": "^2.2.1",
     "load-grunt-tasks": "^4.0",
     "pixrem": "^4.0.0"

--- a/readme.txt
+++ b/readme.txt
@@ -133,6 +133,11 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 == Changelog ==
 
+= 1.0.6 (2018-05-29) =
+* _Bugfix_: Only valid response codes from Gravatar.com are cached (200 and 404).
+* _Bugfix_: Plugin transients are cleared on plugin upgrades.
+* _Bugfix_: The workaround for [trac ticket #42663](https://core.trac.wordpress.org/ticket/42663) introduced in 1.0.5 is expanded to all uses of `wp_get_image_editor()`.
+
 = 1.0.5 (2018-05-22) =
 * _Bugfix_: Prefer GD-based implementations of `WP_Image_Editor` to work around [trac ticket #42663](https://core.trac.wordpress.org/ticket/42663).
 * _Bugfix_: The `rel` and `target` attributes are allowed in `use_gravatar` checkbox labels and by the default, the `noopener` and `nofollow` values for the `rel` attribute are added to the Gravatar.com link.

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: gravatar, avatar, privacy
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 4.9
-Stable tag: 1.0.5
+Stable tag: 1.0.6
 License: GPLv2 or later
 
 Adds options to enhance the privacy when using avatars.


### PR DESCRIPTION
- Clear transients on updates
- Only cache valid Gravatar.com response codes
- Prefer GD-based image editors for user avatars as well