### PR TITLE
Fix instantiation of Retro generator due to missing type hint

### DIFF
--- a/includes/class-avatar-privacy-factory.php
+++ b/includes/class-avatar-privacy-factory.php
@@ -177,9 +177,10 @@ class Avatar_Privacy_Factory extends Dice {
 				],
 			],
 			'$RetroIdenticon'                               => [
-				'instanceOf'    => \Identicon\Identicon::class,
-				'substitutions' => [
-					\Identicon\Generator\GeneratorInterface::class => [ 'instance' => \Identicon\Generator\SvgGenerator::class ],
+				'instanceOf'      => \Identicon\Identicon::class,
+				'constructParams' => [
+					// The constructor argument is not type-hinted.
+					[ 'instance' => \Identicon\Generator\SvgGenerator::class ],
 				],
 			],
 			Default_Icons\Generators\Ring_Icon::class       => [


### PR DESCRIPTION
The `\Identicon\Identicon` constructor is missing a type hint for `\Identicon\Generator\GeneratorInterface`.