### PR TITLE
New uninstallation process

### DIFF
--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -29,7 +29,7 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at
- * Version: 2.1.0-alpha.1
+ * Version: 2.1.0-alpha.2
  * License: GNU General Public License v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: avatar-privacy

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
         "phpunit/phpunit": "5.*||6.*||7.*",
         "mikey179/vfsStream": "~1",
-        "brain/monkey": "^2.2"
+        "brain/monkey": "^2.2",
+        "roave/security-advisories": "dev-master"
     },
 
     "autoload": {

--- a/includes/avatar-privacy/components/class-uninstallation.php
+++ b/includes/avatar-privacy/components/class-uninstallation.php
@@ -124,30 +124,30 @@ class Uninstallation implements \Avatar_Privacy\Component {
 	 */
 	public function run() {
 		// Delete cached files.
-		static::delete_cached_files( $this->file_cache );
+		$this->delete_cached_files();
 
 		// Delete uploaded user avatars.
-		static::delete_uploaded_avatars();
+		$this->delete_uploaded_avatars();
 
 		// Delete usermeta for all users.
-		static::delete_user_meta();
+		$this->delete_user_meta();
 
-		// Delete/change options (from all sites in case of a  multisite network).
-		static::delete_options( $this->options, $this->network_options );
+		// Delete/change options (from all sites in case of a multisite network).
+		$this->delete_options();
 
 		// Delete transients from sitemeta or options table.
-		static::delete_transients( $this->transients, $this->site_transients );
+		$this->delete_transients();
 
 		// Drop all our tables.
-		static::drop_all_tables( $this->database );
+		$this->drop_all_tables();
 	}
 
 	/**
 	 * Deletes uploaded avatar images.
 	 *
-	 * @since 2.1.0 Visibility changed to protected.
+	 * @since 2.1.0 Visibility changed to protected, made non-static.
 	 */
-	protected static function delete_uploaded_avatars() {
+	protected function delete_uploaded_avatars() {
 		$user_avatar = User_Avatar_Upload_Handler::USER_META_KEY;
 		$query       = [
 			'meta_key'     => $user_avatar, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
@@ -166,38 +166,34 @@ class Uninstallation implements \Avatar_Privacy\Component {
 	/**
 	 * Deletes all cached files.
 	 *
-	 * @since 2.1.0 Visibility changed to protected, parameter $file_cache added.
-	 *
-	 * @param Filesystem_Cache $file_cache A fileystem cache handler.
+	 * @since 2.1.0 Visibility changed to protected, made non-static.
 	 */
-	protected static function delete_cached_files( Filesystem_Cache $file_cache ) {
-		$file_cache->invalidate();
+	protected function delete_cached_files() {
+		$this->file_cache->invalidate();
 	}
 
 	/**
 	 * Drops all tables.
 	 *
-	 * @since 2.1.0 Visibility changed to protected.
-	 *
-	 * @param Database $database The database handler.
+	 * @since 2.1.0 Visibility changed to protected, made non-static.
 	 */
-	protected static function drop_all_tables( Database $database ) {
+	protected function drop_all_tables() {
 		// Delete/change options for all other blogs (multisite).
 		if ( \is_multisite() ) {
 			foreach ( \get_sites( [ 'fields' => 'ids' ] ) as $site_id ) {
-				$database->drop_table( $site_id );
+				$this->database->drop_table( $site_id );
 			}
 		} else {
-			$database->drop_table();
+			$this->database->drop_table();
 		}
 	}
 
 	/**
 	 * Delete all user meta data added by the plugin.
 	 *
-	 * @since 2.1.0 Visibility changed to protected.
+	 * @since 2.1.0 Visibility changed to protected, made non-static.
 	 */
-	protected static function delete_user_meta() {
+	protected function delete_user_meta() {
 		\delete_metadata( 'user', 0, Core::GRAVATAR_USE_META_KEY, null, true );
 		\delete_metadata( 'user', 0, Core::ALLOW_ANONYMOUS_META_KEY, null, true );
 		\delete_metadata( 'user', 0, User_Avatar_Upload_Handler::USER_META_KEY, null, true );
@@ -206,15 +202,12 @@ class Uninstallation implements \Avatar_Privacy\Component {
 	/**
 	 * Delete the plugin options (from all sites).
 	 *
-	 * @since 2.1.0 Visibility changed to protected.
-	 *
-	 * @param Options         $options         The options handler.
-	 * @param Network_Options $network_options The network options handler.
+	 * @since 2.1.0 Visibility changed to protected, made non-static.
 	 */
-	protected static function delete_options( Options $options, Network_Options $network_options ) {
+	protected function delete_options() {
 		// Delete/change options for main blog.
-		$options->delete( Core::SETTINGS_NAME );
-		$options->reset_avatar_default();
+		$this->options->delete( Core::SETTINGS_NAME );
+		$this->options->reset_avatar_default();
 
 		// Delete/change options for all other blogs (multisite).
 		if ( \is_multisite() ) {
@@ -222,36 +215,33 @@ class Uninstallation implements \Avatar_Privacy\Component {
 				\switch_to_blog( $blog_id );
 
 				// Delete our settings.
-				$options->delete( Core::SETTINGS_NAME );
+				$this->options->delete( Core::SETTINGS_NAME );
 
 				// Reset avatar_default to working value if necessary.
-				$options->reset_avatar_default();
+				$this->options->reset_avatar_default();
 
 				\restore_current_blog();
 			}
 		}
 
 		// Delete site options as well (except for the salt).
-		$network_options->delete( Network_Options::USE_GLOBAL_TABLE );
+		$this->network_options->delete( Network_Options::USE_GLOBAL_TABLE );
 	}
 
 	/**
 	 * Delete all the plugins transients.
 	 *
-	 * @since 2.1.0 Visibility changed to protected.
-	 *
-	 * @param  Transients      $transients      The transients handler.
-	 * @param  Site_Transients $site_transients The site transients handler.
+	 * @since 2.1.0 Visibility changed to protected, made non-static.
 	 */
-	protected static function delete_transients( Transients $transients, Site_Transients $site_transients ) {
+	protected function delete_transients() {
 		// Remove regular transients.
-		foreach ( $transients->get_keys_from_database() as $key ) {
-			$transients->delete( $key, true );
+		foreach ( $this->transients->get_keys_from_database() as $key ) {
+			$this->transients->delete( $key, true );
 		}
 
 		// Remove site transients.
-		foreach ( $site_transients->get_keys_from_database() as $key ) {
-			$site_transients->delete( $key, true );
+		foreach ( $this->site_transients->get_keys_from_database() as $key ) {
+			$this->site_transients->delete( $key, true );
 		}
 	}
 }

--- a/includes/avatar-privacy/components/class-uninstallation.php
+++ b/includes/avatar-privacy/components/class-uninstallation.php
@@ -67,8 +67,7 @@ class Uninstallation implements \Avatar_Privacy\Component {
 	 * @return void
 	 */
 	public function run() {
-		// Register various hooks.
-		\register_uninstall_hook( $this->plugin_file, [ self::class, 'uninstall' ] );
+		static::uninstall();
 	}
 
 	/**

--- a/includes/class-avatar-privacy-controller.php
+++ b/includes/class-avatar-privacy-controller.php
@@ -36,7 +36,6 @@ use Avatar_Privacy\Components\REST_API;
 use Avatar_Privacy\Components\Setup;
 use Avatar_Privacy\Components\Settings_Page;
 use Avatar_Privacy\Components\User_Profile;
-use Avatar_Privacy\Components\Uninstallation;
 
 /**
  * Initialize Avatar Privacy plugin.
@@ -64,7 +63,6 @@ class Avatar_Privacy_Controller {
 	 *
 	 * @param Core            $core         The core API.
 	 * @param Setup           $setup        The (de-)activation handling.
-	 * @param Uninstallation  $uninstall    The uninstallation handling.
 	 * @param Image_Proxy     $image_proxy  The image handler.
 	 * @param Avatar_Handling $avatars      The avatar handler.
 	 * @param Comments        $comments     The comments handler.
@@ -74,10 +72,9 @@ class Avatar_Privacy_Controller {
 	 * @param REST_API        $rest_api     The REST API handler.
 	 * @param Integrations    $integrations The third-party plugin integrations handler.
 	 */
-	public function __construct( Core $core, Setup $setup, Uninstallation $uninstall, Image_Proxy $image_proxy, Avatar_Handling $avatars, Comments $comments, User_Profile $profile, Settings_Page $settings, Privacy_Tools $privacy, REST_API $rest_api, Integrations $integrations ) {
+	public function __construct( Core $core, Setup $setup, Image_Proxy $image_proxy, Avatar_Handling $avatars, Comments $comments, User_Profile $profile, Settings_Page $settings, Privacy_Tools $privacy, REST_API $rest_api, Integrations $integrations ) {
 		$this->core         = $core;
 		$this->components[] = $setup;
-		$this->components[] = $uninstall;
 		$this->components[] = $avatars;
 		$this->components[] = $image_proxy;
 		$this->components[] = $comments;

--- a/includes/class-avatar-privacy-uninstallation-requirements.php
+++ b/includes/class-avatar-privacy-uninstallation-requirements.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2018 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+// We can't rely on autoloading for the requirements check.
+require_once dirname( dirname( __FILE__ ) ) . '/vendor/mundschenk-at/check-wp-requirements/class-mundschenk-wp-requirements.php'; // @codeCoverageIgnore
+
+/**
+ * A custom requirements class to check for the minimum PHP version (and nothing
+ * else) during the uninstallation process .
+ *
+ * @since 2.1.0
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ */
+class Avatar_Privacy_Uninstallation_Requirements extends Mundschenk_WP_Requirements {
+
+	/**
+	 * Creates a new requirements instance.
+	 *
+	 * @param string $plugin_file The full path to the plugin file.
+	 */
+	public function __construct( $plugin_file ) {
+		$requirements = array(
+			'php'              => '5.6.0',
+		);
+
+		parent::__construct( 'Avatar Privacy', $plugin_file, 'avatar-privacy', $requirements );
+	}
+}

--- a/tests/avatar-privacy/components/class-uninstallation-test.php
+++ b/tests/avatar-privacy/components/class-uninstallation-test.php
@@ -110,7 +110,7 @@ class Uninstallation_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::run
 	 */
 	public function test_run() {
-		Functions\expect( 'register_uninstall_hook' )->once()->with( 'plugin/file', [ Uninstallation::class, 'uninstall' ] );
+		$this->sut->shouldReceive( 'uninstall' )->once();
 
 		$this->assertNull( $this->sut->run() );
 	}

--- a/tests/class-avatar-privacy-controller-test.php
+++ b/tests/class-avatar-privacy-controller-test.php
@@ -37,7 +37,6 @@ use Avatar_Privacy\Components\REST_API;
 use Avatar_Privacy\Components\Setup;
 use Avatar_Privacy\Components\Settings_Page;
 use Avatar_Privacy\Components\User_Profile;
-use Avatar_Privacy\Components\Uninstallation;
 
 use Brain\Monkey\Actions;
 use Brain\Monkey\Filters;
@@ -79,7 +78,6 @@ class Avatar_Privacy_Controller_Test extends TestCase {
 			[
 				m::mock( Core::class ),
 				m::mock( Setup::class ),
-				m::mock( Uninstallation::class ),
 				m::mock( Image_Proxy::class ),
 				m::mock( Avatar_Handling::class ),
 				m::mock( Comments::class ),

--- a/tests/class-avatar-privacy-uninstallation-requirements-test.php
+++ b/tests/class-avatar-privacy-uninstallation-requirements-test.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2018 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+
+use Mockery as m;
+
+/**
+ * Avatar_Privacy_Uninstallation_Requirements unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy_Uninstallation_Requirements
+ * @usesDefaultClass \Avatar_Privacy_Uninstallation_Requirements
+ */
+class Avatar_Privacy_Uninstallation_Requirements_Test extends TestCase {
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var \Avatar_Privacy_Uninstallation_Requirements
+	 */
+	private $sut;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$this->sut = m::mock( \Avatar_Privacy_Uninstallation_Requirements::class )->makePartial()->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * Test ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+
+		Functions\expect( 'wp_parse_args' )->andReturnUsing(
+			function( $args, $defaults ) {
+				return \array_merge( $defaults, $args );
+			}
+		);
+		$req = m::mock( \Avatar_Privacy_Uninstallation_Requirements::class )->makePartial();
+		$req->__construct( 'some_file' );
+
+		$this->assertSame( 'Avatar Privacy', $this->getValue( $req, 'plugin_name', \Mundschenk_WP_Requirements::class ) );
+		$this->assertSame( 'avatar-privacy', $this->getValue( $req, 'textdomain', \Mundschenk_WP_Requirements::class ) );
+		$this->assertSame(
+			[
+				'php'       => '5.6.0',
+				'multibyte' => false,
+				'utf-8'     => false,
+			],
+			$this->getValue( $req, 'install_requirements', \Mundschenk_WP_Requirements::class )
+		);
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2018 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+// Don't do anything if called directly.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	die();
+}
+
+require_once dirname( __FILE__ ) . '/includes/class-avatar-privacy-uninstallation-requirements.php';
+
+/**
+ * Uninstall the plugin after checking for the necessary PHP version.
+ *
+ * It's necessary to do this here because our classes rely on namespaces.
+ */
+function uninstall_avatar_privacy() {
+
+	$requirements = new Avatar_Privacy_Uninstallation_Requirements( __FILE__ );
+
+	if ( $requirements->check() ) {
+		// Autoload the rest of your classes.
+		require_once __DIR__ . '/vendor/autoload.php';
+
+		// Create and start the plugin.
+		$plugin = Avatar_Privacy_Factory::get( __FILE__ )->create( 'Avatar_Privacy\Components\Uninstallation' );
+		$plugin->run();
+	}
+}
+uninstall_avatar_privacy();


### PR DESCRIPTION
Fixes #55:
- Move to `uninstall.php` process to reduce the number of loaded classes.
- Make methods of `Avatar_Privacy\Components\Uninstallation` non-static.
- Add mechanism that ensures proper clean-up on multisite installations.