### PR TITLE
Code quality improvements

### DIFF
--- a/includes/avatar-privacy/components/class-comments.php
+++ b/includes/avatar-privacy/components/class-comments.php
@@ -43,6 +43,13 @@ class Comments implements \Avatar_Privacy\Component {
 	const CHECKBOX_FIELD_NAME = 'use_gravatar';
 
 	/**
+	 * The prefix of the comment cookie (COOKIEHASH is added at the end).
+	 *
+	 * @var string
+	 */
+	const COOKIE_PREFIX = 'comment_use_gravatar_';
+
+	/**
 	 * The core API.
 	 *
 	 * @var Core
@@ -246,7 +253,7 @@ class Comments implements \Avatar_Privacy\Component {
 
 		if ( false === $cookies_consent ) {
 			// Remove any existing cookie.
-			\setcookie( 'comment_use_gravatar_' . COOKIEHASH, 0, time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
+			\setcookie( self::COOKIE_PREFIX . COOKIEHASH, 0, time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
 			return;
 		}
 
@@ -257,6 +264,6 @@ class Comments implements \Avatar_Privacy\Component {
 		/** This filter is documented in wp-includes/comment.php */
 		$comment_cookie_lifetime = \apply_filters( 'comment_cookie_lifetime', 30000000 );
 		$secure                  = ( 'https' === \wp_parse_url( \home_url(), PHP_URL_SCHEME ) );
-		\setcookie( 'comment_use_gravatar_' . COOKIEHASH, $use_gravatar, \time() + $comment_cookie_lifetime, COOKIEPATH, COOKIE_DOMAIN, $secure );
+		\setcookie( self::COOKIE_PREFIX . COOKIEHASH, $use_gravatar, \time() + $comment_cookie_lifetime, COOKIEPATH, COOKIE_DOMAIN, $secure );
 	}
 }

--- a/includes/avatar-privacy/components/class-setup.php
+++ b/includes/avatar-privacy/components/class-setup.php
@@ -241,28 +241,8 @@ class Setup implements \Avatar_Privacy\Component {
 	 */
 	public function deactivate() {
 		$this->disable_cron_jobs();
-		static::reset_avatar_default( $this->options );
+		$this->options->reset_avatar_default();
 		\flush_rewrite_rules();
-	}
-
-	/**
-	 * Resets the `avatar_default` option to a safe value.
-	 *
-	 * @param Options $options The Options handler.
-	 */
-	public static function reset_avatar_default( Options $options ) {
-		switch ( $options->get( 'avatar_default', null, true ) ) {
-			case 'rings':
-			case 'comment':
-			case 'bubble':
-			case 'im-user-offline':
-			case 'bowling-pin':
-			case 'view-media-artist':
-			case 'silhouette':
-			case 'custom':
-				$options->set( 'avatar_default', 'mystery', true, true );
-				break;
-		}
 	}
 
 	/**

--- a/includes/avatar-privacy/components/class-uninstallation.php
+++ b/includes/avatar-privacy/components/class-uninstallation.php
@@ -174,7 +174,7 @@ class Uninstallation implements \Avatar_Privacy\Component {
 	protected static function delete_options( Options $options, Network_Options $network_options ) {
 		// Delete/change options for main blog.
 		$options->delete( Core::SETTINGS_NAME );
-		Setup::reset_avatar_default( $options );
+		$options->reset_avatar_default();
 
 		// Delete/change options for all other blogs (multisite).
 		if ( \is_multisite() ) {
@@ -185,7 +185,7 @@ class Uninstallation implements \Avatar_Privacy\Component {
 				$options->delete( Core::SETTINGS_NAME );
 
 				// Reset avatar_default to working value if necessary.
-				Setup::reset_avatar_default( $options );
+				$options->reset_avatar_default();
 
 				\restore_current_blog();
 			}

--- a/includes/avatar-privacy/data-storage/class-options.php
+++ b/includes/avatar-privacy/data-storage/class-options.php
@@ -54,4 +54,24 @@ class Options extends \Mundschenk\Data_Storage\Options {
 	public function __construct() {
 		parent::__construct( self::PREFIX );
 	}
+
+	/**
+	 * Resets the `avatar_default` option to a safe value.
+	 *
+	 * @since 2.1.0 Moved from \Avatar_Privacy\Components\Setup and made non-static.
+	 */
+	public function reset_avatar_default() {
+		switch ( $this->get( 'avatar_default', null, true ) ) {
+			case 'rings':
+			case 'comment':
+			case 'bubble':
+			case 'im-user-offline':
+			case 'bowling-pin':
+			case 'view-media-artist':
+			case 'silhouette':
+			case 'custom':
+				$this->set( 'avatar_default', 'mystery', true, true );
+				break;
+		}
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1078,9 +1078,9 @@
       }
     },
     "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.4.tgz",
+      "integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1927,16 +1927,16 @@
       }
     },
     "grunt-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.3.1.tgz",
-      "integrity": "sha512-UwBRu/QpAjDc53DRLEkyilFdL0zenpxu+fddTIlsF/KJqdNcHaQmvyu1W3cDesZ9rqqZdKK5A8+QDIyLUEWoZQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.3.2.tgz",
+      "integrity": "sha512-8OHDiZZkcptxVXtMfDxJvmN7MVJNE8L/yIcPb4HB7TlyFD1kDvjHrb62uhySsU14wJx9ORMnTuhRMQ40lH/orQ==",
       "dev": true,
       "requires": {
         "grunt-known-options": "~1.1.0",
         "interpret": "~1.1.0",
         "liftoff": "~2.5.0",
         "nopt": "~4.0.1",
-        "v8flags": "~3.0.2"
+        "v8flags": "~3.1.1"
       },
       "dependencies": {
         "nopt": {
@@ -5276,9 +5276,9 @@
       "dev": true
     },
     "v8flags": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.2.tgz",
-      "integrity": "sha512-6sgSKoFw1UpUPd3cFdF7QGnrH6tDeBgW1F3v9gy8gLY0mlbiBXq8soy8aQpY6xeeCjH5K+JvC62Acp7gtl7wWA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.1.tgz",
+      "integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
       "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "devDependencies": {
     "autoprefixer": "^9.3.1",
     "grunt": "^1.0.3",
-    "grunt-cli": "^1.3.1",
+    "grunt-cli": "^1.3.2",
     "grunt-composer": "^0.4",
     "grunt-contrib-clean": "^2.0",
     "grunt-contrib-compress": "^1.4.3",

--- a/public/partials/comments/use-gravatar.php
+++ b/public/partials/comments/use-gravatar.php
@@ -46,7 +46,7 @@ $allowed_html = [
 $disable_style = \apply_filters( 'avatar_privacy_comment_checkbox_disable_inline_style', false );
 
 // Determine if the checkbox should be checked.
-$cookie_name = 'comment_use_gravatar_' . COOKIEHASH;
+$cookie_name = Comments::COOKIE_PREFIX . COOKIEHASH;
 $is_checked  = false;
 if ( isset( $_POST[ Comments::CHECKBOX_FIELD_NAME ] ) ) { // WPCS: CSRF ok, Input var okay.
 	// Re-displaying the comment form with validation errors.

--- a/tests/avatar-privacy/components/class-setup-test.php
+++ b/tests/avatar-privacy/components/class-setup-test.php
@@ -323,52 +323,9 @@ class Setup_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_deactivate() {
 		$this->sut->shouldReceive( 'disable_cron_jobs' )->once();
 		Functions\expect( 'flush_rewrite_rules' )->once();
-		$this->sut->shouldReceive( 'reset_avatar_default' )->once()->with( $this->options );
+		$this->options->shouldReceive( 'reset_avatar_default' )->once();
 
 		$this->assertNull( $this->sut->deactivate() );
-	}
-
-	/**
-	 * Provides data for testing reset_avatar_default.
-	 *
-	 * @return array
-	 */
-	public function provide_reset_avatar_default_data() {
-		return [
-			[ 'rings', true ],
-			[ 'comment', true ],
-			[ 'bubble', true ],
-			[ 'bubble', true ],
-			[ 'im-user-offline', true ],
-			[ 'bowling-pin', true ],
-			[ 'view-media-artist', true ],
-			[ 'silhouette', true ],
-			[ 'custom', true ],
-			[ 'mystery', false ],
-			[ 'foobar', false ],
-		];
-	}
-
-	/**
-	 * Tests ::reset_avatar_default.
-	 *
-	 * @covers ::reset_avatar_default
-	 *
-	 * @dataProvider provide_reset_avatar_default_data
-	 *
-	 * @param  string $old_default The old value of `avatar_default`.
-	 * @param  bool   $reset       Whether the value should be reset.
-	 */
-	public function test_reset_avatar_default( $old_default, $reset ) {
-		$this->options->shouldReceive( 'get' )->once()->with( 'avatar_default', null, true )->andReturn( $old_default );
-
-		if ( $reset ) {
-			$this->options->shouldReceive( 'set' )->once()->with( 'avatar_default', 'mystery', true, true );
-		} else {
-			$this->options->shouldReceive( 'set' )->never();
-		}
-
-		$this->assertNull( $this->sut->reset_avatar_default( $this->options ) );
 	}
 
 	/**

--- a/tests/avatar-privacy/components/class-uninstallation-test.php
+++ b/tests/avatar-privacy/components/class-uninstallation-test.php
@@ -231,21 +231,17 @@ class Uninstallation_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * Tests ::delete_options.
 	 *
 	 * @covers ::delete_options
-	 *
-	 * @uses Avatar_Privacy\Components\Setup::reset_avatar_default
 	 */
 	public function test_delete_options() {
 		$options         = m::mock( Options::class );
 		$network_options = m::mock( Network_Options::class );
 
 		$options->shouldReceive( 'delete' )->once()->with( Core::SETTINGS_NAME );
+		$options->shouldReceive( 'reset_avatar_default' )->once();
 
 		Functions\expect( 'is_multisite' )->once()->andReturn( false );
 
 		$network_options->shouldReceive( 'delete' )->once()->with( Network_Options::USE_GLOBAL_TABLE );
-
-		// This is from reset_default_avatar.
-		$options->shouldReceive( 'get' )->once()->andReturn( 'foo' );
 
 		$this->assertNull( $this->sut->delete_options( $options, $network_options ) );
 	}
@@ -254,8 +250,6 @@ class Uninstallation_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * Tests ::delete_options.
 	 *
 	 * @covers ::delete_options
-	 *
-	 * @uses Avatar_Privacy\Components\Setup::reset_avatar_default
 	 */
 	public function test_delete_options_multisite() {
 		$options         = m::mock( Options::class );
@@ -268,11 +262,9 @@ class Uninstallation_Test extends \Avatar_Privacy\Tests\TestCase {
 		Functions\expect( 'switch_to_blog' )->times( $site_count )->with( m::type( 'int' ) );
 		Functions\expect( 'restore_current_blog' )->times( $site_count );
 
-		// This is from reset_default_avatar.
-		$options->shouldReceive( 'get' )->times( $site_count + 1 )->andReturn( 'foo' );
-
 		// FIXME: The main site is included!
 		$options->shouldReceive( 'delete' )->times( $site_count + 1 )->with( Core::SETTINGS_NAME );
+		$options->shouldReceive( 'reset_avatar_default' )->times( $site_count + 1 );
 		$network_options->shouldReceive( 'delete' )->once()->with( Network_Options::USE_GLOBAL_TABLE );
 
 		$this->assertNull( $this->sut->delete_options( $options, $network_options ) );

--- a/tests/avatar-privacy/data-storage/class-options-test.php
+++ b/tests/avatar-privacy/data-storage/class-options-test.php
@@ -43,6 +43,13 @@ use Avatar_Privacy\Data_Storage\Options;
 class Options_Test extends \Avatar_Privacy\Tests\TestCase {
 
 	/**
+	 * The system-under-test.
+	 *
+	 * @var \Avatar_Privacy\Data_Storage\Options
+	 */
+	private $sut;
+
+	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
@@ -50,6 +57,8 @@ class Options_Test extends \Avatar_Privacy\Tests\TestCase {
 		parent::setUp();
 
 		Functions\when( '__' )->returnArg();
+
+		$this->sut = m::mock( Options::class )->makePartial()->shouldAllowMockingProtectedMethods();
 	}
 
 	/**
@@ -61,5 +70,48 @@ class Options_Test extends \Avatar_Privacy\Tests\TestCase {
 		$result = new Options();
 
 		$this->assertAttributeSame( Options::PREFIX, 'prefix', $result );
+	}
+
+	/**
+	 * Provides data for testing reset_avatar_default.
+	 *
+	 * @return array
+	 */
+	public function provide_reset_avatar_default_data() {
+		return [
+			[ 'rings', true ],
+			[ 'comment', true ],
+			[ 'bubble', true ],
+			[ 'bubble', true ],
+			[ 'im-user-offline', true ],
+			[ 'bowling-pin', true ],
+			[ 'view-media-artist', true ],
+			[ 'silhouette', true ],
+			[ 'custom', true ],
+			[ 'mystery', false ],
+			[ 'foobar', false ],
+		];
+	}
+
+	/**
+	 * Tests ::reset_avatar_default.
+	 *
+	 * @covers ::reset_avatar_default
+	 *
+	 * @dataProvider provide_reset_avatar_default_data
+	 *
+	 * @param  string $old_default The old value of `avatar_default`.
+	 * @param  bool   $reset       Whether the value should be reset.
+	 */
+	public function test_reset_avatar_default( $old_default, $reset ) {
+		$this->sut->shouldReceive( 'get' )->once()->with( 'avatar_default', null, true )->andReturn( $old_default );
+
+		if ( $reset ) {
+			$this->sut->shouldReceive( 'set' )->once()->with( 'avatar_default', 'mystery', true, true );
+		} else {
+			$this->sut->shouldReceive( 'set' )->never();
+		}
+
+		$this->assertNull( $this->sut->reset_avatar_default() );
 	}
 }


### PR DESCRIPTION
- Use new constant `Comments::COOKIE_PREFIX` instead of literal string.
- Move `Setup::reset_avatar_default` to `Options` class (fixes #57).