### PR TITLE
Refactor Generators and add unit tests

### DIFF
--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-jdenticon.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-jdenticon.php
@@ -47,13 +47,13 @@ class Jdenticon implements Generator {
 
 	/**
 	 * Creates a new instance.
+	 *
+	 * @since 2.1.0 Parameter $identicon added.
+	 *
+	 * @param \Jdenticon\Identicon $identicon The Jdenticon implementation.
 	 */
-	public function __construct() {
-		$args = [
-			'style' => new \Jdenticon\IdenticonStyle( [ 'padding' => 0 ] ),
-		];
-
-		$this->identicon = new \Jdenticon\Identicon( $args );
+	public function __construct( \Jdenticon\Identicon $identicon ) {
+		$this->identicon = $identicon;
 	}
 
 	/**

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-jdenticon.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-jdenticon.php
@@ -65,8 +65,8 @@ class Jdenticon implements Generator {
 	 * @return string
 	 */
 	public function build( $seed, $size = 128 ) {
-		$this->identicon->hash = $seed;
-		$this->identicon->size = $size;
+		$this->identicon->setHash( $seed );
+		$this->identicon->setSize( $size );
 
 		return $this->identicon->getImageData( 'svg' );
 	}

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id.php
@@ -250,13 +250,15 @@ class Monster_ID extends PNG_Generator {
 	/**
 	 * Finds all the monster parts images.
 	 *
+	 * @since 2.1.0 Visibility changed to protected.
+	 *
 	 * @param  array $parts An array of arrays indexed by body parts.
 	 *
 	 * @return array
 	 *
 	 * @throws \RuntimeException The part files could not be found.
 	 */
-	private function locate_parts( array $parts ) {
+	protected function locate_parts( array $parts ) {
 		$noparts = true;
 		if ( false !== ( $dh = \opendir( $this->parts_dir ) ) ) { // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found,WordPress.CodeAnalysis.AssignmentInCondition.Found
 			while ( false !== ( $file = \readdir( $dh ) ) ) { // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found,WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
@@ -285,13 +287,16 @@ class Monster_ID extends PNG_Generator {
 	}
 
 	/**
-	 * Determines exact dimensions for individual parts.
+	 * Determines exact dimensions for individual parts. Mainly useful for subclasses
+	 * exchanging the provided images.
+	 *
+	 * @since 2.1.0 Visibility changed to protected.
 	 *
 	 * @param  bool $text A flag that determines whether a human readable result should be returned.
 	 *
 	 * @return string|array
 	 */
-	private function get_parts_dimensions( $text = false ) {
+	protected function get_parts_dimensions( $text = false ) {
 		$parts = $this->locate_parts( self::EMPTY_PARTS_LIST );
 
 		$bounds      = [];
@@ -412,6 +417,8 @@ class Monster_ID extends PNG_Generator {
 	/**
 	 * Adds color to the given image.
 	 *
+	 * @since 2.1.0 Visibility changed to protected.
+	 *
 	 * @param  resource $image      The image.
 	 * @param  int      $hue        The hue (0-360).
 	 * @param  int      $saturation The saturation (0-100).
@@ -419,7 +426,7 @@ class Monster_ID extends PNG_Generator {
 	 *
 	 * @return resource             The image, for chaining.
 	 */
-	private function image_colorize( $image, $hue = 360, $saturation = 100, $part = '' ) {
+	protected function image_colorize( $image, $hue = 360, $saturation = 100, $part = '' ) {
 		$imgw = \imagesx( $image );
 		$imgh = \imagesy( $image );
 

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-png-generator.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-png-generator.php
@@ -73,10 +73,14 @@ abstract class PNG_Generator implements Generator {
 	 * Helper function for building avatar images. This loads an image and adds it to
 	 * our composite using the given color values. The image resource is freed at the end.
 	 *
+	 * @since 2.1.0 Returns true on success, false on error.
+	 *
 	 * @param  resource        $base   The avatar image resource.
 	 * @param  string|resource $image  The name of the image file relative to the parts directory, or an existing image resource.
 	 * @param  int             $width  Image width in pixels.
 	 * @param  int             $height Image height in pixels.
+	 *
+	 * @return bool
 	 */
 	protected function apply_image( $base, $image, $width, $height ) {
 
@@ -87,14 +91,17 @@ abstract class PNG_Generator implements Generator {
 
 		// Abort if $image is not a valid resource.
 		if ( ! \is_resource( $image ) ) {
-			return; // Abort.
+			return false; // Abort.
 		}
 
 		// Copy the image to the base.
-		\imagecopy( $base, $image, 0, 0, 0, 0, $width, $height );
+		$result = \imagecopy( $base, $image, 0, 0, 0, 0, $width, $height );
 
 		// Clean up.
 		\imagedestroy( $image );
+
+		// Return copy success status.
+		return $result;
 	}
 
 	/**

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-retro.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-retro.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -49,9 +49,13 @@ class Retro implements Generator {
 
 	/**
 	 * Creates a new instance.
+	 *
+	 * @since 2.1.0 Parameter $identicon added.
+	 *
+	 * @param \Identicon\Identicon $identicon The identicon implementation.
 	 */
-	public function __construct() {
-		$this->identicon = new \Identicon\Identicon( new \Identicon\Generator\SvgGenerator() );
+	public function __construct( \Identicon\Identicon $identicon ) {
+		$this->identicon = $identicon;
 	}
 
 	/**

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-rings.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-rings.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -37,17 +37,34 @@ use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generator;
 class Rings implements Generator {
 
 	/**
+	 * The "real" icon generator.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var Ring_Icon
+	 */
+	private $ring_icon;
+
+	/**
+	 * Creates a new instance.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Ring_Icon $ring_icon The configured Ring_Icon instance.
+	 */
+	public function __construct( Ring_Icon $ring_icon ) {
+		$this->ring_icon = $ring_icon;
+	}
+
+	/**
 	 * Builds an icon based on the given seed returns the image data.
 	 *
 	 * @param  string $seed The seed data (hash).
-	 * @param  int    $size The size in pixels.
+	 * @param  int    $size The size in pixels (ignored for SVG images).
 	 *
 	 * @return string|false
 	 */
-	public function build( $seed, $size ) {
-		$ring_icon = new Ring_Icon( $size, 3 );
-		$ring_icon->setMono( true );
-
-		return $ring_icon->get_svg_image_data( $seed );
+	public function build( $seed, /* @scrutinizer-ignore */ $size ) {
+		return $this->ring_icon->get_svg_image_data( $seed );
 	}
 }

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar.php
@@ -60,6 +60,8 @@ class Wavatar extends PNG_Generator {
 	/**
 	 * Extract a "random" value from the seed string.
 	 *
+	 * @since 2.1.0 Visibility changed to protected.
+	 *
 	 * @param  string $seed   The seed.
 	 * @param  int    $index  The index.
 	 * @param  int    $length The number of bytes.
@@ -67,7 +69,7 @@ class Wavatar extends PNG_Generator {
 	 *
 	 * @return int
 	 */
-	private function seed( $seed, $index, $length, $modulo ) {
+	protected function seed( $seed, $index, $length, $modulo ) {
 		return \hexdec( \substr( $seed, $index, $length ) ) % $modulo;
 	}
 

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar.php
@@ -98,7 +98,7 @@ class Wavatar extends PNG_Generator {
 
 		// Check for valid image resource.
 		if ( false === $avatar ) {
-			return '';
+			return ''; // @codeCoverageIgnore
 		}
 
 		// Pick a random color for the background.

--- a/includes/class-avatar-privacy-factory.php
+++ b/includes/class-avatar-privacy-factory.php
@@ -171,6 +171,16 @@ class Avatar_Privacy_Factory extends Dice {
 					[ 'style' => [ 'padding' => 0 ] ],
 				],
 			],
+			Default_Icons\Generators\Ring_Icon::class       => [
+				'shared'          => true, // Not really necessary, but ...
+				'constructParams' => [
+					512, // The bounding box dimensions.
+					3,   // The number of rings.
+				],
+				'call'            => [
+					[ 'setMono', [ true ] ], // The rings should be monochrome.
+				],
+			],
 
 			// Upload handlers.
 			Upload_Handler::class                           => self::SHARED,

--- a/includes/class-avatar-privacy-factory.php
+++ b/includes/class-avatar-privacy-factory.php
@@ -157,6 +157,19 @@ class Avatar_Privacy_Factory extends Dice {
 
 			// Default icon generators.
 			Default_Icons\Generator::class                  => self::SHARED,
+			Default_Icons\Generators\Jdenticon::class       => [
+				'substitutions' => [
+					\Jdenticon\Identicon::class => [ 'instance' => '$JdenticonIdenticon' ],
+				],
+			],
+
+			// Icon components.
+			'$JdenticonIdenticon'                           => [
+				'constructParams' => [
+					// Some extra styling for the Jdenticon instance.
+					[ 'style' => [ 'padding' => 0 ] ],
+				],
+			],
 
 			// Upload handlers.
 			Upload_Handler::class                           => self::SHARED,

--- a/includes/class-avatar-privacy-factory.php
+++ b/includes/class-avatar-privacy-factory.php
@@ -162,6 +162,11 @@ class Avatar_Privacy_Factory extends Dice {
 					\Jdenticon\Identicon::class => [ 'instance' => '$JdenticonIdenticon' ],
 				],
 			],
+			Default_Icons\Generators\Retro::class           => [
+				'substitutions' => [
+					\Identicon\Identicon::class => [ 'instance' => '$RetroIdenticon' ],
+				],
+			],
 
 			// Icon components.
 			'$JdenticonIdenticon'                           => [
@@ -169,6 +174,12 @@ class Avatar_Privacy_Factory extends Dice {
 				'constructParams' => [
 					// Some extra styling for the Jdenticon instance.
 					[ 'style' => [ 'padding' => 0 ] ],
+				],
+			],
+			'$RetroIdenticon'                               => [
+				'instanceOf'    => \Identicon\Identicon::class,
+				'substitutions' => [
+					\Identicon\Generator\GeneratorInterface::class => [ 'instance' => \Identicon\Generator\SvgGenerator::class ],
 				],
 			],
 			Default_Icons\Generators\Ring_Icon::class       => [

--- a/includes/class-avatar-privacy-factory.php
+++ b/includes/class-avatar-privacy-factory.php
@@ -165,6 +165,7 @@ class Avatar_Privacy_Factory extends Dice {
 
 			// Icon components.
 			'$JdenticonIdenticon'                           => [
+				'instanceOf'      => \Jdenticon\Identicon::class,
 				'constructParams' => [
 					// Some extra styling for the Jdenticon instance.
 					[ 'style' => [ 'padding' => 0 ] ],

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-jdenticon-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-jdenticon-test.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Jdenticon;
+
+/**
+ * Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Jdenticon unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Jdenticon
+ * @usesDefaultClass \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Jdenticon
+ *
+ * @uses ::__construct
+ */
+class Jdenticon_Test extends \Avatar_Privacy\Tests\TestCase {
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var Jdenticon
+	 */
+	private $sut;
+
+	/**
+	 * The identicon mock.
+	 *
+	 * @var \Jdenticon\Identicon
+	 */
+	private $identicon;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		// Helper mocks.
+		$this->identicon = m::mock( \Jdenticon\Identicon::class );
+
+		// Partially mock system under test.
+		$this->sut = m::mock( Jdenticon::class )->makePartial()->shouldAllowMockingProtectedMethods();
+
+		// Manually invoke the constructor as it is protected.
+		$this->invokeMethod( $this->sut, '__construct', [ $this->identicon ] );
+	}
+
+	/**
+	 * Tests ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$identicon = m::mock( \Jdenticon\Identicon::class );
+		$mock      = m::mock( Jdenticon::class )->makePartial()->shouldAllowMockingProtectedMethods();
+
+		$this->invokeMethod( $mock, '__construct', [ $identicon ] );
+
+		$this->assertAttributeSame( $identicon, 'identicon', $mock );
+	}
+
+	/**
+	 * Tests ::build.
+	 *
+	 * @covers ::build
+	 */
+	public function test_build() {
+		$seed = 'fake email hash';
+		$size = 42;
+		$data = 'fake SVG image';
+
+		$this->identicon->shouldReceive( 'setHash' )->once()->with( $seed );
+		$this->identicon->shouldReceive( 'setSize' )->once()->with( $size );
+		$this->identicon->shouldReceive( 'getImageData' )->once()->with( 'svg' )->andReturn( $data );
+
+		$this->assertSame( $data, $this->sut->build( $seed, $size ) );
+	}
+}

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
@@ -391,4 +391,53 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->assertFalse( $this->sut->build( $seed, $size ) );
 	}
+
+	/**
+	 * Tests ::image_colorize.
+	 *
+	 * @covers ::image_colorize
+	 *
+	 * @uses Scriptura\Color\Helpers\HSLtoRGB
+	 */
+	public function test_image_colorize() {
+		// Input.
+		$hue        = 66;
+		$saturation = 70;
+		$part       = 'arms_S8.png';
+
+		// The image.
+		$resource = \imagecreatefrompng( "{$this->real_image_path}/{$part}" );
+
+		$result = $this->sut->image_colorize( $resource, $hue, $saturation, $part );
+
+		$this->assertInternalType( 'resource', $result );
+
+		// Clean up.
+		\imagedestroy( $resource );
+	}
+
+	/**
+	 * Tests ::image_colorize.
+	 *
+	 * @covers ::image_colorize
+	 *
+	 * @uses Scriptura\Color\Helpers\HSLtoRGB
+	 */
+	public function test_image_colorize_no_optimization() {
+		// Input.
+		$hue        = 66;
+		$saturation = 70;
+		$part       = 'fake.png';
+
+		// The image.
+		$size     = 200;
+		$resource = \imagecreate( $size, $size );
+
+		$result = $this->sut->image_colorize( $resource, $hue, $saturation, $part );
+
+		$this->assertInternalType( 'resource', $result );
+
+		// Clean up.
+		\imagedestroy( $resource );
+	}
 }

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
@@ -1,0 +1,386 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+
+use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Monster_ID;
+
+use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\PNG_Generator;
+use Avatar_Privacy\Tools\Images\Editor;
+
+
+/**
+ * Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Monster_ID unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Monster_ID
+ * @usesDefaultClass \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Monster_ID
+ *
+ * @uses ::__construct
+ * @uses Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\PNG_Generator::__construct
+ */
+class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var Monster_ID
+	 */
+	private $sut;
+
+	/**
+	 * The Images\Editor mock.
+	 *
+	 * @var Editor
+	 */
+	private $editor;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$png_data = \base64_decode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions
+			'iVBORw0KGgoAAAANSUhEUgAAABwAAAASCAMAAAB/2U7WAAAABl' .
+			'BMVEUAAAD///+l2Z/dAAAASUlEQVR4XqWQUQoAIAxC2/0vXZDr' .
+			'EX4IJTRkb7lobNUStXsB0jIXIAMSsQnWlsV+wULF4Avk9fLq2r' .
+			'8a5HSE35Q3eO2XP1A1wQkZSgETvDtKdQAAAABJRU5ErkJggg=='
+		);
+
+		$filesystem = [
+			'plugin' => [
+				'public' => [
+					'images' => [
+						'monster-id'       => [
+							'back.png'    => $png_data,
+							'body_1.png'  => $png_data,
+							'body_2.png'  => $png_data,
+							'arms_S8.png' => $png_data,
+							'legs_1.png'  => $png_data,
+							'mouth_6.png' => $png_data,
+						],
+						'monster-id-empty' => [],
+					],
+				],
+			],
+		];
+
+		// Set up virtual filesystem.
+		$root = vfsStream::setup( 'root', null, $filesystem );
+
+		// Helper mocks.
+		$this->editor = m::mock( Editor::class );
+
+		// Partially mock system under test.
+		$this->sut = m::mock( Monster_ID::class )->makePartial()->shouldAllowMockingProtectedMethods();
+
+		// Manually invoke the constructor as it is protected.
+		$this->invokeMethod( $this->sut, '__construct', [ $this->editor ] );
+
+		// Override the parts directory.
+		$this->setValue( $this->sut, 'parts_dir', vfsStream::url( 'root/plugin/public/images/monster-id' ) );
+	}
+
+	/**
+	 * Tests ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$editor = m::mock( Editor::class );
+		$mock   = m::mock( Monster_ID::class )->makePartial()->shouldAllowMockingProtectedMethods();
+
+		$this->invokeMethod( $mock, '__construct', [ $editor ] );
+
+		// An attribute of the PNG_Generator superclass.
+		$this->assertAttributeSame( $editor, 'images', $mock );
+	}
+
+	/**
+	 * Tests ::locate_parts.
+	 *
+	 * @covers ::locate_parts
+	 */
+	public function test_locate_parts() {
+		// Input data.
+		$parts = [
+			'body'  => [],
+			'arms'  => [],
+			'legs'  => [],
+			'mouth' => [],
+		];
+
+		// Expected result.
+		$result = [
+			'body'  => [
+				'body_1.png',
+				'body_2.png',
+			],
+			'arms'  => [
+				'arms_S8.png',
+			],
+			'legs'  => [
+				'legs_1.png',
+			],
+			'mouth' => [
+				'mouth_6.png',
+			],
+		];
+
+		// Run test.
+		$this->assertSame( $result, $this->sut->locate_parts( $parts ) );
+	}
+
+	/**
+	 * Tests ::locate_parts.
+	 *
+	 * @covers ::locate_parts
+	 *
+	 * @expectedException RuntimeException
+	 * @expectedExceptionMessage Could not find parts images
+	 */
+	public function test_locate_parts_incorrect_parts_dir() {
+		// Input data.
+		$parts = [
+			'body'  => [],
+			'arms'  => [],
+			'legs'  => [],
+			'mouth' => [],
+		];
+
+		// Expected result.
+		$result = [];
+
+		// Override the parts directory.
+		$this->setValue( $this->sut, 'parts_dir', vfsStream::url( 'root/plugin/public/images/monster-id-empty' ) );
+
+		// Run test.
+		$this->assertSame( $result, $this->sut->locate_parts( $parts ) );
+	}
+
+	/**
+	 * Tests ::get_parts_dimensions.
+	 *
+	 * @covers ::get_parts_dimensions
+	 */
+	public function test_get_parts_dimensions() {
+		// Intermediate results.
+		$parts = [
+			'body'  => [
+				'body_1.png',
+				'body_2.png',
+			],
+			'arms'  => [
+				'arms_FOOBAR.png',  // Does not exist and will be ignored.
+				'arms_S8.png',
+			],
+		];
+
+		// Expected result.
+		$expected = [
+			'body_1.png'  => [
+				[ 22, 99 ],
+				[ 17, 90 ],
+			],
+			'body_2.png'  => [
+				[ 14, 104 ],
+				[ 16, 89 ],
+			],
+			'arms_S8.png' => [
+				[ 2, 119 ],
+				[ 18, 98 ],
+			],
+		];
+
+		// Override the parts directory.
+		$real_image_path = \dirname( \dirname( \dirname( \dirname( \dirname( __DIR__ ) ) ) ) ) . '/public/images/monster-id';
+		$this->setValue( $this->sut, 'parts_dir', $real_image_path );
+
+		$this->sut->shouldReceive( 'locate_parts' )->once()->with( Monster_ID::EMPTY_PARTS_LIST )->andReturn( $parts );
+
+		$result = $this->sut->get_parts_dimensions( false );
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Tests ::get_parts_dimensions.
+	 *
+	 * @covers ::get_parts_dimensions
+	 */
+	public function test_get_parts_dimensions_as_text() {
+		// Intermediate results.
+		$parts = [
+			'body'  => [
+				'body_1.png',
+				'body_2.png',
+			],
+			'arms'  => [
+				'arms_FOOBAR.png', // Does not exist and will be ignored.
+				'arms_S8.png',
+			],
+		];
+
+		// Expected result.
+		$expected = "'body_1.png' => [[22,99],[17,90]], 'body_2.png' => [[14,104],[16,89]], 'arms_S8.png' => [[2,119],[18,98]], ";
+
+		// Override the parts directory.
+		$real_image_path = \dirname( \dirname( \dirname( \dirname( \dirname( __DIR__ ) ) ) ) ) . '/public/images/monster-id';
+		$this->setValue( $this->sut, 'parts_dir', $real_image_path );
+
+		$this->sut->shouldReceive( 'locate_parts' )->once()->with( Monster_ID::EMPTY_PARTS_LIST )->andReturn( $parts );
+
+		$this->assertSame( $expected, $this->sut->get_parts_dimensions( true ) );
+	}
+
+	/**
+	 * Tests ::build.
+	 *
+	 * @covers ::build
+	 */
+	public function test_build() {
+		$seed = 'fake email hash';
+		$size = 42;
+		$data = 'fake SVG image';
+
+		// Intermediate results.
+		$parts        = [
+			'body'  => [
+				'body_1.png',
+				'body_2.png',
+			],
+			'arms'  => [
+				'arms_S8.png', // SAME_COLOR_PARTS.
+			],
+			'legs'  => [
+				'legs_1.png', // RANDOM_COLOR_PARTS.
+			],
+			'mouth' => [
+				'mouth_6.png', // SPECIFIC_COLOR_PARTS.
+			],
+		];
+		$parts_number = \count( $parts );
+
+		$this->sut->shouldReceive( 'locate_parts' )->once()->with( Monster_ID::EMPTY_PARTS_LIST )->andReturn( $parts );
+
+		// The method takes int arguments in theory, but might be floats.
+		$this->sut->shouldReceive( 'image_colorize' )->times( $parts_number )->with( m::type( 'resource' ), m::type( 'numeric' ), m::type( 'numeric' ), m::type( 'string' ) );
+		$this->sut->shouldReceive( 'apply_image' )->times( $parts_number )->with( m::type( 'resource' ), m::type( 'resource' ), Monster_ID::SIZE, Monster_ID::SIZE );
+
+		$this->sut->shouldReceive( 'get_resized_image_data' )->once()->with( m::type( 'resource' ), $size )->andReturn( $data );
+
+		$this->assertSame( $data, $this->sut->build( $seed, $size ) );
+	}
+
+	/**
+	 * Tests ::build.
+	 *
+	 * @covers ::build
+	 */
+	public function test_build_missing_background() {
+		$seed = 'fake email hash';
+		$size = 42;
+
+		// Intermediate results.
+		$parts        = [
+			'body'  => [
+				'body_1.png',
+				'body_2.png',
+			],
+			'arms'  => [
+				'arms_S8.png', // SAME_COLOR_PARTS.
+			],
+			'legs'  => [
+				'legs_1.png', // RANDOM_COLOR_PARTS.
+			],
+			'mouth' => [
+				'mouth_6.png', // SPECIFIC_COLOR_PARTS.
+			],
+		];
+		$parts_number = \count( $parts );
+
+		// Delete the background file.
+		\unlink( vfsStream::url( 'root/plugin/public/images/monster-id/back.png' ) );
+
+		$this->sut->shouldReceive( 'locate_parts' )->once()->with( Monster_ID::EMPTY_PARTS_LIST )->andReturn( $parts );
+
+		$this->sut->shouldReceive( 'image_colorize' )->never();
+		$this->sut->shouldReceive( 'apply_image' )->never();
+		$this->sut->shouldReceive( 'get_resized_image_data' )->never();
+
+		$this->assertFalse( $this->sut->build( $seed, $size ) );
+	}
+
+	/**
+	 * Tests ::build.
+	 *
+	 * @covers ::build
+	 */
+	public function test_build_missing_part() {
+		$seed = 'fake email hash';
+		$size = 42;
+
+		// Intermediate results.
+		$parts        = [
+			'body'  => [
+				'body_1.png',
+				'body_2.png',
+			],
+			'arms'  => [
+				'arms_S8.png', // SAME_COLOR_PARTS.
+			],
+			'legs'  => [
+				'legs_1.png', // RANDOM_COLOR_PARTS.
+			],
+			'mouth' => [
+				'mouth_6.png', // SPECIFIC_COLOR_PARTS.
+			],
+		];
+		$parts_number = \count( $parts );
+
+		// Delete body part.
+		\unlink( vfsStream::url( 'root/plugin/public/images/monster-id/mouth_6.png' ) );
+
+		$this->sut->shouldReceive( 'locate_parts' )->once()->with( Monster_ID::EMPTY_PARTS_LIST )->andReturn( $parts );
+
+		// The method takes int arguments in theory, but might be floats.
+		$this->sut->shouldReceive( 'image_colorize' )->times( $parts_number - 1 )->with( m::type( 'resource' ), m::type( 'numeric' ), m::type( 'numeric' ), m::type( 'string' ) );
+		$this->sut->shouldReceive( 'apply_image' )->times( $parts_number - 1 )->with( m::type( 'resource' ), m::type( 'resource' ), Monster_ID::SIZE, Monster_ID::SIZE );
+
+		$this->sut->shouldReceive( 'get_resized_image_data' )->never();
+
+		$this->assertFalse( $this->sut->build( $seed, $size ) );
+	}
+}

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
@@ -67,6 +67,13 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 	private $editor;
 
 	/**
+	 * The full path of the folder containing the real images.
+	 *
+	 * @var string
+	 */
+	private $real_image_path;
+
+	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
@@ -100,6 +107,9 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		// Set up virtual filesystem.
 		$root = vfsStream::setup( 'root', null, $filesystem );
+
+		// Provide access to the real images.
+		$this->real_image_path = \dirname( \dirname( \dirname( \dirname( \dirname( __DIR__ ) ) ) ) ) . '/public/images/monster-id';
 
 		// Helper mocks.
 		$this->editor = m::mock( Editor::class );
@@ -226,8 +236,7 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 		];
 
 		// Override the parts directory.
-		$real_image_path = \dirname( \dirname( \dirname( \dirname( \dirname( __DIR__ ) ) ) ) ) . '/public/images/monster-id';
-		$this->setValue( $this->sut, 'parts_dir', $real_image_path );
+		$this->setValue( $this->sut, 'parts_dir', $this->real_image_path );
 
 		$this->sut->shouldReceive( 'locate_parts' )->once()->with( Monster_ID::EMPTY_PARTS_LIST )->andReturn( $parts );
 
@@ -257,8 +266,7 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 		$expected = "'body_1.png' => [[22,99],[17,90]], 'body_2.png' => [[14,104],[16,89]], 'arms_S8.png' => [[2,119],[18,98]], ";
 
 		// Override the parts directory.
-		$real_image_path = \dirname( \dirname( \dirname( \dirname( \dirname( __DIR__ ) ) ) ) ) . '/public/images/monster-id';
-		$this->setValue( $this->sut, 'parts_dir', $real_image_path );
+		$this->setValue( $this->sut, 'parts_dir', $this->real_image_path );
 
 		$this->sut->shouldReceive( 'locate_parts' )->once()->with( Monster_ID::EMPTY_PARTS_LIST )->andReturn( $parts );
 

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-png-generator-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-png-generator-test.php
@@ -138,7 +138,7 @@ class PNG_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 		$orig_base_data = ob_get_clean();
 
 		// Run the test.
-		$this->sut->apply_image( $base, $image, $width, $height );
+		$this->assertTrue( $this->sut->apply_image( $base, $image, $width, $height ) );
 
 		// Get the new base image data.
 		\ob_start();
@@ -175,7 +175,7 @@ class PNG_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 		$orig_base_data = ob_get_clean();
 
 		// Run the test.
-		$this->sut->apply_image( $base, $image, $width, $height );
+		$this->assertFalse( $this->sut->apply_image( $base, $image, $width, $height ) );
 
 		// Get the new base image data.
 		\ob_start();

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-png-generator-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-png-generator-test.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+
+use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\PNG_Generator;
+
+use Avatar_Privacy\Tools\Images\Editor;
+
+
+/**
+ * Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\PNG_Generator unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\PNG_Generator
+ * @usesDefaultClass \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\PNG_Generator
+ *
+ * @uses ::__construct
+ */
+class PNG_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var PNG_Generator
+	 */
+	private $sut;
+
+	/**
+	 * The Images\Editor mock.
+	 *
+	 * @var Editor
+	 */
+	private $editor;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$png_data = \base64_decode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions
+			'iVBORw0KGgoAAAANSUhEUgAAABwAAAASCAMAAAB/2U7WAAAABl' .
+			'BMVEUAAAD///+l2Z/dAAAASUlEQVR4XqWQUQoAIAxC2/0vXZDr' .
+			'EX4IJTRkb7lobNUStXsB0jIXIAMSsQnWlsV+wULF4Avk9fLq2r' .
+			'8a5HSE35Q3eO2XP1A1wQkZSgETvDtKdQAAAABJRU5ErkJggg=='
+		);
+
+		$filesystem = [
+			'plugin' => [
+				'my_parts_dir' => [
+					'somefile.png' => $png_data,
+				],
+			],
+		];
+
+		// Set up virtual filesystem.
+		$root = vfsStream::setup( 'root', null, $filesystem );
+
+		// Helper mocks.
+		$this->editor = m::mock( Editor::class );
+
+		// Partially mock system under test.
+		$this->sut = m::mock( PNG_Generator::class, [ vfsStream::url( 'root/plugin/my_parts_dir' ), $this->editor ] )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * Tests ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$fake_path = 'some/fake/path';
+		$editor    = m::mock( Editor::class );
+		$mock      = m::mock( PNG_Generator::class )->makePartial()->shouldAllowMockingProtectedMethods();
+
+		$this->invokeMethod( $mock, '__construct', [ $fake_path, $editor ] );
+
+		// An attribute of the PNG_Generator superclass.
+		$this->assertAttributeSame( $fake_path, 'parts_dir', $mock );
+		$this->assertAttributeSame( $editor, 'images', $mock );
+	}
+
+	/**
+	 * Tests ::apply_image.
+	 *
+	 * @covers ::apply_image
+	 */
+	public function test_apply_image() {
+		// The base image.
+		$width  = 200;
+		$height = 100;
+		$base   = \imagecreatetruecolor( $width, $height );
+
+		// Make the base image white.
+		\imagefill( $base, 0, 0, \imagecolorallocate( $base, 255, 255, 255 ) );
+
+		// The second image.
+		$image = 'somefile.png';
+
+		// Store base image data for comparison.
+		\ob_start();
+		\imagepng( $base );
+		$orig_base_data = ob_get_clean();
+
+		// Run the test.
+		$this->sut->apply_image( $base, $image, $width, $height );
+
+		// Get the new base image data.
+		\ob_start();
+		\imagepng( $base );
+		$new_base_data = ob_get_clean();
+
+		// Check that they are different because of the applied image.
+		$this->assertNotSame( $orig_base_data, $new_base_data );
+
+		// Clean up.
+		\imagedestroy( $base );
+	}
+
+	/**
+	 * Tests ::apply_image.
+	 *
+	 * @covers ::apply_image
+	 */
+	public function test_apply_image_error() {
+		// The base image.
+		$width  = 200;
+		$height = 100;
+		$base   = \imagecreatetruecolor( $width, $height );
+
+		// Make the base image white.
+		\imagefill( $base, 0, 0, \imagecolorallocate( $base, 255, 255, 255 ) );
+
+		// The second image does not exist.
+		$image = 'fakename.png';
+
+		// Store base image data for comparison.
+		\ob_start();
+		\imagepng( $base );
+		$orig_base_data = ob_get_clean();
+
+		// Run the test.
+		$this->sut->apply_image( $base, $image, $width, $height );
+
+		// Get the new base image data.
+		\ob_start();
+		\imagepng( $base );
+		$new_base_data = ob_get_clean();
+
+		// Check that they are different because of the applied image.
+		$this->assertSame( $orig_base_data, $new_base_data );
+
+		// Clean up.
+		\imagedestroy( $base );
+	}
+
+	/**
+	 * Tests ::fill.
+	 *
+	 * @covers ::fill
+	 */
+	public function test_fill() {
+		// Input.
+		$hue        = 345;
+		$saturation = 99;
+		$lightness  = 10;
+		$x          = 23;
+		$y          = 42;
+
+		// The image.
+		$width    = 200;
+		$height   = 100;
+		$resource = \imagecreate( $width, $height );
+
+		$this->assertTrue( $this->sut->fill( $resource, $hue, $saturation, $lightness, $x, $y ) );
+
+		// Clean up.
+		\imagedestroy( $resource );
+	}
+
+
+	/**
+	 * Tests ::fill.
+	 *
+	 * @covers ::fill
+	 */
+	public function test_fill_error() {
+		// Input.
+		$hue        = 0;
+		$saturation = 99;
+		$lightness  = 10;
+		$x          = 23;
+		$y          = 42;
+
+		// The image.
+		$width    = 200;
+		$height   = 100;
+		$resource = \imagecreate( $width, $height );
+
+		// Eat up all color slots.
+		for ( $i = 0; $i < 256; ++$i ) {
+			\imagecolorallocate( $resource, 0, 0, 0 );
+		}
+
+		$this->assertFalse( $this->sut->fill( $resource, $hue, $saturation, $lightness, $x, $y ) );
+
+		// Clean up.
+		\imagedestroy( $resource );
+	}
+
+	/**
+	 * Tests ::get_resized_image_data.
+	 *
+	 * @covers ::get_resized_image_data
+	 */
+	public function test_get_resized_image_data() {
+		$fake_resource = 'should be a resource';
+		$size          = 42;
+		$result        = 'the image data';
+
+		$this->editor->shouldReceive( 'create_from_image_resource' )->once()->with( $fake_resource )->andReturn( m::mock( \WP_Image_Editor::class ) );
+		$this->editor->shouldReceive( 'get_resized_image_data' )->once()->with( m::type( \WP_Image_Editor::class ), $size, $size, 'image/png' )->andReturn( $result );
+
+		$this->assertSame( $result, $this->sut->get_resized_image_data( $fake_resource, $size ) );
+	}
+}

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-retro-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-retro-test.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Retro;
+
+/**
+ * Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Retro unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Retro
+ * @usesDefaultClass \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Retro
+ *
+ * @uses ::__construct
+ */
+class Retro_Test extends \Avatar_Privacy\Tests\TestCase {
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var Retro
+	 */
+	private $sut;
+
+	/**
+	 * The identicon mock.
+	 *
+	 * @var \Identicon\Identicon
+	 */
+	private $identicon;
+
+	/**
+	 * Alias mock of Colors\RandomColor.
+	 *
+	 * @var \Colors\RandomColor
+	 */
+	private $random_color;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		// Helper mocks.
+		$this->identicon    = m::mock( \Identicon\Identicon::class );
+		$this->random_color = m::mock( 'alias:' . \Colors\RandomColor::class );
+
+		// Partially mock system under test.
+		$this->sut = m::mock( Retro::class )->makePartial()->shouldAllowMockingProtectedMethods();
+
+		// Manually invoke the constructor as it is protected.
+		$this->invokeMethod( $this->sut, '__construct', [ $this->identicon ] );
+	}
+
+	/**
+	 * Tests ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$identicon = m::mock( \Identicon\Identicon::class );
+		$mock      = m::mock( Retro::class )->makePartial()->shouldAllowMockingProtectedMethods();
+
+		$this->invokeMethod( $mock, '__construct', [ $identicon ] );
+
+		$this->assertAttributeSame( $identicon, 'identicon', $mock );
+	}
+
+	/**
+	 * Tests ::build.
+	 *
+	 * @covers ::build
+	 */
+	public function test_build() {
+		$seed = 'fake email hash';
+		$size = 42;
+		$data = 'fake SVG image';
+
+		// Intermediate.
+		$bright_color = 'A bright color definition';
+		$light_color  = 'A light color definition';
+
+		$this->random_color->shouldReceive( 'one' )->once()->with( [ 'luminosity' => 'bright' ] )->andReturn( $bright_color );
+		$this->random_color->shouldReceive( 'one' )->once()->with( [ 'luminosity' => 'light' ] )->andReturn( $light_color );
+
+		$this->identicon->shouldReceive( 'getImageData' )->once()->with( $seed, $size, $bright_color, $light_color )->andReturn( $data );
+
+		$this->assertSame( $data, $this->sut->build( $seed, $size ) );
+	}
+}

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-ring-icon-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-ring-icon-test.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Ring_Icon;
+
+/**
+ * Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Ring_Icon unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Ring_Icon
+ * @usesDefaultClass \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Ring_Icon
+ */
+class Ring_Icon_Test extends \Avatar_Privacy\Tests\TestCase {
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var Ring_Icon
+	 */
+	private $sut;
+
+	/**
+	 * Tests ::get_svg_image_data.
+	 *
+	 * @covers ::get_svg_image_data
+	 */
+	public function test_get_svg_image_data() {
+		$sut = m::mock( Ring_Icon::class )->makePartial()->shouldAllowMockingProtectedMethods();
+
+		$icon = 'fake SVG icon data';
+		$seed = 'fake email hash';
+
+		$sut->shouldReceive( 'generateSVGImage' )->once()->with( $seed, true )->andReturn( $icon );
+
+		$this->assertSame( $icon, $sut->get_svg_image_data( $seed ) );
+	}
+}

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-rings-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-rings-test.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Rings;
+use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Ring_Icon;
+
+/**
+ * Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Rings unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Rings
+ * @usesDefaultClass \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Rings
+ *
+ * @uses ::__construct
+ */
+class Rings_Test extends \Avatar_Privacy\Tests\TestCase {
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var Rings
+	 */
+	private $sut;
+
+	/**
+	 * The identicon mock.
+	 *
+	 * @var Ring_Icon
+	 */
+	private $ring_icon;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		// Helper mocks.
+		$this->ring_icon = m::mock( Ring_Icon::class );
+
+		// Partially mock system under test.
+		$this->sut = m::mock( Rings::class, [ $this->ring_icon ] )->makePartial()->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * Tests ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$ring_icon = m::mock( Ring_Icon::class );
+		$mock      = m::mock( Rings::class )->makePartial()->shouldAllowMockingProtectedMethods();
+
+		$this->invokeMethod( $mock, '__construct', [ $ring_icon ] );
+
+		$this->assertAttributeSame( $ring_icon, 'ring_icon', $mock );
+	}
+
+	/**
+	 * Tests ::build.
+	 *
+	 * @covers ::build
+	 */
+	public function test_build() {
+		$seed = 'fake email hash';
+		$size = 42;
+		$data = 'fake SVG image';
+
+		$this->ring_icon->shouldReceive( 'get_svg_image_data' )->once()->with( $seed )->andReturn( $data );
+
+		$this->assertSame( $data, $this->sut->build( $seed, $size ) );
+	}
+}

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar-test.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+
+use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Wavatar;
+
+use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\PNG_Generator;
+use Avatar_Privacy\Tools\Images\Editor;
+
+
+/**
+ * Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Wavatar unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Wavatar
+ * @usesDefaultClass \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Wavatar
+ *
+ * @uses ::__construct
+ * @uses Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\PNG_Generator::__construct
+ */
+class Wavatar_Test extends \Avatar_Privacy\Tests\TestCase {
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var Wavatar
+	 */
+	private $sut;
+
+	/**
+	 * The Images\Editor mock.
+	 *
+	 * @var Editor
+	 */
+	private $editor;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$png_data = \base64_decode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions
+			'iVBORw0KGgoAAAANSUhEUgAAABwAAAASCAMAAAB/2U7WAAAABl' .
+			'BMVEUAAAD///+l2Z/dAAAASUlEQVR4XqWQUQoAIAxC2/0vXZDr' .
+			'EX4IJTRkb7lobNUStXsB0jIXIAMSsQnWlsV+wULF4Avk9fLq2r' .
+			'8a5HSE35Q3eO2XP1A1wQkZSgETvDtKdQAAAABJRU5ErkJggg=='
+		);
+
+		$filesystem = [
+			'plugin' => [
+				'public' => [
+					'images' => [
+						'monster-id'       => [
+							'back.png'    => $png_data,
+							'body_1.png'  => $png_data,
+							'body_2.png'  => $png_data,
+							'arms_S8.png' => $png_data,
+							'legs_1.png'  => $png_data,
+							'mouth_6.png' => $png_data,
+						],
+						'monster-id-empty' => [],
+					],
+				],
+			],
+		];
+
+		// Set up virtual filesystem.
+		$root = vfsStream::setup( 'root', null, $filesystem );
+
+		// Helper mocks.
+		$this->editor = m::mock( Editor::class );
+
+		// Partially mock system under test.
+		$this->sut = m::mock( Wavatar::class )->makePartial()->shouldAllowMockingProtectedMethods();
+
+		// Manually invoke the constructor as it is protected.
+		$this->invokeMethod( $this->sut, '__construct', [ $this->editor ] );
+
+		// Override the parts directory.
+		$this->setValue( $this->sut, 'parts_dir', vfsStream::url( 'root/plugin/public/images/monster-id' ) );
+	}
+
+	/**
+	 * Tests ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$editor = m::mock( Editor::class );
+		$mock   = m::mock( Wavatar::class )->makePartial()->shouldAllowMockingProtectedMethods();
+
+		$this->invokeMethod( $mock, '__construct', [ $editor ] );
+
+		// An attribute of the PNG_Generator superclass.
+		$this->assertAttributeSame( $editor, 'images', $mock );
+	}
+
+	/**
+	 * Provides data for testing ::seed.
+	 *
+	 * @return array
+	 */
+	public function provide_seed_data() {
+		return [
+			[ 'd41d8cd98f00b204e9800998ecf8427e', 1, 2, 11, 10 ],
+			[ 'd41d8cd98f00b204e9800998ecf8427e', 5, 2, 4, 1 ],
+			[ 'd41d8cd98f00b204e9800998ecf8427e', 9, 2, 8, 0 ],
+			[ 'd41d8cd98f00b204e9800998ecf8427e', 11, 2, 13, 11 ],
+			[ 'd41d8cd98f00b204e9800998ecf8427e', 13, 2, 11, 10 ],
+			[ 'd41d8cd98f00b204e9800998ecf8427e', 15, 2, 19, 2 ],
+			[ '00000000000000000000000000000000', 1, 2, 11, 0 ],
+			[ 'ffffffffffffffffffffffffffffffff', 1, 2, 11, 2 ],
+			[ 'ffffffffffffffffffffffffffffffff', 5, 2, 4, 3 ],
+			[ 'ffffffffffffffffffffffffffffffff', 9, 2, 8, 7 ],
+			[ 'ffffffffffffffffffffffffffffffff', 11, 2, 13, 8 ],
+			[ 'ffffffffffffffffffffffffffffffff', 13, 2, 11, 2 ],
+			[ 'ffffffffffffffffffffffffffffffff', 15, 2, 19, 8 ],
+		];
+	}
+
+	/**
+	 * Tests ::seed.
+	 *
+	 * @covers ::seed
+	 *
+	 * @dataProvider provide_seed_data
+	 *
+	 * @param  string $seed   The seed (hexadecimal hash).
+	 * @param  int    $index  The index to use.
+	 * @param  int    $length The number of bytes.
+	 * @param  int    $modulo The maximum value of the result.
+	 * @param  int    $result Expected result.
+	 */
+	public function test_seed( $seed, $index, $length, $modulo, $result ) {
+		$this->assertSame( $result, $this->sut->seed( $seed, $index, $length, $modulo, $result ) );
+	}
+
+	/**
+	 * Tests ::build.
+	 *
+	 * @covers ::build
+	 */
+	public function test_build() {
+		$seed = 'fake email hash';
+		$size = 42;
+		$data = 'fake SVG image';
+
+		// Intermediate results.
+		$face      = 0;
+		$bg_color  = 1;
+		$fade      = 2;
+		$wav_color = 3;
+		$brow      = 4;
+		$eyes      = 5;
+		$pupil     = 6;
+		$mouth     = 7;
+
+		$this->sut->shouldReceive( 'seed' )->once()->with( $seed, 1, 2, Wavatar::WAVATAR_FACES )->andReturn( $face );
+		$this->sut->shouldReceive( 'seed' )->once()->with( $seed, 3, 2, 240 )->andReturn( $bg_color );
+		$this->sut->shouldReceive( 'seed' )->once()->with( $seed, 5, 2, Wavatar::WAVATAR_BACKGROUNDS )->andReturn( $fade );
+		$this->sut->shouldReceive( 'seed' )->once()->with( $seed, 7, 2, 240 )->andReturn( $wav_color );
+		$this->sut->shouldReceive( 'seed' )->once()->with( $seed, 9, 2, Wavatar::WAVATAR_BROWS )->andReturn( $brow );
+		$this->sut->shouldReceive( 'seed' )->once()->with( $seed, 11, 2, Wavatar::WAVATAR_EYES )->andReturn( $eyes );
+		$this->sut->shouldReceive( 'seed' )->once()->with( $seed, 13, 2, Wavatar::WAVATAR_PUPILS )->andReturn( $pupil );
+		$this->sut->shouldReceive( 'seed' )->once()->with( $seed, 15, 2, Wavatar::WAVATAR_MOUTHS )->andReturn( $mouth );
+
+		$this->sut->shouldReceive( 'fill' )->once()->with( m::type( 'resource' ), m::type( 'numeric' ), 94, 20, 1, 1 );
+
+		$this->sut->shouldReceive( 'apply_image' )->once()->with( m::type( 'resource' ), 'fade' . ( $fade + 1 ) . '.png', Wavatar::SIZE, Wavatar::SIZE );
+		$this->sut->shouldReceive( 'apply_image' )->once()->with( m::type( 'resource' ), 'mask' . ( $face + 1 ) . '.png', Wavatar::SIZE, Wavatar::SIZE );
+
+		$this->sut->shouldReceive( 'fill' )->once()->with( m::type( 'resource' ), m::type( 'numeric' ), 94, 66, (int) ( Wavatar::SIZE / 2 ), (int) ( Wavatar::SIZE / 2 ) );
+
+		$this->sut->shouldReceive( 'apply_image' )->once()->with( m::type( 'resource' ), 'shine' . ( $face + 1 ) . '.png', Wavatar::SIZE, Wavatar::SIZE );
+		$this->sut->shouldReceive( 'apply_image' )->once()->with( m::type( 'resource' ), 'brow' . ( $brow + 1 ) . '.png', Wavatar::SIZE, Wavatar::SIZE );
+		$this->sut->shouldReceive( 'apply_image' )->once()->with( m::type( 'resource' ), 'eyes' . ( $eyes + 1 ) . '.png', Wavatar::SIZE, Wavatar::SIZE );
+		$this->sut->shouldReceive( 'apply_image' )->once()->with( m::type( 'resource' ), 'pupils' . ( $pupil + 1 ) . '.png', Wavatar::SIZE, Wavatar::SIZE );
+		$this->sut->shouldReceive( 'apply_image' )->once()->with( m::type( 'resource' ), 'mouth' . ( $mouth + 1 ) . '.png', Wavatar::SIZE, Wavatar::SIZE );
+
+		$this->sut->shouldReceive( 'get_resized_image_data' )->once()->with( m::type( 'resource' ), $size )->andReturn( $data );
+
+		$this->assertSame( $data, $this->sut->build( $seed, $size ) );
+	}
+}


### PR DESCRIPTION
- All `Generator` implementations use dependency injection.
- There are now unit tests as well.

Fixes #88.