### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
+## 1.1.1 (2018-06-11)
+*   _Bugfix_: Changing the default gravatar policy via `avatar_privacy_gravatar_use_default`
+    works again for registered users.
+
 ## 1.1.0 (2018-06-10)
 *   _Feature_: Supports the new privacy tools on WordPress >= 4.9.6 (export and
     deletion of personal data, suggested privacy notice text).
 *   _Feature_: Registered users can opt into allowing logged-out comments with the
     same mail address to user their profile pictures.
 *   _Feature_: The plugin is now compatible with bbPress.
+*   _Feature_: The position of the `use_gravatar` checkbox can be adjusted via the
+    new filter hook `avatar_privacy_use_gravatar_position`.
 *   _Change_: Trashed comments and comments marked as spam do not trigger a validation
     request to Gravatar.com if the admin has set the default gravatar use policy
     to "enabled" via the filter hook `avatar_privacy_gravatar_use_default`.

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -29,7 +29,7 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer, Johannes Freudendahl
  * Author URI: https://code.mundschenk.at
- * Version: 1.1.0
+ * Version: 1.1.1
  * License: GNU General Public License v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: avatar-privacy

--- a/includes/avatar-privacy/components/class-avatar-handling.php
+++ b/includes/avatar-privacy/components/class-avatar-handling.php
@@ -467,8 +467,9 @@ class Avatar_Handling implements \Avatar_Privacy\Component {
 
 		if ( $user_id ) {
 			// For users get the value from the usermeta table.
-			$show_gravatar = \get_user_meta( $user_id, Core::GRAVATAR_USE_META_KEY, true ) === 'true';
-			$use_default   = '' === $show_gravatar;
+			$meta_value    = \get_user_meta( $user_id, Core::GRAVATAR_USE_META_KEY, true );
+			$show_gravatar = 'true' === $meta_value;
+			$use_default   = '' === $meta_value;
 		} else {
 			// For comments get the value from the plugin's table.
 			$show_gravatar = $this->core->comment_author_allows_gravatar_use( $email );

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: gravatar, avatar, privacy, bbpress
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 4.9
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 License: GPLv2 or later
 
 Adds options to enhance the privacy when using avatars.
@@ -133,11 +133,15 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 == Changelog ==
 
+= 1.1.1 (2018-06-11) =
+* _Bugfix_: Changing the default gravatar policy via `avatar_privacy_gravatar_use_default` works again for registered users.
+
 = 1.1.0 (2018-06-10) =
-*   _Feature_: Supports the new privacy tools on WordPress >= 4.9.6 (export and deletion of personal data, suggested privacy notice text).
-*   _Feature_: Registered users can opt into allowing logged-out comments with the same mail address to user their profile pictures.
-*   _Feature_: The plugin is now compatible with bbPress.
-*   _Change_: Trashed comments and comments marked as spam do not trigger a validation request to Gravatar.com if the admin has set the default gravatar use policy to "enabled" via the filter hook `avatar_privacy_gravatar_use_default`.
+* _Feature_: Supports the new privacy tools on WordPress >= 4.9.6 (export and deletion of personal data, suggested privacy notice text).
+* _Feature_: Registered users can opt into allowing logged-out comments with the same mail address to user their profile pictures.
+* _Feature_: The plugin is now compatible with bbPress.
+* _Feature_: The position of the `use_gravatar` checkbox can be adjusted via the new filter hook `avatar_privacy_use_gravatar_position`.
+* _Change_: Trashed comments and comments marked as spam do not trigger a validation request to Gravatar.com if the admin has set the default gravatar use policy to "enabled" via the filter hook `avatar_privacy_gravatar_use_default`.
 
 = 1.0.7 (2018-06-06) =
 * _Bugfix_: The `use_gravatar` is actually checked when the cookie has been set.


### PR DESCRIPTION
_Bugfix_: Changing the default gravatar policy via `avatar_privacy_gravatar_use_default` works again for registered users.
