### PR TITLE
Peaceful co-existence with WP User Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.0 (unreleased)
+*   _Feature_: Integration for the following plugins had been added:
+    -   WP User Manager
+
 ## 2.1.0 (2019-04-14)
 *   _Feature_: Improved compatibility with multisite installations. Plugin data will
     be properly deleted on uninstallation or when a site is removed. ("Large Networks"

--- a/admin/partials/profile/user-avatar-upload.php
+++ b/admin/partials/profile/user-avatar-upload.php
@@ -24,9 +24,10 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
+use Avatar_Privacy\Core;
 use Avatar_Privacy\Tools\Template;
 
-$current_avatar                = \get_user_meta( $user->ID, self::USER_META_KEY, true );
+$current_avatar                = \get_user_meta( $user->ID, Core::USER_AVATAR_META_KEY, true );
 $current_user_can_upload_files = \current_user_can( 'upload_files' );
 
 if ( $current_user_can_upload_files ) {

--- a/includes/avatar-privacy/avatar-handlers/class-user-avatar-handler.php
+++ b/includes/avatar-privacy/avatar-handlers/class-user-avatar-handler.php
@@ -162,7 +162,7 @@ class User_Avatar_Handler implements Avatar_Handler {
 	public function cache_image( $type, $hash, $size, $subdir, $extension ) {
 		$user = $this->core->get_user_by_hash( $hash );
 		if ( ! empty( $user ) ) {
-			$local_avatar = \get_user_meta( $user->ID, User_Avatar_Upload_Handler::USER_META_KEY, true );
+			$local_avatar = $this->core->get_user_avatar( $user->ID );
 		}
 
 		// Could not find user or uploaded avatar.

--- a/includes/avatar-privacy/avatar-handlers/class-user-avatar-handler.php
+++ b/includes/avatar-privacy/avatar-handlers/class-user-avatar-handler.php
@@ -30,8 +30,6 @@ use Avatar_Privacy\Core;
 
 use Avatar_Privacy\Tools\Images;
 
-use Avatar_Privacy\Upload_Handlers\User_Avatar_Upload_Handler;
-
 use Avatar_Privacy\Data_Storage\Filesystem_Cache;
 
 /**

--- a/includes/avatar-privacy/class-core.php
+++ b/includes/avatar-privacy/class-core.php
@@ -70,6 +70,14 @@ class Core {
 	const ALLOW_ANONYMOUS_META_KEY = 'avatar_privacy_allow_anonymous';
 
 	/**
+	 * The user meta key for the local avatar.
+	 *
+	 * @var string
+	 */
+	const USER_AVATAR_META_KEY = 'avatar_privacy_user_avatar';
+
+
+	/**
 	 * Prefix for caching avatar privacy for non-logged-in users.
 	 */
 	const EMAIL_CACHE_PREFIX = 'email_';
@@ -646,6 +654,6 @@ class Core {
 			return $avatar;
 		}
 
-		return \get_user_meta( $user_id, User_Avatar_Upload_Handler::USER_META_KEY, true );
+		return \get_user_meta( $user_id, self::USER_AVATAR_META_KEY, true );
 	}
 }

--- a/includes/avatar-privacy/class-core.php
+++ b/includes/avatar-privacy/class-core.php
@@ -49,21 +49,21 @@ class Core {
 	const SETTINGS_NAME = 'settings';
 
 	/**
-	 * The meta key for the hashed email.
+	 * The user meta key for the hashed email.
 	 *
 	 * @var string
 	 */
 	const EMAIL_HASH_META_KEY = 'avatar_privacy_hash';
 
 	/**
-	 * The meta key for the gravatar use flag.
+	 * The user meta key for the gravatar use flag.
 	 *
 	 * @var string
 	 */
 	const GRAVATAR_USE_META_KEY = 'avatar_privacy_use_gravatar';
 
 	/**
-	 * The meta key for the gravatar use flag.
+	 * The user meta key for the gravatar use flag.
 	 *
 	 * @var string
 	 */

--- a/includes/avatar-privacy/class-core.php
+++ b/includes/avatar-privacy/class-core.php
@@ -613,4 +613,39 @@ class Core {
 
 		return $users[0];
 	}
+
+	/**
+	 * Retrieves the full-size local avatar for a user (if one exists).
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param  int $user_id The user ID.
+	 *
+	 * @return string[] {
+	 *     @type string $file The local filename.
+	 *     @type string $type The MIME type.
+	 * }
+	 */
+	public function get_user_avatar( $user_id ) {
+		/**
+		 * Filters whether to retrieve the user avatar early. If the filtered result
+		 * contains both a filename and a MIME type, those will be returned immediately.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param array|null {
+		 *     Optional. The user avatar information. Default null.
+		 *
+		 *     @type string $file The local filename.
+		 *     @type string $type The MIME type.
+		 * }
+		 * @param int $user_id The user ID.
+		 */
+		$avatar = \apply_filters( 'avatar_privacy_pre_get_user_avatar', null, $user_id );
+		if ( ! empty( $avatar ) && ! empty( $avatar['file'] ) && ! empty( $avatar['type'] ) ) {
+			return $avatar;
+		}
+
+		return \get_user_meta( $user_id, User_Avatar_Upload_Handler::USER_META_KEY, true );
+	}
 }

--- a/includes/avatar-privacy/components/class-avatar-handling.php
+++ b/includes/avatar-privacy/components/class-avatar-handling.php
@@ -35,8 +35,6 @@ use Avatar_Privacy\Data_Storage\Options;
 use Avatar_Privacy\Tools\Images;
 use Avatar_Privacy\Tools\Network\Gravatar_Service;
 
-use Avatar_Privacy\Upload_Handlers\User_Avatar_Upload_Handler;
-
 /**
  * Handles the display of avatars in WordPress.
  *

--- a/includes/avatar-privacy/components/class-avatar-handling.php
+++ b/includes/avatar-privacy/components/class-avatar-handling.php
@@ -365,7 +365,7 @@ class Avatar_Handling implements \Avatar_Privacy\Component {
 
 		// Fetch local avatar from meta and make sure it's properly stzed.
 		$url          = '';
-		$local_avatar = \get_user_meta( $user_id, User_Avatar_Upload_Handler::USER_META_KEY, true );
+		$local_avatar = $this->core->get_user_avatar( $user_id );
 		if ( ! empty( $local_avatar['file'] ) && ! empty( $local_avatar['type'] ) ) {
 			// Prepare filter arguments.
 			$args = [

--- a/includes/avatar-privacy/components/class-privacy-tools.php
+++ b/includes/avatar-privacy/components/class-privacy-tools.php
@@ -27,7 +27,6 @@
 namespace Avatar_Privacy\Components;
 
 use Avatar_Privacy\Core;
-use Avatar_Privacy\Upload_Handlers\User_Avatar_Upload_Handler;
 
 use Avatar_Privacy\Data_Storage\Cache;
 use Avatar_Privacy\Data_Storage\Options;
@@ -186,7 +185,7 @@ class Privacy_Tools implements \Avatar_Privacy\Component {
 
 		// Export the uploaded avatar.
 		// We don't want to use the filtered value here.
-		$local_avatar = \get_user_meta( $user->ID, User_Avatar_Upload_Handler::USER_META_KEY, true );
+		$local_avatar = \get_user_meta( $user->ID, Core::USER_AVATAR_META_KEY, true );
 		if ( ! empty( $local_avatar['file'] ) ) {
 			$user_data[] = [
 				'name'  => __( 'User Profile Picture', 'avatar-privacy' ),
@@ -303,7 +302,7 @@ class Privacy_Tools implements \Avatar_Privacy\Component {
 			$items_removed += (int) \delete_user_meta( $user->ID, Core::EMAIL_HASH_META_KEY );
 			$items_removed += (int) \delete_user_meta( $user->ID, Core::GRAVATAR_USE_META_KEY );
 			$items_removed += (int) \delete_user_meta( $user->ID, Core::ALLOW_ANONYMOUS_META_KEY );
-			$items_removed += (int) \delete_user_meta( $user->ID, User_Avatar_Upload_Handler::USER_META_KEY );
+			$items_removed += (int) \delete_user_meta( $user->ID, Core::USER_AVATAR_META_KEY );
 		}
 
 		// Remove comment author data.

--- a/includes/avatar-privacy/components/class-privacy-tools.php
+++ b/includes/avatar-privacy/components/class-privacy-tools.php
@@ -185,6 +185,7 @@ class Privacy_Tools implements \Avatar_Privacy\Component {
 		];
 
 		// Export the uploaded avatar.
+		// We don't want to use the filtered value here.
 		$local_avatar = \get_user_meta( $user->ID, User_Avatar_Upload_Handler::USER_META_KEY, true );
 		if ( ! empty( $local_avatar['file'] ) ) {
 			$user_data[] = [

--- a/includes/avatar-privacy/components/class-uninstallation.php
+++ b/includes/avatar-privacy/components/class-uninstallation.php
@@ -27,7 +27,6 @@
 namespace Avatar_Privacy\Components;
 
 use Avatar_Privacy\Core;
-use Avatar_Privacy\Upload_Handlers\User_Avatar_Upload_Handler;
 
 use Avatar_Privacy\Data_Storage\Database;
 use Avatar_Privacy\Data_Storage\Filesystem_Cache;
@@ -180,7 +179,7 @@ class Uninstallation implements \Avatar_Privacy\Component {
 	 * @since 2.1.0 Visibility changed to public, made non-static.
 	 */
 	public function delete_uploaded_avatars() {
-		$user_avatar = User_Avatar_Upload_Handler::USER_META_KEY;
+		$user_avatar = Core::USER_AVATAR_META_KEY;
 		$query       = [
 			'meta_key'     => $user_avatar, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 			'meta_compare' => 'EXISTS',
@@ -203,7 +202,7 @@ class Uninstallation implements \Avatar_Privacy\Component {
 	public function delete_user_meta() {
 		\delete_metadata( 'user', 0, Core::GRAVATAR_USE_META_KEY, null, true );
 		\delete_metadata( 'user', 0, Core::ALLOW_ANONYMOUS_META_KEY, null, true );
-		\delete_metadata( 'user', 0, User_Avatar_Upload_Handler::USER_META_KEY, null, true );
+		\delete_metadata( 'user', 0, Core::USER_AVATAR_META_KEY, null, true );
 	}
 
 	/**

--- a/includes/avatar-privacy/integrations/class-wp-user-manager-integration.php
+++ b/includes/avatar-privacy/integrations/class-wp-user-manager-integration.php
@@ -119,7 +119,7 @@ class WP_User_Manager_Integration implements Plugin_Integration {
 	 * }
 	 */
 	public function enable_wpusermanager_user_avatars( array $avatar = null, $user_id ) {
-		$file = \carbon_get_user_meta( $user_id, self::WP_USER_MANAGER_META_KEY );
+		$file = /* @scrutinizer ignore-call */ \carbon_get_user_meta( $user_id, self::WP_USER_MANAGER_META_KEY );
 		$type = \wp_check_filetype( $file )['type'];
 
 		return [

--- a/includes/avatar-privacy/integrations/class-wp-user-manager-integration.php
+++ b/includes/avatar-privacy/integrations/class-wp-user-manager-integration.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Integrations;
+
+use Avatar_Privacy\Core;
+use Avatar_Privacy\Components\User_Profile;
+use Avatar_Privacy\Upload_Handlers\User_Avatar_Upload_Handler;
+
+use Carbon_Fields\Field\Field;
+
+/**
+ * An integration for WP User Manager.
+ *
+ * @since      2.2.0
+ * @author     Peter Putzer <github@mundschenk.at>
+ */
+class WP_User_Manager_Integration implements Plugin_Integration {
+
+	const WP_USER_MANAGER_META_KEY = 'current_user_avatar';
+
+	/**
+	 * The user profile component.
+	 *
+	 * @var User_Profile
+	 */
+	private $profile;
+
+	/**
+	 * The avatar upload handler.
+	 *
+	 * @var User_Avatar_Upload_Handler
+	 */
+	private $upload;
+
+	/**
+	 * A flag indicating that the user avatar cache should be invalidated soon.
+	 *
+	 * @var bool
+	 */
+	private $flush_cache = false;
+
+	/**
+	 * Indiciates whether the settings page is buffering its output.
+	 *
+	 * @var bool
+	 */
+	private $buffering;
+
+	/**
+	 * Creates a new instance.
+	 *
+	 * @param User_Profile               $profile The user profile component.
+	 * @param User_Avatar_Upload_Handler $upload  The avatar upload handler.
+	 */
+	public function __construct( User_Profile $profile, User_Avatar_Upload_Handler $upload ) {
+		$this->profile = $profile;
+		$this->upload  = $upload;
+	}
+
+	/**
+	 * Check if the WP_User_Manager integration should be activated.
+	 *
+	 * @return bool
+	 */
+	public function check() {
+		return \class_exists( \WP_User_Manager::class ) && \function_exists( 'wpum_get_option' ) && \wpum_get_option( 'custom_avatars' );
+	}
+
+	/**
+	 * Activate the integration.
+	 *
+	 * @param Core $core The plugin instance.
+	 */
+	public function run( Core $core ) {
+		if ( \is_admin() ) {
+			\add_action( 'admin_init', [ $this, 'remove_profile_picture_upload' ] );
+		}
+
+		\add_filter( 'avatar_privacy_pre_get_user_avatar',      [ $this, 'enable_wpusermanager_user_avatars' ], 10, 2 );
+		\add_filter( 'carbon_fields_should_save_field_value',   [ $this, 'maybe_mark_user_avater_for_cache_flushing' ], 9999, 3 );
+		\add_action( 'carbon_fields_user_meta_container_saved', [ $this, 'maybe_flush_cache_after_saving_user_avatar' ], 10, 1 );
+	}
+
+	/**
+	 * Retrieves the user avatar from WP User Manager.
+	 *
+	 * @param  array|null $avatar  Optional. The user avatar information. Default null.
+	 * @param  int        $user_id The user ID.
+	 *
+	 * @return array|null {
+	 *     Optional. The user avatar information. Default null.
+	 *
+	 *     @type string $file The local filename.
+	 *     @type string $type The MIME type.
+	 * }
+	 */
+	public function enable_wpusermanager_user_avatars( array $avatar = null, $user_id ) {
+		$file = \carbon_get_user_meta( $user_id, self::WP_USER_MANAGER_META_KEY );
+		$type = \wp_check_filetype( $file )['type'];
+
+		return [
+			'file' => $file,
+			'type' => $type,
+		];
+	}
+
+	/**
+	 * Enables output buffering.
+	 */
+	public function admin_head() {
+		if ( \ob_start( [ $this, 'remove_profile_picture_section' ] ) ) {
+			$this->buffering = true;
+		}
+	}
+
+	/**
+	 * Cleans up any output buffering.
+	 */
+	public function admin_footer() {
+		// Clean up output buffering.
+		if ( $this->buffering && \ob_get_level() > 0 ) {
+			\ob_end_flush();
+			$this->buffering = false;
+		}
+	}
+
+	/**
+	 * Remove the profile picture section from the user profile screen.
+	 *
+	 * @param  string $content The captured HTML output.
+	 *
+	 * @return string
+	 */
+	public function remove_profile_picture_section( $content ) {
+		return \preg_replace( '#(<tr class="user-profile-picture">.*<p class="description">).*(</p>.*</tr>)#Usi', '$1$2', $content );
+	}
+
+	/**
+	 * Removes the profile picture upload handling.
+	 */
+	public function remove_profile_picture_upload() {
+		// Unhook the default handlers.
+		\remove_action( 'admin_head-profile.php',     [ $this->profile, 'admin_head' ] );
+		\remove_action( 'admin_head-user-edit.php',   [ $this->profile, 'admin_head' ] );
+		\remove_action( 'admin_footer-profile.php',   [ $this->profile, 'admin_footer' ] );
+		\remove_action( 'admin_footer-user-edit.php', [ $this->profile, 'admin_footer' ] );
+
+		// Remove the profile picture setting completely.
+		\add_action( 'admin_head-profile.php',     [ $this, 'admin_head' ] );
+		\add_action( 'admin_head-user-edit.php',   [ $this, 'admin_head' ] );
+		\add_action( 'admin_footer-profile.php',   [ $this, 'admin_footer' ] );
+		\add_action( 'admin_footer-user-edit.php', [ $this, 'admin_footer' ] );
+	}
+
+	/**
+	 * Marks the user avatar cache for flushing if the corresponding WP_User_Manager
+	 * field is about to been changed.
+	 *
+	 * @param  bool  $save  Whether the field should be saved. Passed on as-is.
+	 * @param  mixed $value The field value. Ignored.
+	 * @param  Field $field A Carbon Fields object.
+	 *
+	 * @return bool
+	 */
+	public function maybe_mark_user_avater_for_cache_flushing( $save, $value, Field $field ) {
+		if ( $field->get_base_name() === self::WP_USER_MANAGER_META_KEY ) {
+			$this->flush_cache = true;
+		}
+
+		return $save;
+	}
+
+	/**
+	 * Flushes the user avatar cache if necessary.
+	 *
+	 * @param  int $user_id The user ID.
+	 */
+	public function maybe_flush_cache_after_saving_user_avatar( $user_id ) {
+		if ( ! empty( $this->flush_cache ) ) {
+			$this->upload->invalidate_user_avatar_cache( $user_id );
+		}
+	}
+}

--- a/includes/avatar-privacy/upload-handlers/class-user-avatar-upload-handler.php
+++ b/includes/avatar-privacy/upload-handlers/class-user-avatar-upload-handler.php
@@ -188,15 +188,26 @@ class User_Avatar_Upload_Handler extends Upload_Handler {
 	 */
 	public function delete_uploaded_avatar( $user_id ) {
 		// Invalidate cached avatar images.
-		$hash = $this->core->get_user_hash( $user_id );
-		if ( ! empty( $hash ) ) {
-			$this->file_cache->invalidate( 'user', "#/{$hash}-[1-9][0-9]*\.[a-z]{3}\$#" );
-		}
+		$this->invalidate_user_avatar_cache( $user_id );
 
 		// Delete original upload.
 		$avatar = \get_user_meta( $user_id, self::USER_META_KEY, true );
 		if ( ! empty( $avatar['file'] ) && \file_exists( $avatar['file'] ) && \unlink( $avatar['file'] ) ) {
 			\delete_user_meta( $user_id, self::USER_META_KEY );
+		}
+	}
+
+	/**
+	 * Invalidates cached avatar images.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param  int $user_id The user ID.
+	 */
+	public function invalidate_user_avatar_cache( $user_id ) {
+		$hash = $this->core->get_user_hash( $user_id );
+		if ( ! empty( $hash ) ) {
+			$this->file_cache->invalidate( 'user', "#/{$hash}-[1-9][0-9]*\.[a-z]{3}\$#" );
 		}
 	}
 }

--- a/includes/avatar-privacy/upload-handlers/class-user-avatar-upload-handler.php
+++ b/includes/avatar-privacy/upload-handlers/class-user-avatar-upload-handler.php
@@ -59,8 +59,6 @@ class User_Avatar_Upload_Handler extends Upload_Handler {
 
 	const UPLOAD_DIR = '/avatar-privacy/user-avatar';
 
-	const USER_META_KEY = 'avatar_privacy_user_avatar';
-
 	/**
 	 * The ID of the user whose profile is being edited.
 	 *
@@ -140,7 +138,7 @@ class User_Avatar_Upload_Handler extends Upload_Handler {
 		$this->delete_uploaded_avatar( $user_id );
 
 		// Save user information (overwriting previous).
-		\update_user_meta( $user_id, self::USER_META_KEY, $avatar );
+		\update_user_meta( $user_id, Core::USER_AVATAR_META_KEY, $avatar );
 	}
 
 	/**
@@ -191,9 +189,9 @@ class User_Avatar_Upload_Handler extends Upload_Handler {
 		$this->invalidate_user_avatar_cache( $user_id );
 
 		// Delete original upload.
-		$avatar = \get_user_meta( $user_id, self::USER_META_KEY, true );
+		$avatar = \get_user_meta( $user_id, Core::USER_AVATAR_META_KEY, true );
 		if ( ! empty( $avatar['file'] ) && \file_exists( $avatar['file'] ) && \unlink( $avatar['file'] ) ) {
-			\delete_user_meta( $user_id, self::USER_META_KEY );
+			\delete_user_meta( $user_id, Core::USER_AVATAR_META_KEY );
 		}
 	}
 

--- a/includes/class-avatar-privacy-factory.php
+++ b/includes/class-avatar-privacy-factory.php
@@ -58,8 +58,8 @@ use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators;
 use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generated_Icons;
 use Avatar_Privacy\Avatar_Handlers\Default_Icons\Static_Icons;
 
-use Avatar_Privacy\Integrations\Plugin_Integration;
 use Avatar_Privacy\Integrations\BBPress_Integration;
+use Avatar_Privacy\Integrations\WP_User_Manager_Integration;
 
 use Avatar_Privacy\Tools\Images;
 use Avatar_Privacy\Tools\Multisite as Multisite_Tools;
@@ -270,6 +270,7 @@ class Avatar_Privacy_Factory extends Dice {
 	protected function get_plugin_integrations() {
 		return [
 			[ 'instance' => BBPress_Integration::class ],
+			[ 'instance' => WP_User_Manager_Integration::class ],
 		];
 	}
 }

--- a/public/partials/bbpress/profile/user-avatar-upload.php
+++ b/public/partials/bbpress/profile/user-avatar-upload.php
@@ -27,7 +27,7 @@
 use Avatar_Privacy\Tools\Template;
 use Avatar_Privacy\Upload_Handlers\User_Avatar_Upload_Handler;
 
-$current_avatar                = \get_user_meta( $user_id, User_Avatar_Upload_Handler::USER_META_KEY, true );
+$current_avatar                = \get_user_meta( $user_id, Core::USER_AVATAR_META_KEY, true );
 $current_user_can_upload_files = \current_user_can( 'upload_files' );
 
 if ( $current_user_can_upload_files ) {

--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,7 @@ I used Avatar Privacy together with these plugins:
 
 * [AntiSpam Bee](https://wordpress.org/plugins/antispam-bee/)
 * [EWWW Image Optimizer](https://wordpress.org/plugins/ewww-image-optimizer/)
+* [WP User Manager – User Profile Builder & Membership](https://wordpress.org/plugins/wp-user-manager/)
 
 If you find any problems with particular plugins, please tell me!
 
@@ -133,6 +134,10 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 
 == Changelog ==
+
+= 2.2.0 (unreleased) =
+* _Feature_: Integration for the following plugins had been added:
+  - WP User Manager
 
 = 2.1.0 (2019-04-14) =
 * _Feature_: Improved compatibility with multisite installations. Plugin data will be properly deleted on uninstallation or when a site is removed. ("Large Networks" will still have to take manual action to prevent timeouts.)

--- a/tests/avatar-privacy/avatar-handlers/class-user-avatar-handler-test.php
+++ b/tests/avatar-privacy/avatar-handlers/class-user-avatar-handler-test.php
@@ -269,8 +269,7 @@ class User_Avatar_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 		];
 
 		$this->core->shouldReceive( 'get_user_by_hash' )->once()->with( $hash )->andReturn( $user );
-
-		Functions\expect( 'get_user_meta' )->once()->with( $user->ID, User_Avatar_Upload_Handler::USER_META_KEY, true )->andReturn( $local_avatar );
+		$this->core->shouldReceive( 'get_user_avatar' )->once()->with( $user->ID )->andReturn( $local_avatar );
 
 		$this->sut->shouldReceive( 'get_url' )->once()->with( '', $hash, $size, $args )->andReturn( 'https://foobar.org/cached_avatar_url' );
 
@@ -294,8 +293,7 @@ class User_Avatar_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 		$user = null;
 
 		$this->core->shouldReceive( 'get_user_by_hash' )->once()->with( $hash )->andReturn( $user );
-
-		Functions\expect( 'get_user_meta' )->never();
+		$this->core->shouldReceive( 'get_user_avatar' )->never();
 
 		$this->sut->shouldReceive( 'get_url' )->never();
 
@@ -320,8 +318,7 @@ class User_Avatar_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 		$user->ID = '666';
 
 		$this->core->shouldReceive( 'get_user_by_hash' )->once()->with( $hash )->andReturn( $user );
-
-		Functions\expect( 'get_user_meta' )->once()->with( $user->ID, User_Avatar_Upload_Handler::USER_META_KEY, true )->andReturn( false );
+		$this->core->shouldReceive( 'get_user_avatar' )->once()->with( $user->ID )->andReturn( false );
 
 		$this->sut->shouldReceive( 'get_url' )->never();
 

--- a/tests/avatar-privacy/class-core-test.php
+++ b/tests/avatar-privacy/class-core-test.php
@@ -1040,4 +1040,58 @@ class Core_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->assertNull( $this->sut->get_user_by_hash( $hash ) );
 	}
+
+	/**
+	 * Tests ::get_user_avatar.
+	 *
+	 * @covers ::get_user_avatar
+	 */
+	public function test_get_user_avatar() {
+		$user_id = 42;
+		$avatar  = [
+			'type' => 'image/png',
+			'file' => '/some/fake/file.png',
+		];
+
+		Filters\expectApplied( 'avatar_privacy_pre_get_user_avatar' )->once()->with( null, $user_id )->andReturn( null );
+		Functions\expect( 'get_user_meta' )->once()->with( $user_id, \Avatar_Privacy\Core::USER_AVATAR_META_KEY, true )->andReturn( $avatar );
+
+		$this->assertSame( $avatar, $this->sut->get_user_avatar( $user_id ) );
+	}
+
+	/**
+	 * Tests ::get_user_avatar.
+	 *
+	 * @covers ::get_user_avatar
+	 */
+	public function test_get_user_avatar_invalid_filter_result() {
+		$user_id = 42;
+		$avatar  = [
+			'type' => 'image/png',
+			'file' => '/some/fake/file.png',
+		];
+
+		Filters\expectApplied( 'avatar_privacy_pre_get_user_avatar' )->once()->with( null, $user_id )->andReturn( [ 'file' => '/some/other/file' ] );
+		Functions\expect( 'get_user_meta' )->once()->with( $user_id, \Avatar_Privacy\Core::USER_AVATAR_META_KEY, true )->andReturn( $avatar );
+
+		$this->assertSame( $avatar, $this->sut->get_user_avatar( $user_id ) );
+	}
+
+	/**
+	 * Tests ::get_user_avatar.
+	 *
+	 * @covers ::get_user_avatar
+	 */
+	public function test_get_user_avatar_invalid_filtered() {
+		$user_id = 42;
+		$avatar  = [
+			'type' => 'image/png',
+			'file' => '/some/fake/file.png',
+		];
+
+		Filters\expectApplied( 'avatar_privacy_pre_get_user_avatar' )->once()->with( null, $user_id )->andReturn( $avatar );
+		Functions\expect( 'get_user_meta' )->never();
+
+		$this->assertSame( $avatar, $this->sut->get_user_avatar( $user_id ) );
+	}
 }

--- a/tests/avatar-privacy/components/class-avatar-handling-test.php
+++ b/tests/avatar-privacy/components/class-avatar-handling-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -497,7 +497,7 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 			'type' => 'image/png',
 		];
 
-		Functions\expect( 'get_user_meta' )->once()->with( $user_id, \Avatar_Privacy\Upload_Handlers\User_Avatar_Upload_Handler::USER_META_KEY, true )->andReturn( $local );
+		$this->core->shouldReceive( 'get_user_avatar' )->once()->with( $user_id )->andReturn( $local );
 		Filters\expectApplied( 'avatar_privacy_user_avatar_icon_url' )->once()->with( '', $hash, $size, m::type( 'array' ) )->andReturn( $result );
 
 		$this->assertSame( $result, $this->sut->get_local_avatar_url( $user_id, $hash, $size ) );
@@ -513,7 +513,7 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 		$hash    = 'some hash';
 		$size    = 100;
 
-		Functions\expect( 'get_user_meta' )->once()->with( $user_id, \Avatar_Privacy\Upload_Handlers\User_Avatar_Upload_Handler::USER_META_KEY, true )->andReturn( [] );
+		$this->core->shouldReceive( 'get_user_avatar' )->once()->with( $user_id )->andReturn( [] );
 		Filters\expectApplied( 'avatar_privacy_user_avatar_icon_url' )->never();
 
 		$this->assertSame( '', $this->sut->get_local_avatar_url( $user_id, $hash, $size ) );
@@ -529,7 +529,7 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 		$hash    = 'some hash';
 		$size    = 100;
 
-		Functions\expect( 'get_user_meta' )->never();
+		$this->core->shouldReceive( 'get_user_avatar' )->never();
 		Filters\expectApplied( 'avatar_privacy_user_avatar_icon_url' )->never();
 
 		$this->assertSame( '', $this->sut->get_local_avatar_url( $user_id, $hash, $size ) );

--- a/tests/avatar-privacy/components/class-privacy-tools-test.php
+++ b/tests/avatar-privacy/components/class-privacy-tools-test.php
@@ -194,7 +194,7 @@ class Privacy_Tools_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->core->shouldReceive( 'get_user_hash' )->once()->with( $user->ID )->andReturn( $hash );
 		Functions\expect( 'get_user_meta' )->once()->with( $user->ID, Core::GRAVATAR_USE_META_KEY, true )->andReturn( $gravatar );
 		Functions\expect( 'get_user_meta' )->once()->with( $user->ID, Core::ALLOW_ANONYMOUS_META_KEY, true )->andReturn( $anon );
-		Functions\expect( 'get_user_meta' )->once()->with( $user->ID, User_Avatar_Upload_Handler::USER_META_KEY, true )->andReturn( $local );
+		Functions\expect( 'get_user_meta' )->once()->with( $user->ID, Core::USER_AVATAR_META_KEY, true )->andReturn( $local );
 		Functions\expect( 'site_url' )->once()->andReturn( $site_url );
 
 		$result = $this->sut->export_user_data( $email, $page );
@@ -296,7 +296,7 @@ class Privacy_Tools_Test extends \Avatar_Privacy\Tests\TestCase {
 		Functions\expect( 'delete_user_meta' )->once()->with( $user_id, Core::EMAIL_HASH_META_KEY )->andReturnTrue();
 		Functions\expect( 'delete_user_meta' )->once()->with( $user_id, Core::GRAVATAR_USE_META_KEY )->andReturnTrue();
 		Functions\expect( 'delete_user_meta' )->once()->with( $user_id, Core::ALLOW_ANONYMOUS_META_KEY )->andReturnTrue();
-		Functions\expect( 'delete_user_meta' )->once()->with( $user_id, User_Avatar_Upload_Handler::USER_META_KEY )->andReturnTrue();
+		Functions\expect( 'delete_user_meta' )->once()->with( $user_id, Core::USER_AVATAR_META_KEY )->andReturnTrue();
 
 		$this->core->shouldReceive( 'get_comment_author_key' )->once()->with( $email )->andReturn( $comment_author_id );
 		$this->sut->shouldReceive( 'delete_comment_author_data' )->once()->with( $comment_author_id, $email )->andReturn( 1 );

--- a/tests/avatar-privacy/components/class-uninstallation-test.php
+++ b/tests/avatar-privacy/components/class-uninstallation-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -194,7 +194,7 @@ class Uninstallation_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::delete_uploaded_avatars
 	 */
 	public function test_delete_uploaded_avatars() {
-		$user_avatar        = User_Avatar_Upload_Handler::USER_META_KEY;
+		$user_avatar        = Core::USER_AVATAR_META_KEY;
 		$query              = [
 			'meta_key'     => $user_avatar,  // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 			'meta_compare' => 'EXISTS',
@@ -256,7 +256,7 @@ class Uninstallation_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_delete_user_meta() {
 		Functions\expect( 'delete_metadata' )->once()->with( 'user', 0, Core::GRAVATAR_USE_META_KEY, null, true );
 		Functions\expect( 'delete_metadata' )->once()->with( 'user', 0, Core::ALLOW_ANONYMOUS_META_KEY, null, true );
-		Functions\expect( 'delete_metadata' )->once()->with( 'user', 0, User_Avatar_Upload_Handler::USER_META_KEY, null, true );
+		Functions\expect( 'delete_metadata' )->once()->with( 'user', 0, Core::USER_AVATAR_META_KEY, null, true );
 
 		$this->assertNull( $this->sut->delete_user_meta() );
 	}

--- a/tests/avatar-privacy/integrations/class-wp-user-manager-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-wp-user-manager-integration-test.php
@@ -1,0 +1,298 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2018 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\Integrations;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use org\bovigo\vfs\vfsStream;
+
+use Avatar_Privacy\Integrations\WP_User_Manager_Integration;
+
+use Avatar_Privacy\Core;
+
+use Avatar_Privacy\Components\User_Profile;
+use Avatar_Privacy\Upload_Handlers\User_Avatar_Upload_Handler;
+
+
+/**
+ * Avatar_Privacy\Integrations\WP_User_Manager_Integration unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy\Integrations\WP_User_Manager_Integration
+ * @usesDefaultClass \Avatar_Privacy\Integrations\WP_User_Manager_Integration
+ *
+ * @uses ::__construct
+ */
+class WP_User_Manager_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var WP_User_Manager_Integration
+	 */
+	private $sut;
+
+	/**
+	 * Mocked helper object.
+	 *
+	 * @var User_Profile
+	 */
+	private $profile;
+
+	/**
+	 * Mocked helper object.
+	 *
+	 * @var User_Avatar_Upload_Handler
+	 */
+	private $upload;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$this->profile = m::mock( User_Profile::class );
+		$this->upload  = m::mock( User_Avatar_Upload_Handler::class );
+
+		$this->sut = m::mock( WP_User_Manager_Integration::class, [ $this->profile, $this->upload ] )->makePartial()->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * Tests ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$mock = m::mock( WP_User_Manager_Integration::class )->makePartial();
+
+		$mock->__construct( $this->profile, $this->upload );
+
+		$this->assertAttributeSame( $this->profile, 'profile', $mock );
+		$this->assertAttributeSame( $this->upload, 'upload', $mock );
+	}
+
+	/**
+	 * Tests ::check.
+	 *
+	 * @covers ::check
+	 */
+	public function test_check() {
+		$this->assertFalse( $this->sut->check() );
+
+		$fake_plugin = m::mock( \WP_User_Manager::class );
+		Functions\when( 'wpum_get_option' )->justReturn( true );
+
+		$this->assertTrue( $this->sut->check() );
+	}
+
+	/**
+	 * Tests ::run.
+	 *
+	 * @covers ::run
+	 */
+	public function test_run() {
+		$core = m::mock( \Avatar_Privacy\Core::class );
+
+		Functions\expect( 'is_admin' )->once()->andReturn( false );
+
+		Actions\expectAdded( 'admin_init' )->never();
+
+		$this->assertNull( $this->sut->run( $core ) );
+	}
+
+	/**
+	 * Tests ::enable_wpusermanager_user_avatars.
+	 *
+	 * @covers ::enable_wpusermanager_user_avatars
+	 */
+	public function test_enable_wpusermanager_user_avatars() {
+		$user_id = 42;
+		$file    = '/some/file';
+		$type    = 'mime/type';
+		$result  = [
+			'file' => $file,
+			'type' => $type,
+		];
+
+		Functions\expect( 'carbon_get_user_meta' )->once()->with( $user_id, WP_User_Manager_Integration::WP_USER_MANAGER_META_KEY )->andReturn( $file );
+		Functions\expect( 'wp_check_filetype' )->once()->with( $file )->andReturn( [ 'type' => $type ] );
+
+		$this->assertSame( $result, $this->sut->enable_wpusermanager_user_avatars( null, $user_id ) );
+	}
+
+	/**
+	 * Tests ::run.
+	 *
+	 * @covers ::run
+	 */
+	public function test_run_admin() {
+		$core = m::mock( \Avatar_Privacy\Core::class );
+
+		Functions\expect( 'is_admin' )->once()->andReturn( true );
+
+		Actions\expectAdded( 'admin_init' )->once()->with( [ $this->sut, 'remove_profile_picture_upload' ] );
+
+		$this->assertNull( $this->sut->run( $core ) );
+	}
+
+	/**
+	 * Tests ::admin_head.
+	 *
+	 * @covers ::admin_head
+	 */
+	public function test_admin_head() {
+		$this->assertNull( $this->sut->admin_head() );
+		$this->assertAttributeSame( true, 'buffering', $this->sut );
+
+		$this->sut->shouldReceive( 'remove_profile_picture_section' )->once();
+
+		// Clean up.
+		\ob_end_flush();
+	}
+
+	/**
+	 * Tests ::admin_footer.
+	 *
+	 * @covers ::admin_footer
+	 */
+	public function test_admin_footer() {
+		// Fake settings_head.
+		\ob_start();
+		$this->setValue( $this->sut, 'buffering', true, WP_User_Manager_Integration::class );
+
+		$this->assertNull( $this->sut->admin_footer() );
+		$this->assertAttributeSame( false, 'buffering', $this->sut );
+	}
+
+
+	/**
+	 * Tests ::remove_profile_picture_section.
+	 *
+	 * @covers ::remove_profile_picture_section
+	 */
+	public function test_remove_profile_picture_section() {
+		// Content should be unchanged, as `markup` is empty.
+		$content = 'some content with <tr class="user-profile-picture">foobar</tr>';
+		$this->assertSame( $content, $this->sut->remove_profile_picture_section( $content ) );
+
+		// Content should be unchanged because the pattern does not match.
+		$content = 'some content with <tr class="foobar">foobar<p class="description">FOOBAR</p></tr>';
+		$this->assertSame( $content, $this->sut->remove_profile_picture_section( $content ) );
+
+		// Finally, the content should be modified.
+		$content = 'some content with <tr class="user-profile-picture">foobar<p class="description">FOOBAR</p></tr>';
+		$this->assertSame( 'some content with <tr class="user-profile-picture">foobar<p class="description"></p></tr>', $this->sut->remove_profile_picture_section( $content ) );
+	}
+
+	/**
+	 * Tests ::remove_profile_picture_upload.
+	 *
+	 * @covers ::remove_profile_picture_upload
+	 */
+	public function test_remove_profile_picture_upload() {
+		Functions\expect( 'remove_action' )->once()->with( 'admin_head-profile.php', [ $this->profile, 'admin_head' ] );
+		Functions\expect( 'remove_action' )->once()->with( 'admin_head-user-edit.php', [ $this->profile, 'admin_head' ] );
+		Functions\expect( 'remove_action' )->once()->with( 'admin_footer-profile.php', [ $this->profile, 'admin_footer' ] );
+		Functions\expect( 'remove_action' )->once()->with( 'admin_footer-user-edit.php', [ $this->profile, 'admin_footer' ] );
+
+		Actions\expectAdded( 'admin_head-profile.php' )->once()->with( [ $this->sut, 'admin_head' ] );
+		Actions\expectAdded( 'admin_head-user-edit.php' )->once()->with( [ $this->sut, 'admin_head' ] );
+		Actions\expectAdded( 'admin_footer-profile.php' )->once()->with( [ $this->sut, 'admin_footer' ] );
+		Actions\expectAdded( 'admin_footer-user-edit.php' )->once()->with( [ $this->sut, 'admin_footer' ] );
+
+		$this->assertNull( $this->sut->remove_profile_picture_upload() );
+	}
+
+	/**
+	 * Tests ::maybe_mark_user_avater_for_cache_flushing.
+	 *
+	 * @covers ::maybe_mark_user_avater_for_cache_flushing
+	 */
+	public function test_maybe_mark_user_avater_for_cache_flushing() {
+		$field = m::mock( \Carbon_Fields\Field\Field::class );
+		$save  = true;
+		$value = 'some value';
+
+		$field->shouldReceive( 'get_base_name' )->once()->andReturn( WP_User_Manager_Integration::WP_USER_MANAGER_META_KEY );
+
+		$this->assertSame( $save, $this->sut->maybe_mark_user_avater_for_cache_flushing( $save, $value, $field ) );
+
+		$this->assertAttributeSame( true, 'flush_cache', $this->sut );
+	}
+
+	/**
+	 * Tests ::maybe_mark_user_avater_for_cache_flushing.
+	 *
+	 * @covers ::maybe_mark_user_avater_for_cache_flushing
+	 */
+	public function test_maybe_mark_user_avater_for_cache_flushing_wrong_field() {
+		$field = m::mock( \Carbon_Fields\Field\Field::class );
+		$save  = true;
+		$value = 'some value';
+
+		$field->shouldReceive( 'get_base_name' )->once()->andReturn( 'some_other_field' );
+
+		$this->assertSame( $save, $this->sut->maybe_mark_user_avater_for_cache_flushing( $save, $value, $field ) );
+
+		$this->assertAttributeSame( false, 'flush_cache', $this->sut );
+	}
+
+	/**
+	 * Tests ::maybe_flush_cache_after_saving_user_avatar.
+	 *
+	 * @covers ::maybe_flush_cache_after_saving_user_avatar
+	 */
+	public function test_maybe_flush_cache_after_saving_user_avatar() {
+		$user_id = 42;
+
+		$this->setValue( $this->sut, 'flush_cache', true, WP_User_Manager_Integration::class );
+
+		$this->upload->shouldReceive( 'invalidate_user_avatar_cache' )->once()->with( $user_id );
+
+		$this->assertNull( $this->sut->maybe_flush_cache_after_saving_user_avatar( $user_id ) );
+	}
+
+	/**
+	 * Tests ::maybe_flush_cache_after_saving_user_avatar.
+	 *
+	 * @covers ::maybe_flush_cache_after_saving_user_avatar
+	 */
+	public function test_maybe_flush_cache_after_saving_user_avatar_do_not_flush() {
+		$user_id = 42;
+
+		$this->setValue( $this->sut, 'flush_cache', false, WP_User_Manager_Integration::class );
+
+		$this->upload->shouldReceive( 'invalidate_user_avatar_cache' )->never();
+
+		$this->assertNull( $this->sut->maybe_flush_cache_after_saving_user_avatar( $user_id ) );
+	}
+}

--- a/tests/avatar-privacy/upload-handlers/class-user-avatar-upload-handler-test.php
+++ b/tests/avatar-privacy/upload-handlers/class-user-avatar-upload-handler-test.php
@@ -475,12 +475,41 @@ class User_Avatar_Upload_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 		$hash   = 'some_hash';
 		$avatar = [ 'file' => vfsStream::url( $file ) ];
 
-		$this->core->shouldReceive( 'get_user_hash' )->once()->with( $user_id )->andReturn( $hash );
-		$this->file_cache->shouldReceive( 'invalidate' )->once()->with( 'user', "#/{$hash}-[1-9][0-9]*\.[a-z]{3}\$#" );
+		$this->sut->shouldReceive( 'invalidate_user_avatar_cache' )->once()->with( $user_id );
 
 		Functions\expect( 'get_user_meta' )->once()->with( $user_id, User_Avatar_Upload_Handler::USER_META_KEY, true )->andReturn( $avatar );
 		Functions\expect( 'delete_user_meta' )->times( (int) $result )->with( $user_id, User_Avatar_Upload_Handler::USER_META_KEY );
 
 		$this->assertNull( $this->sut->delete_uploaded_avatar( $user_id ) );
+	}
+
+	/**
+	 * Tests ::invalidate_user_avatar_cache.
+	 *
+	 * @covers ::invalidate_user_avatar_cache
+	 */
+	public function test_invalidate_user_avatar_cache() {
+		$user_id = '777';
+		$hash    = 'some_hash';
+
+		$this->core->shouldReceive( 'get_user_hash' )->once()->with( $user_id )->andReturn( $hash );
+		$this->file_cache->shouldReceive( 'invalidate' )->once()->with( 'user', "#/{$hash}-[1-9][0-9]*\.[a-z]{3}\$#" );
+
+		$this->assertNull( $this->sut->invalidate_user_avatar_cache( $user_id ) );
+	}
+
+	/**
+	 * Tests ::invalidate_user_avatar_cache.
+	 *
+	 * @covers ::invalidate_user_avatar_cache
+	 */
+	public function test_invalidate_user_avatar_cache_no_hash() {
+		$user_id = '777';
+		$hash    = '';
+
+		$this->core->shouldReceive( 'get_user_hash' )->once()->with( $user_id )->andReturn( $hash );
+		$this->file_cache->shouldReceive( 'invalidate' )->never();
+
+		$this->assertNull( $this->sut->invalidate_user_avatar_cache( $user_id ) );
 	}
 }

--- a/tests/avatar-privacy/upload-handlers/class-user-avatar-upload-handler-test.php
+++ b/tests/avatar-privacy/upload-handlers/class-user-avatar-upload-handler-test.php
@@ -197,7 +197,7 @@ class User_Avatar_Upload_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->sut->shouldReceive( 'delete_uploaded_avatar' )->once()->with( $user_id )->andReturn( true );
 		$this->sut->shouldReceive( 'handle_errors' )->never();
 
-		Functions\expect( 'update_user_meta' )->once()->with( $user_id, User_Avatar_Upload_Handler::USER_META_KEY, $avatar );
+		Functions\expect( 'update_user_meta' )->once()->with( $user_id, Core::USER_AVATAR_META_KEY, $avatar );
 
 		// Check results.
 		$this->assertNull( $this->sut->save_uploaded_user_avatar( $user_id ) );
@@ -477,8 +477,8 @@ class User_Avatar_Upload_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->sut->shouldReceive( 'invalidate_user_avatar_cache' )->once()->with( $user_id );
 
-		Functions\expect( 'get_user_meta' )->once()->with( $user_id, User_Avatar_Upload_Handler::USER_META_KEY, true )->andReturn( $avatar );
-		Functions\expect( 'delete_user_meta' )->times( (int) $result )->with( $user_id, User_Avatar_Upload_Handler::USER_META_KEY );
+		Functions\expect( 'get_user_meta' )->once()->with( $user_id, Core::USER_AVATAR_META_KEY, true )->andReturn( $avatar );
+		Functions\expect( 'delete_user_meta' )->times( (int) $result )->with( $user_id, Core::USER_AVATAR_META_KEY );
 
 		$this->assertNull( $this->sut->delete_uploaded_avatar( $user_id ) );
 	}


### PR DESCRIPTION
Integrates with `WP User Manager` and fixes #96:
* Moves user avatar loading to the Core API.
* Adds a filter hook `avatar_privacy_pre_get_user_avatar`. 