### PR TITLE
Various minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.1.0 (2019-04-xx)
+*   _Feature_: Improved compatibility with multisite installations. Plugin data will
+    be properly deleted on uninstallation or when a site is removed. ("Large Networks"
+    will still have to take manual action to prevent timeouts.)
+*   _Feature_: Network settings for enabling/disabling global table use on multisite.
+    Existing global data will be migrated to the site-specific tables when global
+    table use is disabled (but not in the other direction).
+*   _Change_: `usermeta` keys are now prefixed (`avatar_privacy_use_gravatar`
+    instead of `use_gravatar`).
+*   _Change_: Generally improved code quality through unit tests.
+*   _Bugfix_: New multisite installations were incorrectly detected as "legacy",
+    making them use the global table (instead of per-site tables). Affected installations
+    can be switched via the new network settings page.
+
 ## 2.0.5 (2019-02-23)
 *   _Bugfix_: Fixed a previously undiscovered compatibility issue with recent versions of EWWW Image Optimizer.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.1.0 (2019-04-xx)
+## 2.1.0 (2019-04-14)
 *   _Feature_: Improved compatibility with multisite installations. Plugin data will
     be properly deleted on uninstallation or when a site is removed. ("Large Networks"
     will still have to take manual action to prevent timeouts.)

--- a/admin/partials/network/settings-page.php
+++ b/admin/partials/network/settings-page.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -27,7 +27,7 @@
 use Avatar_Privacy\Data_Storage\Network_Options;
 
 ?><div class='wrap'>
-	<h1><?php \esc_html_e( 'Avatar Privacy Settings', 'avatar-privacy' ); ?></h1>
+	<h1><?php \esc_html_e( 'Avatar Privacy Network Settings', 'avatar-privacy' ); ?></h1>
 
 	<form method="post" action="<?php echo \esc_url( 'edit.php?action=' . self::ACTION ); ?>">
 		<?php \settings_fields( self::OPTION_GROUP ); ?>

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -29,7 +29,7 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at
- * Version: 2.1.0-beta.1
+ * Version: 2.1.0
  * License: GNU General Public License v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: avatar-privacy

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -29,7 +29,7 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at
- * Version: 2.1.0-alpha.3
+ * Version: 2.1.0-beta.1
  * License: GNU General Public License v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: avatar-privacy

--- a/includes/avatar-privacy/components/class-network-settings-page.php
+++ b/includes/avatar-privacy/components/class-network-settings-page.php
@@ -190,7 +190,7 @@ class Network_Settings_Page implements \Avatar_Privacy\Component {
 	public function save_network_settings() {
 		// Check if the user has the correct permissions.
 		if ( ! \current_user_can( 'manage_network_options' ) ) {
-			\wp_die( \esc_html( \__( 'Sorry, you are not allowed to edit network options.', 'avatar-privacy' ) ), 403 );
+			\wp_die( \esc_html( \__( 'Sorry, you are not allowed to access this page.', 'avatar-privacy' ) ), 403 );
 		}
 
 		// Make sure we are posting from our options page.
@@ -218,7 +218,7 @@ class Network_Settings_Page implements \Avatar_Privacy\Component {
 
 		$settings_errors = \get_settings_errors();
 		if ( empty( $settings_errors ) ) {
-			\add_settings_error( self::OPTION_GROUP, 'settings_updated', \__( 'Settings updated.', 'avatar-privacy' ), 'updated' );
+			\add_settings_error( self::OPTION_GROUP, 'settings_updated', \__( 'Settings saved.', 'avatar-privacy' ), 'updated' );
 		}
 
 		// Save the settings errors until after the redirect.
@@ -327,7 +327,7 @@ class Network_Settings_Page implements \Avatar_Privacy\Component {
 			$this->network_options->set( Network_Options::START_GLOBAL_TABLE_MIGRATION, $queue );
 
 			// Notify admins.
-			$this->trigger_admin_notice( Network_Options::USE_GLOBAL_TABLE, 'settings_updated', \__( 'Settings updated. Consent data will be migrated to site-specific tables.', 'avatar-privacy' ), 'updated' );
+			$this->trigger_admin_notice( Network_Options::USE_GLOBAL_TABLE, 'settings_updated', \__( 'Settings saved. Consent data will be migrated to site-specific tables.', 'avatar-privacy' ), 'updated' );
 		} elseif ( ! empty( $value ) && empty( $old_value ) ) {
 			// Clean up any running migrations on the next page load.
 			$this->network_options->set( Network_Options::START_GLOBAL_TABLE_MIGRATION, [] );

--- a/includes/avatar-privacy/components/class-network-settings-page.php
+++ b/includes/avatar-privacy/components/class-network-settings-page.php
@@ -149,7 +149,7 @@ class Network_Settings_Page implements \Avatar_Privacy\Component {
 	 */
 	public function register_network_settings() {
 		// Create our options page.
-		$page = \add_submenu_page( 'settings.php', \__( 'My Network Options', 'avatar-privacy' ), \__( 'Avatar Privacy', 'avatar-privacy' ), 'manage_network_options', self::OPTION_GROUP, [ $this, 'print_settings_page' ] );
+		$page = \add_submenu_page( 'settings.php', \__( 'Avatar Privacy Network Settings', 'avatar-privacy' ), \__( 'Avatar Privacy', 'avatar-privacy' ), 'manage_network_options', self::OPTION_GROUP, [ $this, 'print_settings_page' ] );
 
 		// Add the section(s).
 		\add_settings_section( self::SECTION, '', [ $this, 'print_settings_section' ], self::OPTION_GROUP );

--- a/includes/avatar-privacy/components/class-privacy-tools.php
+++ b/includes/avatar-privacy/components/class-privacy-tools.php
@@ -95,11 +95,6 @@ class Privacy_Tools implements \Avatar_Privacy\Component {
 	 * @since 2.1.0 Visibility changed to protected.
 	 */
 	protected function add_privacy_notice_content() {
-		// Don't crash on older versions of WordPress.
-		if ( ! function_exists( 'wp_add_privacy_policy_content' ) ) {
-			return;
-		}
-
 		$suggested_text = '<strong class="privacy-policy-tutorial">' . __( 'Suggested text:' ) . ' </strong>'; // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- Missing text domain is intentional to use Core translation.
 
 		$content  = '<h3>' . __( 'Comments', 'avatar-privacy' ) . '</h3>';

--- a/includes/avatar-privacy/components/class-setup.php
+++ b/includes/avatar-privacy/components/class-setup.php
@@ -301,7 +301,7 @@ class Setup implements \Avatar_Privacy\Component {
 
 		if ( \count( $affected_users ) > 0 ) {
 			// Update the database table.
-			$rows = $wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->usermeta} SET meta_key = %s WHERE meta_key = %s", Core::GRAVATAR_USE_META_KEY, 'use_gravatar' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$rows = $wpdb->update( $wpdb->usermeta, [ 'meta_key' => Core::GRAVATAR_USE_META_KEY ], [ 'meta_key' => 'use_gravatar' ] ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 			// If there were any keys to update, we also have to clear the user_meta cache group.
 			if ( false !== $rows && $rows > 0 ) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,7 +6,7 @@
 	<!-- Set a description for this ruleset. -->
 	<description>A custom set of code standard rules to check for WordPress plugins.</description>
 
-	<config name="minimum_supported_wp_version" value="4.9"/>
+	<config name="minimum_supported_wp_version" value="5.1"/>
 	<config name="testVersion" value="5.6-"/>
 
 	<!-- Include the WordPress ruleset, with exclusions. -->

--- a/readme.txt
+++ b/readme.txt
@@ -4,9 +4,9 @@ Plugin Name: Avatar Privacy
 Plugin URI: https://code.mundschenk.at/avatar-privacy/
 Author URI: https://code.mundschenk.at/
 Tags: gravatar, avatar, privacy, caching, bbpress
-Requires at least: 4.9
+Requires at least: 5.1
 Requires PHP: 5.6
-Tested up to: 5.1
+Tested up to: 5.2
 Stable tag: 2.0.5
 License: GPLv2 or later
 

--- a/readme.txt
+++ b/readme.txt
@@ -134,6 +134,13 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 == Changelog ==
 
+= 2.1.0 (2019-04-xx) =
+* _Feature_: Improved compatibility with multisite installations. Plugin data will be properly deleted on uninstallation or when a site is removed. ("Large Networks" will still have to take manual action to prevent timeouts.)
+* _Feature_: Network settings for enabling/disabling global table use on multisite. Existing global data will be migrated to the site-specific tables when global table use is disabled (but not in the other direction).
+* _Change_: `usermeta` keys are now prefixed (`avatar_privacy_use_gravatar` instead of `use_gravatar`).
+* _Change_: Generally improved code quality through unit tests.
+* _Bugfix_: New multisite installations were incorrectly detected as "legacy", making them use the global table (instead of per-site tables). Affected installations can be switched via the new network settings page.
+
 = 2.0.5 (2019-02-23) =
 * _Bugfix_: Fixed a previously undiscovered compatibility issue with recent versions of EWWW Image Optimizer.
 

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: gravatar, avatar, privacy, caching, bbpress
 Requires at least: 5.1
 Requires PHP: 5.6
 Tested up to: 5.2
-Stable tag: 2.0.5
+Stable tag: 2.1.0
 License: GPLv2 or later
 
 Enhances the privacy of your users and visitors with gravatar opt-in and local avatars.
@@ -134,7 +134,7 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 == Changelog ==
 
-= 2.1.0 (2019-04-xx) =
+= 2.1.0 (2019-04-14) =
 * _Feature_: Improved compatibility with multisite installations. Plugin data will be properly deleted on uninstallation or when a site is removed. ("Large Networks" will still have to take manual action to prevent timeouts.)
 * _Feature_: Network settings for enabling/disabling global table use on multisite. Existing global data will be migrated to the site-specific tables when global table use is disabled (but not in the other direction).
 * _Change_: `usermeta` keys are now prefixed (`avatar_privacy_use_gravatar` instead of `use_gravatar`).

--- a/tests/avatar-privacy/components/class-privacy-tools-test.php
+++ b/tests/avatar-privacy/components/class-privacy-tools-test.php
@@ -130,16 +130,6 @@ class Privacy_Tools_Test extends \Avatar_Privacy\Tests\TestCase {
 	 *
 	 * @covers ::add_privacy_notice_content
 	 */
-	public function test_add_privacy_notice_content_old_wordpress() {
-		// No expectation so that the function does not exist.
-		$this->assertNull( $this->sut->add_privacy_notice_content() );
-	}
-
-	/**
-	 * Tests ::add_privacy_notice_content.
-	 *
-	 * @covers ::add_privacy_notice_content
-	 */
 	public function test_add_privacy_notice_content() {
 		Functions\expect( 'wp_add_privacy_policy_content' )->once();
 

--- a/tests/avatar-privacy/components/class-setup-test.php
+++ b/tests/avatar-privacy/components/class-setup-test.php
@@ -439,8 +439,7 @@ class Setup_Test extends \Avatar_Privacy\Tests\TestCase {
 		// Update meta keys.
 		$wpdb->shouldReceive( 'prepare' )->once()->with( "SELECT DISTINCT user_id FROM {$wpdb->usermeta} WHERE meta_key = %s", 'use_gravatar' )->andReturn( 'select_query' );
 		$wpdb->shouldReceive( 'get_col' )->once()->with( 'select_query' )->andReturn( $user_ids );
-		$wpdb->shouldReceive( 'prepare' )->once()->with( "UPDATE {$wpdb->usermeta} SET meta_key = %s WHERE meta_key = %s", Core::GRAVATAR_USE_META_KEY, 'use_gravatar' )->andReturn( 'update_query' );
-		$wpdb->shouldReceive( 'query' )->once()->with( 'update_query' )->andReturn( $rows );
+		$wpdb->shouldReceive( 'update' )->once()->with( $wpdb->usermeta, [ 'meta_key' => Core::GRAVATAR_USE_META_KEY ], [ 'meta_key' => 'use_gravatar' ] )->andReturn( $rows ); // phpcs:ignore WordPress.DB.SlowDBQuery
 
 		// Clear cache.
 		Functions\expect( 'wp_cache_delete' )->times( $rows )->with( m::type( 'int' ), 'user_meta' );


### PR DESCRIPTION
- Use `wpdb::update` instead of custom query for prefixing the `usermeta` keys.
- Mirror WordPress Core error messages and admin notices more closely.
- Use consistent page titles for the plugin's network settings.
- Update the CHANGELOG.
- Set version to 2.1.0.