### PR TITLE
Make rel and target attributes filterable

### DIFF
--- a/admin/partials/profile/use-gravatar.php
+++ b/admin/partials/profile/use-gravatar.php
@@ -25,6 +25,8 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
+use Avatar_Privacy\Tools\Template;
+
 // Allowed HTML tags in the checkbox label.
 $allowed_html = [
 	'a' => [
@@ -46,7 +48,7 @@ $allowed_html = [
 			value="true"
 			<?php checked( $use_gravatar ); ?>
 		/>
-		<label for="<?php echo esc_attr( self::CHECKBOX_FIELD_NAME ); ?>"><?php echo wp_kses( sprintf( /* translators: gravatar.com URL */ __( 'Display a <a href="%s" rel="noopener nofollow">Gravatar</a> image for my e-mail address.', 'avatar-privacy' ), __( 'https://en.gravatar.com/', 'avatar-privacy' ) ), $allowed_html ); ?></label><br />
+		<label for="<?php echo esc_attr( self::CHECKBOX_FIELD_NAME ); ?>"><?php echo wp_kses( sprintf( /* translators: 1: gravatar.com URL, 2: rel attribute, 3: target attribute */ __( 'Display a <a href="%1$s" rel="%2$s" target="%3$s">Gravatar</a> image for my e-mail address.', 'avatar-privacy' ), __( 'https://en.gravatar.com/', 'avatar-privacy' ), Template::get_gravatar_link_rel(), Template::get_gravatar_link_target() ), $allowed_html ); ?></label><br />
 		<p class="description">
 			<?php esc_html_e( "Uncheck this box if you don't want to display the gravatar for your e-mail address (or don't have an account on Gravatar.com).", 'avatar-privacy' ); ?>
 			<?php esc_html_e( 'This setting will only take effect if you have not uploaded a local profile picture.', 'avatar-privacy' ); ?>

--- a/admin/partials/profile/user-avatar-upload.php
+++ b/admin/partials/profile/user-avatar-upload.php
@@ -24,29 +24,31 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
+use Avatar_Privacy\Tools\Template;
+
 $current_avatar                = \get_user_meta( $user->ID, self::USER_META_KEY, true );
 $current_user_can_upload_files = \current_user_can( 'upload_files' );
 
 if ( $current_user_can_upload_files ) {
 	if ( empty( $current_avatar ) ) {
 		$description = \sprintf(
-			/* translators: %s: Gravatar URL */
-			\__( 'No local profile picture is set. Use the upload field to add a local profile picture or change your profile picture on <a href="%s">Gravatar</a>.', 'avatar-privacy' ),
-			\__( 'https://en.gravatar.com/', 'avatar-privacy' )
+			/* translators: 1: gravatar.com URL, 2: rel attribute, 3: target attribute */
+			\__( 'No local profile picture is set. Use the upload field to add a local profile picture or change your profile picture on <a href="%1$s" rel="%2$s" target="%3$s">Gravatar</a>.', 'avatar-privacy' ),
+			\__( 'https://en.gravatar.com/', 'avatar-privacy' ), Template::get_gravatar_link_rel(), Template::get_gravatar_link_target()
 		);
 	} else {
 		$description = \sprintf(
-			/* translators: %s: Gravatar URL */
-			\__( 'Replace the local profile picture by uploading a new avatar, or erase it (falling back on <a href="%s">Gravatar</a>) by checking the delete option.', 'avatar-privacy' ),
-			\__( 'https://en.gravatar.com/', 'avatar-privacy' )
+			/* translators: 1: gravatar.com URL, 2: rel attribute, 3: target attribute */
+			\__( 'Replace the local profile picture by uploading a new avatar, or erase it (falling back on <a href="%1$s" rel="%2$s" target="%3$s">Gravatar</a>) by checking the delete option.', 'avatar-privacy' ),
+			\__( 'https://en.gravatar.com/', 'avatar-privacy' ), Template::get_gravatar_link_rel(), Template::get_gravatar_link_target()
 		);
 	}
 } else {
 	if ( empty( $current_avatar ) ) {
 		$description = \sprintf(
-			/* translators: %s: Gravatar URL */
-			\__( 'No local profile picture is set. Change your profile picture on <a href="%s">Gravatar</a>.', 'avatar-privacy' ),
-			\__( 'https://en.gravatar.com/', 'avatar-privacy' )
+			/* translators: 1: gravatar.com URL, 2: rel attribute, 3: target attribute */
+			\__( 'No local profile picture is set. Change your profile picture on <a href="%1$s" rel="%2$s" target="%3$s">Gravatar</a>.', 'avatar-privacy' ),
+			\__( 'https://en.gravatar.com/', 'avatar-privacy' ), Template::get_gravatar_link_rel(), Template::get_gravatar_link_target()
 		);
 	} else {
 		$description = \__( 'You do not have media management permissions. To change your local profile picture, contact the site administrator.', 'avatar-privacy' );

--- a/includes/avatar-privacy/avatar-handlers/class-default-icons-handler.php
+++ b/includes/avatar-privacy/avatar-handlers/class-default-icons-handler.php
@@ -28,7 +28,8 @@ namespace Avatar_Privacy\Avatar_Handlers;
 
 use Avatar_Privacy\Core;
 use Avatar_Privacy\Default_Icons;
-use Avatar_Privacy\Image_Tools;
+
+use Avatar_Privacy\Tools\Images as Image_Tools;
 
 use Avatar_Privacy\Data_Storage\Filesystem_Cache;
 

--- a/includes/avatar-privacy/avatar-handlers/class-user-avatar-handler.php
+++ b/includes/avatar-privacy/avatar-handlers/class-user-avatar-handler.php
@@ -27,7 +27,9 @@
 namespace Avatar_Privacy\Avatar_Handlers;
 
 use Avatar_Privacy\Core;
-use Avatar_Privacy\Image_Tools;
+
+use Avatar_Privacy\Tools\Images as Image_Tools;
+
 use Avatar_Privacy\Upload_Handlers\User_Avatar_Upload_Handler;
 
 use Avatar_Privacy\Data_Storage\Filesystem_Cache;

--- a/includes/avatar-privacy/default-icons/class-custom-icon-provider.php
+++ b/includes/avatar-privacy/default-icons/class-custom-icon-provider.php
@@ -27,12 +27,13 @@
 namespace Avatar_Privacy\Default_Icons;
 
 use Avatar_Privacy\Core;
-use Avatar_Privacy\Image_Tools;
 use Avatar_Privacy\Settings;
 
 use Avatar_Privacy\Components\Images;
 
 use Avatar_Privacy\Data_Storage\Filesystem_Cache;
+
+use Avatar_Privacy\Tools\Images as Image_Tools;
 
 use Avatar_Privacy\Upload_Handlers\Custom_Default_Icon_Upload_Handler as Upload;
 

--- a/includes/avatar-privacy/default-icons/generator/class-monster-id.php
+++ b/includes/avatar-privacy/default-icons/generator/class-monster-id.php
@@ -28,7 +28,7 @@
 
 namespace Avatar_Privacy\Default_Icons\Generator;
 
-use Avatar_Privacy\Image_Tools;
+use Avatar_Privacy\Tools\Images as Image_Tools;
 
 use function Scriptura\Color\Helpers\HSLtoRGB;
 

--- a/includes/avatar-privacy/default-icons/generator/class-wavatar.php
+++ b/includes/avatar-privacy/default-icons/generator/class-wavatar.php
@@ -27,7 +27,7 @@
 
 namespace Avatar_Privacy\Default_Icons\Generator;
 
-use Avatar_Privacy\Image_Tools;
+use Avatar_Privacy\Tools\Images as Image_Tools;
 
 /**
  * A wavatar generator.

--- a/includes/avatar-privacy/tools/class-template.php
+++ b/includes/avatar-privacy/tools/class-template.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2018 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tools;
+
+/**
+ * A collection of utility methods for use in templates.
+ *
+ * @since 1.2.0
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ */
+abstract class Template {
+
+	/**
+	 * Retrieves and filters the `rel` attribute for links to gravatar.com.
+	 *
+	 * @return string The result is safe for output.
+	 */
+	public static function get_gravatar_link_rel() {
+		/**
+		 * Filters the `rel` attribute for user-visible links to gravatar.com.
+		 *
+		 * @param string $rel Default 'noopener nofollow'.
+		 */
+		return \esc_attr( \apply_filters( 'avatar_privacy_gravatar_link_rel', 'noopener nofollow' ) );
+	}
+
+	/**
+	 * Retrieves and filters the `target` attribute for links to gravatar.com.
+	 *
+	 * @return string The result is safe for output.
+	 */
+	public static function get_gravatar_link_target() {
+		/**
+		 * Filters the `target` attribute for user-visible links to gravatar.com.
+		 *
+		 * @param string $target Default '_self'.
+		 */
+		return \esc_attr( \apply_filters( 'avatar_privacy_gravatar_link_target', '_self' ) );
+	}
+}

--- a/includes/avatar-privacy/tools/images/class-editor.php
+++ b/includes/avatar-privacy/tools/images/class-editor.php
@@ -24,7 +24,7 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
-namespace Avatar_Privacy\Image_Tools;
+namespace Avatar_Privacy\Tools\Images;
 
 /**
  * A collection of utlitiy methods for using the \WP_Image_Editor class.

--- a/includes/avatar-privacy/tools/images/class-image-stream.php
+++ b/includes/avatar-privacy/tools/images/class-image-stream.php
@@ -24,7 +24,7 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
-namespace Avatar_Privacy\Image_Tools;
+namespace Avatar_Privacy\Tools\Images;
 
 /**
  * A persistent memory stream for storing temporary images.

--- a/includes/avatar-privacy/upload-handlers/class-custom-default-icon-upload-handler.php
+++ b/includes/avatar-privacy/upload-handlers/class-custom-default-icon-upload-handler.php
@@ -27,11 +27,12 @@
 namespace Avatar_Privacy\Upload_Handlers;
 
 use Avatar_Privacy\Core;
-use Avatar_Privacy\Image_Tools;
 use Avatar_Privacy\Settings;
 
 use Avatar_Privacy\Data_Storage\Filesystem_Cache;
 use Avatar_Privacy\Data_Storage\Options;
+
+use Avatar_Privacy\Tools\Images as Image_Tools;
 
 /**
  * Handles uploaded custom default icons.

--- a/includes/avatar-privacy/upload-handlers/class-upload-handler.php
+++ b/includes/avatar-privacy/upload-handlers/class-upload-handler.php
@@ -27,9 +27,10 @@
 namespace Avatar_Privacy\Upload_Handlers;
 
 use Avatar_Privacy\Core;
-use Avatar_Privacy\Image_Tools;
 
 use Avatar_Privacy\Data_Storage\Filesystem_Cache;
+
+use Avatar_Privacy\Tools\Images as Image_Tools;
 
 /**
  * Handles image uploads.

--- a/includes/avatar-privacy/upload-handlers/class-user-avatar-upload-handler.php
+++ b/includes/avatar-privacy/upload-handlers/class-user-avatar-upload-handler.php
@@ -27,9 +27,10 @@
 namespace Avatar_Privacy\Upload_Handlers;
 
 use Avatar_Privacy\Core;
-use Avatar_Privacy\Image_Tools;
 
 use Avatar_Privacy\Data_Storage\Filesystem_Cache;
+
+use Avatar_Privacy\Tools\Images as Image_Tools;
 
 /**
  * Handles uploaded user avatars.

--- a/public/partials/bbpress/profile/use-gravatar.php
+++ b/public/partials/bbpress/profile/use-gravatar.php
@@ -25,6 +25,7 @@
  */
 
 use Avatar_Privacy\Components\User_Profile;
+use Avatar_Privacy\Tools\Template;
 
 // Allowed HTML tags in the checkbox label.
 $allowed_html = [
@@ -46,7 +47,7 @@ $allowed_html = [
 			value="true"
 			<?php checked( $use_gravatar ); ?>
 		/>
-		<?php echo wp_kses( sprintf( /* translators: gravatar.com URL */ __( 'Display a <a href="%s" rel="noopener nofollow">Gravatar</a> image for my e-mail address.', 'avatar-privacy' ), __( 'https://en.gravatar.com/', 'avatar-privacy' ) ), $allowed_html ); ?>
+		<?php echo wp_kses( sprintf( /* translators: 1: gravatar.com URL, 2: rel attribute, 3: target attribute */ __( 'Display a <a href="%1$s" rel="%2$s" target="%3$s">Gravatar</a> image for my e-mail address.', 'avatar-privacy' ), __( 'https://en.gravatar.com/', 'avatar-privacy' ), Template::get_gravatar_link_rel(), Template::get_gravatar_link_target() ), $allowed_html ); ?>
 	</label>
 	<span class="description indicator-hint" style="width:100%;margin-left:0;">
 		<?php \esc_html_e( 'An uploaded profile picture takes precedence over your gravatar.', 'avatar-privacy' ); ?>

--- a/public/partials/bbpress/profile/user-avatar-upload.php
+++ b/public/partials/bbpress/profile/user-avatar-upload.php
@@ -24,6 +24,7 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
+use Avatar_Privacy\Tools\Template;
 use Avatar_Privacy\Upload_Handlers\User_Avatar_Upload_Handler;
 
 $current_avatar                = \get_user_meta( $user_id, User_Avatar_Upload_Handler::USER_META_KEY, true );
@@ -32,23 +33,23 @@ $current_user_can_upload_files = \current_user_can( 'upload_files' );
 if ( $current_user_can_upload_files ) {
 	if ( empty( $current_avatar ) ) {
 		$description = \sprintf(
-			/* translators: %s: Gravatar URL */
-			\__( 'No local profile picture is set. Use the upload field to add a local profile picture or change your profile picture on <a href="%s">Gravatar</a>.', 'avatar-privacy' ),
-			\__( 'https://en.gravatar.com/', 'avatar-privacy' )
+			/* translators: 1: gravatar.com URL, 2: rel attribute, 3: target attribute */
+			\__( 'No local profile picture is set. Use the upload field to add a local profile picture or change your profile picture on <a href="%1$s" rel="%2$s" target="%3$s">Gravatar</a>.', 'avatar-privacy' ),
+			\__( 'https://en.gravatar.com/', 'avatar-privacy' ), Template::get_gravatar_link_rel(), Template::get_gravatar_link_target()
 		);
 	} else {
 		$description = \sprintf(
-			/* translators: %s: Gravatar URL */
-			\__( 'Replace the local profile picture by uploading a new avatar, or erase it (falling back on <a href="%s">Gravatar</a>) by checking the delete option.', 'avatar-privacy' ),
-			\__( 'https://en.gravatar.com/', 'avatar-privacy' )
+			/* translators: 1: gravatar.com URL, 2: rel attribute, 3: target attribute */
+			\__( 'Replace the local profile picture by uploading a new avatar, or erase it (falling back on <a href="%1$s" rel="%2$s" target="%3$s">Gravatar</a>) by checking the delete option.', 'avatar-privacy' ),
+			\__( 'https://en.gravatar.com/', 'avatar-privacy' ), Template::get_gravatar_link_rel(), Template::get_gravatar_link_target()
 		);
 	}
 } else {
 	if ( empty( $current_avatar ) ) {
 		$description = \sprintf(
-			/* translators: %s: Gravatar URL */
-			\__( 'No local profile picture is set. Change your profile picture on <a href="%s">Gravatar</a>.', 'avatar-privacy' ),
-			\__( 'https://en.gravatar.com/', 'avatar-privacy' )
+			/* translators: 1: gravatar.com URL, 2: rel attribute, 3: target attribute */
+			\__( 'No local profile picture is set. Change your profile picture on <a href="%1$s" rel="%2$s" target="%3$s">Gravatar</a>.', 'avatar-privacy' ),
+			\__( 'https://en.gravatar.com/', 'avatar-privacy' ), Template::get_gravatar_link_rel(), Template::get_gravatar_link_target()
 		);
 	} else {
 		$description = \__( 'You do not have media management permissions. To change your local profile picture, contact the site administrator.', 'avatar-privacy' );

--- a/public/partials/comments/use-gravatar.php
+++ b/public/partials/comments/use-gravatar.php
@@ -26,6 +26,7 @@
  */
 
 use Avatar_Privacy\Components\Comments;
+use Avatar_Privacy\Tools\Template;
 
 // Allowed HTML tags in the checkbox label.
 $allowed_html = [
@@ -61,6 +62,6 @@ if ( isset( $_POST[ Comments::CHECKBOX_FIELD_NAME ] ) ) { // WPCS: CSRF ok, Inpu
 		style="display:inline;"
 	<?php endif; ?>
 		for="<?php echo \esc_attr( Comments::CHECKBOX_FIELD_NAME ); ?>"
-	><?php echo \wp_kses( \sprintf( /* translators: gravatar.com URL */ \__( 'Display a <a href="%s" rel="noopener nofollow">Gravatar</a> image next to my comments.', 'avatar-privacy' ), __( 'https://en.gravatar.com/', 'avatar-privacy' ) ), $allowed_html ); ?></label>
+	><?php echo \wp_kses( \sprintf( /* translators: 1: gravatar.com URL, 2: rel attribute, 3: target attribute */ \__( 'Display a <a href="%1$s" rel="%2$s" target="%3$s">Gravatar</a> image next to my comments.', 'avatar-privacy' ), __( 'https://en.gravatar.com/', 'avatar-privacy' ), Template::get_gravatar_link_rel(), Template::get_gravatar_link_target() ), $allowed_html ); ?></label>
 </p>
 <?php


### PR DESCRIPTION
- Make Gravatar.com link attributes filterable.
- Rename `Avatar_Privacy\Image_Tools` to `Avatar_Privacy\Tools\Image_Tools`