### PR TITLE
Remove deprecated parameter from Images\Editor::get_resized_image_data

### DIFF
--- a/includes/avatar-privacy/avatar-handlers/class-user-avatar-handler.php
+++ b/includes/avatar-privacy/avatar-handlers/class-user-avatar-handler.php
@@ -120,7 +120,7 @@ class User_Avatar_Handler implements Avatar_Handler {
 
 		if ( $args['force'] || ! \file_exists( "{$this->base_dir}{$filename}" ) ) {
 			$data = $this->images->get_resized_image_data(
-				$this->images->get_image_editor( $args['avatar'] ), $size, $size, true, $args['mimetype']
+				$this->images->get_image_editor( $args['avatar'] ), $size, $size, $args['mimetype']
 			);
 
 			// Save the generated PNG file (empty files will fail this check).

--- a/includes/avatar-privacy/avatar-handlers/default-icons/class-custom-icon-provider.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/class-custom-icon-provider.php
@@ -116,7 +116,7 @@ class Custom_Icon_Provider extends Abstract_Icon_Provider {
 		// Only generate a new icon if necessary.
 		if ( ! \file_exists( "{$this->file_cache->get_base_dir()}{$filename}" ) ) {
 
-			$data = $this->images->get_resized_image_data( $this->images->get_image_editor( $icon['file'] ), $size, $size, true, $icon['type'] );
+			$data = $this->images->get_resized_image_data( $this->images->get_image_editor( $icon['file'] ), $size, $size, $icon['type'] );
 			if ( empty( $data ) ) {
 				// Something went wrong..
 				return $default;

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-png-generator.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-png-generator.php
@@ -130,7 +130,7 @@ abstract class PNG_Generator implements Generator {
 	 */
 	protected function get_resized_image_data( $image, $size ) {
 		return $this->images->get_resized_image_data(
-			$this->images->create_from_image_resource( $image ), $size, $size, false, 'image/png'
+			$this->images->create_from_image_resource( $image ), $size, $size, 'image/png'
 		);
 	}
 }

--- a/includes/avatar-privacy/tools/images/class-editor.php
+++ b/includes/avatar-privacy/tools/images/class-editor.php
@@ -172,16 +172,16 @@ class Editor {
 	 * Resizes the given image and returns the image data.
 	 *
 	 * @since 2.0.5 Parameter $crop has been deprecated.
+	 * @since 2.1.0 Parameter $crop has been removed.
 	 *
 	 * @param  \WP_Image_Editor|\WP_Error $image      The image.
 	 * @param  int                        $width      The width in pixels.
 	 * @param  int                        $height     The height in pixels.
-	 * @param  bool                       $deprecated Optional. This deprecated argument is ignored. Default false.
 	 * @param  string                     $format     Optional. The image mimetype. Default 'image/png'.
 	 *
 	 * @return string
 	 */
-	public function get_resized_image_data( $image, $width, $height, $deprecated = false, $format = 'image/png' ) {
+	public function get_resized_image_data( $image, $width, $height, $format = 'image/png' ) {
 
 		// Try to resize only if we haven't been handed an error object.
 		if ( $image instanceof \WP_Error ) {

--- a/tests/avatar-privacy/avatar-handlers/class-user-avatar-handler-test.php
+++ b/tests/avatar-privacy/avatar-handlers/class-user-avatar-handler-test.php
@@ -163,7 +163,7 @@ class User_Avatar_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->sut->shouldReceive( 'get_sub_dir' )->once()->with( $hash )->andReturn( 'a/b' );
 
 		$this->images->shouldReceive( 'get_image_editor' )->once()->with( $args['avatar'] )->andReturn( m::mock( \WP_Image_Editor::class ) );
-		$this->images->shouldReceive( 'get_resized_image_data' )->once()->with( m::type( \WP_Image_Editor::class ), $size, $size, true, $args['mimetype'] )->andReturn( $image );
+		$this->images->shouldReceive( 'get_resized_image_data' )->once()->with( m::type( \WP_Image_Editor::class ), $size, $size, $args['mimetype'] )->andReturn( $image );
 
 		$this->file_cache->shouldReceive( 'set' )->once()->with( m::type( 'string' ), $image, $force )->andReturn( true );
 		$this->file_cache->shouldReceive( 'get_url' )->once()->with( m::type( 'string' ) )->andReturn( $url );
@@ -201,7 +201,7 @@ class User_Avatar_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->sut->shouldReceive( 'get_sub_dir' )->once()->with( $hash )->andReturn( 'a/b' );
 
 		$this->images->shouldReceive( 'get_image_editor' )->once()->with( $args['avatar'] )->andReturn( m::mock( \WP_Image_Editor::class ) );
-		$this->images->shouldReceive( 'get_resized_image_data' )->once()->with( m::type( \WP_Image_Editor::class ), $size, $size, true, $args['mimetype'] )->andReturn( $image );
+		$this->images->shouldReceive( 'get_resized_image_data' )->once()->with( m::type( \WP_Image_Editor::class ), $size, $size, $args['mimetype'] )->andReturn( $image );
 
 		$this->file_cache->shouldReceive( 'set' )->once()->with( m::type( 'string' ), $image, $force )->andReturn( false );
 		$this->file_cache->shouldReceive( 'get_url' )->never();

--- a/tests/avatar-privacy/avatar-handlers/default-icons/class-custom-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/class-custom-icon-provider-test.php
@@ -174,7 +174,7 @@ class Custom_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->file_cache->shouldReceive( 'get_base_dir' )->once()->with()->andReturn( $basedir );
 
 		$this->images->shouldReceive( 'get_image_editor' )->once()->with( $icon['file'] )->andReturn( m::mock( \WP_Image_Editor::class ) );
-		$this->images->shouldReceive( 'get_resized_image_data' )->once()->with( m::type( \WP_Image_Editor::class ), $size, $size, true, $icon['type'] )->andReturn( $data );
+		$this->images->shouldReceive( 'get_resized_image_data' )->once()->with( m::type( \WP_Image_Editor::class ), $size, $size, $icon['type'] )->andReturn( $data );
 
 		$this->file_cache->shouldReceive( 'set' )->once()->with( $filename, $data )->andReturn( true );
 		$this->file_cache->shouldReceive( 'get_url' )->once()->with( $filename )->andReturn( $url );
@@ -260,7 +260,7 @@ class Custom_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->file_cache->shouldReceive( 'get_base_dir' )->once()->with()->andReturn( $basedir );
 
 		$this->images->shouldReceive( 'get_image_editor' )->once()->with( $icon['file'] )->andReturn( m::mock( \WP_Image_Editor::class ) );
-		$this->images->shouldReceive( 'get_resized_image_data' )->once()->with( m::type( \WP_Image_Editor::class ), $size, $size, true, $icon['type'] )->andReturn( $data );
+		$this->images->shouldReceive( 'get_resized_image_data' )->once()->with( m::type( \WP_Image_Editor::class ), $size, $size, $icon['type'] )->andReturn( $data );
 
 		$this->file_cache->shouldReceive( 'set' )->never();
 		$this->file_cache->shouldReceive( 'get_url' )->never();

--- a/tests/avatar-privacy/tools/images/class-editor-test.php
+++ b/tests/avatar-privacy/tools/images/class-editor-test.php
@@ -264,7 +264,7 @@ class Editor_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->sut->shouldReceive( 'get_image_data' )->once()->with( $editor, $format )->andReturn( $data );
 
-		$this->assertSame( $data, $this->sut->get_resized_image_data( $editor, $width, $height, false, $format ) );
+		$this->assertSame( $data, $this->sut->get_resized_image_data( $editor, $width, $height, $format ) );
 	}
 
 	/**
@@ -284,7 +284,7 @@ class Editor_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->sut->shouldReceive( 'get_image_data' )->never();
 
-		$this->assertSame( '', $this->sut->get_resized_image_data( $editor, $width, $height, false, $format ) );
+		$this->assertSame( '', $this->sut->get_resized_image_data( $editor, $width, $height, $format ) );
 	}
 
 	/**
@@ -313,7 +313,7 @@ class Editor_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->sut->shouldReceive( 'get_image_data' )->never();
 
-		$this->assertSame( '', $this->sut->get_resized_image_data( $editor, $width, $height, false, $format ) );
+		$this->assertSame( '', $this->sut->get_resized_image_data( $editor, $width, $height, $format ) );
 	}
 
 	/**


### PR DESCRIPTION
Remove deprecated parameter `$deprecated` (previously: `$crop`) from `Tools\Images\Editor::get_resized_image_data()`.