### PR TITLE
Move classes from the global namespace

### DIFF
--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -56,7 +56,7 @@ function run_avatar_privacy() {
 		require_once __DIR__ . '/vendor/autoload.php';
 
 		// Create and start the plugin.
-		$plugin = Avatar_Privacy_Factory::get( __FILE__ )->create( 'Avatar_Privacy_Controller' );
+		$plugin = Avatar_Privacy_Factory::get( __FILE__ )->create( 'Avatar_Privacy\Controller' );
 		$plugin->run();
 	}
 }

--- a/includes/avatar-privacy/class-controller.php
+++ b/includes/avatar-privacy/class-controller.php
@@ -25,7 +25,7 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
-use Avatar_Privacy\Core;
+namespace Avatar_Privacy;
 
 use Avatar_Privacy\Components\Avatar_Handling;
 use Avatar_Privacy\Components\Comments;
@@ -41,8 +41,9 @@ use Avatar_Privacy\Components\User_Profile;
  * Initialize Avatar Privacy plugin.
  *
  * @since 1.0.0
+ * @since 2.1.0 Renamed to Avatar_Privacy\Controller.
  */
-class Avatar_Privacy_Controller {
+class Controller {
 
 	/**
 	 * The settings page handler.

--- a/tests/avatar-privacy/class-controller-test.php
+++ b/tests/avatar-privacy/class-controller-test.php
@@ -24,7 +24,7 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
-namespace Avatar_Privacy\Tests;
+namespace Avatar_Privacy\Tests\Avatar_Privacy;
 
 use Avatar_Privacy\Core;
 
@@ -47,10 +47,10 @@ use Mockery as m;
 /**
  * Unit tests for plugin controller.
  *
- * @coversDefaultClass \Avatar_Privacy_Controller
- * @usesDefaultClass \Avatar_Privacy_Controller
+ * @coversDefaultClass \Avatar_Privacy\Controller
+ * @usesDefaultClass \Avatar_Privacy\Controller
  */
-class Avatar_Privacy_Controller_Test extends TestCase {
+class Controller_Test extends \Avatar_Privacy\Tests\TestCase {
 
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
@@ -74,7 +74,7 @@ class Avatar_Privacy_Controller_Test extends TestCase {
 	 */
 	public function test_constructor() {
 		$controller = m::mock(
-			\Avatar_Privacy_Controller::class,
+			\Avatar_Privacy\Controller::class,
 			[
 				m::mock( Core::class ),
 				m::mock( Setup::class ),
@@ -89,7 +89,7 @@ class Avatar_Privacy_Controller_Test extends TestCase {
 			]
 		)->makePartial();
 
-		$this->assertInstanceOf( \Avatar_Privacy_Controller::class, $controller );
+		$this->assertInstanceOf( \Avatar_Privacy\Controller::class, $controller );
 
 		return $controller;
 	}
@@ -103,10 +103,10 @@ class Avatar_Privacy_Controller_Test extends TestCase {
 	 *
 	 * @uses \Avatar_Privacy\Core::set_instance
 	 *
-	 * @param \Avatar_Privacy_Controller $controller Required.
+	 * @param \Avatar_Privacy\Controller $controller Required.
 	 */
 	public function test_run( $controller ) {
-		foreach ( $this->getValue( $controller, 'components', \Avatar_Privacy_Controller::class ) as $component ) {
+		foreach ( $this->getValue( $controller, 'components', \Avatar_Privacy\Controller::class ) as $component ) {
 			$component->shouldReceive( 'run' )->once();
 		}
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -43,9 +43,9 @@ function uninstall_avatar_privacy() {
 		// Autoload the rest of your classes.
 		require_once __DIR__ . '/vendor/autoload.php';
 
-		// Create and start the plugin.
-		$plugin = Avatar_Privacy_Factory::get( __FILE__ )->create( 'Avatar_Privacy\Components\Uninstallation' );
-		$plugin->run();
+		// Create and start the uninstallation handler.
+		$uninstaller = Avatar_Privacy_Factory::get( __FILE__ )->create( 'Avatar_Privacy\Components\Uninstallation' );
+		$uninstaller->run();
 	}
 }
 uninstall_avatar_privacy();


### PR DESCRIPTION
Move classes from the global namespace to `\Avatar_Privacy` if possible. Fixes #59.