### PR TITLE
Plugin file cleanup

### DIFF
--- a/includes/avatar-privacy-functions.php
+++ b/includes/avatar-privacy-functions.php
@@ -34,18 +34,14 @@ if ( ! function_exists( 'avapr_get_avatar_checkbox' ) ) {
 	 * This is intended as a template function for older or highly-customized
 	 * themes. Output the result with echo or print.
 	 *
-	 * @since 2.1.0 Added optional $path parameter.
-	 *
-	 * @param  string $path Optional. The path to the main plugin file (used only for unit testing). Default empty.
-	 *
 	 * @return string       The HTML code for the checkbox or an empty string.
 	 */
-	function avapr_get_avatar_checkbox( $path = '' ) {
+	function avapr_get_avatar_checkbox() {
 		// The checkbox is meaningless for logged-in users.
 		if ( \is_user_logged_in() ) {
 			return '';
 		}
 
-		return Comments::get_gravatar_checkbox( $path ?: __DIR__ );
+		return Comments::get_gravatar_checkbox();
 	}
 }

--- a/includes/avatar-privacy/components/class-comments.php
+++ b/includes/avatar-privacy/components/class-comments.php
@@ -107,7 +107,7 @@ class Comments implements \Avatar_Privacy\Component {
 		}
 
 		// Define the new checkbox field.
-		$new_field = self::get_gravatar_checkbox( AVATAR_PRIVACY_PLUGIN_FILE );
+		$new_field = self::get_gravatar_checkbox();
 
 		/**
 		 * Filters the insert position for the `use_gravatar` checkbox.
@@ -186,16 +186,16 @@ class Comments implements \Avatar_Privacy\Component {
 	/**
 	 * Retrieves the markup for the use_gravatar checkbox for the comment form.
 	 *
-	 * @param  string $path The path to the main plugin file.
+	 * @since 2.1.0 Parameter $path removed.
 	 *
 	 * @return string
 	 */
-	public static function get_gravatar_checkbox( $path ) {
+	public static function get_gravatar_checkbox() {
 		// Start output buffering.
 		\ob_start();
 
 		// Include the partial.
-		require \dirname( $path ) . '/public/partials/comments/use-gravatar.php';
+		require \dirname( AVATAR_PRIVACY_PLUGIN_FILE ) . '/public/partials/comments/use-gravatar.php';
 
 		// Return included markup.
 		return \ob_get_clean();

--- a/tests/avatar-privacy/class-core-test.php
+++ b/tests/avatar-privacy/class-core-test.php
@@ -520,13 +520,6 @@ class Core_Test extends \Avatar_Privacy\Tests\TestCase {
 		$result = (object) [ 'foo' => 'bar' ];
 		$key    = \Avatar_Privacy\Core::EMAIL_CACHE_PREFIX . $hash;
 
-		if ( ! defined( 'OBJECT' ) ) {
-			define( 'OBJECT', 'object' );
-		}
-		if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
-			define( 'MINUTE_IN_SECONDS', 60 );
-		}
-
 		global $wpdb;
 		$wpdb                 = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wpdb->avatar_privacy = 'avatar_privacy_table';
@@ -550,13 +543,6 @@ class Core_Test extends \Avatar_Privacy\Tests\TestCase {
 		$hash   = 'foo_hashed';
 		$result = (object) [ 'foo' => 'bar' ];
 		$key    = \Avatar_Privacy\Core::EMAIL_CACHE_PREFIX . $hash;
-
-		if ( ! defined( 'OBJECT' ) ) {
-			define( 'OBJECT', 'object' );
-		}
-		if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
-			define( 'MINUTE_IN_SECONDS', 60 );
-		}
 
 		global $wpdb;
 		$wpdb                 = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -602,13 +588,6 @@ class Core_Test extends \Avatar_Privacy\Tests\TestCase {
 		$result = (object) [ 'foo' => 'bar' ];
 		$key    = \Avatar_Privacy\Core::EMAIL_CACHE_PREFIX . $hash;
 
-		if ( ! defined( 'OBJECT' ) ) {
-			define( 'OBJECT', 'object' );
-		}
-		if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
-			define( 'MINUTE_IN_SECONDS', 60 );
-		}
-
 		global $wpdb;
 		$wpdb                 = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wpdb->avatar_privacy = 'avatar_privacy_table';
@@ -630,13 +609,6 @@ class Core_Test extends \Avatar_Privacy\Tests\TestCase {
 		$hash   = 'foo_hashed';
 		$result = (object) [ 'foo' => 'bar' ];
 		$key    = \Avatar_Privacy\Core::EMAIL_CACHE_PREFIX . $hash;
-
-		if ( ! defined( 'OBJECT' ) ) {
-			define( 'OBJECT', 'object' );
-		}
-		if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
-			define( 'MINUTE_IN_SECONDS', 60 );
-		}
 
 		global $wpdb;
 		$wpdb                 = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited

--- a/tests/avatar-privacy/components/class-comments-test.php
+++ b/tests/avatar-privacy/components/class-comments-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -328,7 +328,7 @@ class Comments_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::get_gravatar_checkbox
 	 */
 	public function test_get_gravatar_checkbox() {
-		$this->assertSame( 'USE_GRAVATAR', Comments::get_gravatar_checkbox( 'plugin/file' ) );
+		$this->assertSame( 'USE_GRAVATAR', Comments::get_gravatar_checkbox() );
 	}
 
 	/**

--- a/tests/avatar-privacy/components/class-comments-test.php
+++ b/tests/avatar-privacy/components/class-comments-test.php
@@ -91,21 +91,6 @@ class Comments_Test extends \Avatar_Privacy\Tests\TestCase {
 		$root = vfsStream::setup( 'root', null, $filesystem );
 		set_include_path( 'vfs://root/' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_set_include_path
 
-		// Necessary constants.
-		if ( ! defined( 'COOKIEHASH' ) ) {
-			define( 'COOKIEHASH', 'somehash' );
-		}
-		if ( ! defined( 'YEAR_IN_SECONDS' ) ) {
-			define( 'YEAR_IN_SECONDS', 60 * 60 * 24 * 365 );
-		}
-		if ( ! defined( 'COOKIEPATH' ) ) {
-			define( 'COOKIEPATH', 'some/path' );
-		}
-		if ( ! defined( 'COOKIE_DOMAIN' ) ) {
-			define( 'COOKIE_DOMAIN', 'some.blog' );
-		}
-
-
 		// Mock required helpers.
 		$this->core = m::mock( Core::class );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -29,9 +29,11 @@
  */
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
-// Necessary constants.
-if ( ! defined( 'ABSPATH' ) ) {
-	define( 'ABSPATH', 'wordpress/path/' );
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals
+
+// WordPress time constants.
+if ( ! defined( 'YEAR_IN_SECONDS' ) ) {
+	define( 'YEAR_IN_SECONDS', 60 * 60 * 24 * 365 );
 }
 if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
 	define( 'WEEK_IN_SECONDS', 7 * 24 * 60 * 60 );
@@ -45,9 +47,30 @@ if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
 if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
 	define( 'MINUTE_IN_SECONDS', 60 );
 }
+
+// WordPress cookie constants.
+if ( ! defined( 'COOKIEHASH' ) ) {
+	define( 'COOKIEHASH', 'somehash' );
+}
+if ( ! defined( 'COOKIEPATH' ) ) {
+	define( 'COOKIEPATH', 'some/path' );
+}
+if ( ! defined( 'COOKIE_DOMAIN' ) ) {
+	define( 'COOKIE_DOMAIN', 'some.blog' );
+}
+
+// Other WordPress constants.
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', 'wordpress/path/' );
+}
+if ( ! defined( 'OBJECT' ) ) {
+	define( 'OBJECT', 'OBJECT' );
+}
 if ( ! defined( 'OBJECT_K' ) ) {
 	define( 'OBJECT_K', 'OBJECT_K' );
 }
+
+// Avatar Privacy constants.
 if ( ! defined( 'AVATAR_PRIVACY_PLUGIN_FILE' ) ) {
 	define( 'AVATAR_PRIVACY_PLUGIN_FILE', 'plugin/file' );
 }

--- a/tests/class-avatar-privacy-functions-test.php
+++ b/tests/class-avatar-privacy-functions-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -76,7 +76,7 @@ class Avatar_Privacy_Functions_Test extends TestCase {
 	public function test_avapr_get_avatar_checkbox() {
 		Functions\expect( 'is_user_logged_in' )->once()->andReturn( false );
 
-		$this->assertSame( 'USE_GRAVATAR', \avapr_get_avatar_checkbox( 'plugin/plugin.php' ) );
+		$this->assertSame( 'USE_GRAVATAR', \avapr_get_avatar_checkbox() );
 	}
 
 	/**
@@ -89,6 +89,6 @@ class Avatar_Privacy_Functions_Test extends TestCase {
 	public function test_avapr_get_avatar_checkbox_user_is_logged_in() {
 		Functions\expect( 'is_user_logged_in' )->once()->andReturn( true );
 
-		$this->assertSame( '', \avapr_get_avatar_checkbox( 'plugin/plugin.php' ) );
+		$this->assertSame( '', \avapr_get_avatar_checkbox() );
 	}
 }


### PR DESCRIPTION
- Remove unnecessary plugin file `$path` parameter in favor `AVATAR_PRIVACY_PLUGIN_FILE`.
- Move all constant definitions for tests to `bootstrap.php`.