### PR TITLE
Add support for wpDiscuz commenting system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.2.0 (unreleased)
 *   _Feature_: Integration for the following plugins had been added:
-    -   WP User Manager
+    -   [wpDiscuz](https://wordpress.org/plugins/wpdiscuz/)
+    -   [WP User Manager](https://wordpress.org/plugins/wp-user-manager/)
 
 ## 2.1.0 (2019-04-14)
 *   _Feature_: Improved compatibility with multisite installations. Plugin data will

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -29,7 +29,7 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at
- * Version: 2.2.0-beta.1
+ * Version: 2.2.0-beta.2
  * License: GNU General Public License v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: avatar-privacy

--- a/includes/avatar-privacy/integrations/class-wpdiscuz-integration.php
+++ b/includes/avatar-privacy/integrations/class-wpdiscuz-integration.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Integrations;
+
+use Avatar_Privacy\Core;
+use Avatar_Privacy\Components\Comments;
+
+use wpdFormAttr\Form;
+use wpdFormAttr\Field;
+
+/**
+ * An integration for wpDiscuz.
+ *
+ * @since      2.2.0
+ * @author     Peter Putzer <github@mundschenk.at>
+ */
+class WPDiscuz_Integration implements Plugin_Integration {
+
+	/**
+	 * The core API.
+	 *
+	 * @var Core
+	 */
+	private $core;
+
+	/**
+	 * The comment handling component.
+	 *
+	 * @var Comments
+	 */
+	private $comments;
+
+	/**
+	 * The field name for the cookies consent checkbox.
+	 *
+	 * @var string
+	 */
+	private $cookie_consent_name;
+
+	/**
+	 * Creates a new instance.
+	 *
+	 * @param Core     $core     The core API.
+	 * @param Comments $comments The comment handler.
+	 */
+	public function __construct( Core $core, Comments $comments ) {
+		$this->core     = $core;
+		$this->comments = $comments;
+	}
+
+	/**
+	 * Check if the bbPress integration should be activated.
+	 *
+	 * @return bool
+	 */
+	public function check() {
+		return \function_exists( 'wpDiscuz' );
+	}
+
+	/**
+	 * Activate the integration.
+	 *
+	 * @param Core $core The plugin instance.
+	 */
+	public function run( Core $core ) {
+		\add_action( 'init', [ $this, 'init' ] );
+	}
+
+	/**
+	 * Init action handler.
+	 */
+	public function init() {
+		if ( ! \is_user_logged_in() ) {
+			if ( ! \is_admin() ) {
+				\add_action( 'wpdiscuz_submit_button_before', [ $this, 'print_gravatar_checkbox' ] );
+				\add_action( 'wp_enqueue_scripts',            [ $this, 'enqeue_styles_and_scripts' ] );
+			}
+
+			// Needed in AJAX calls.
+			\add_action( 'wpdiscuz_form_init',               [ $this, 'store_cookie_consent_checkbox' ] );
+			\add_action( 'wpdiscuz_before_save_commentmeta', [ $this, 'set_comment_cookies' ] );
+		}
+	}
+
+	/**
+	 * Prints the wpDiscuz "Use Gravatar" checkbox.
+	 */
+	public function print_gravatar_checkbox() {
+		// Include the partial.
+		require \dirname( AVATAR_PRIVACY_PLUGIN_FILE ) . '/public/partials/wpdiscuz/use-gravatar.php';
+	}
+
+
+	/**
+	 * Enqueue stylesheet comments form.
+	 */
+	public function enqeue_styles_and_scripts() {
+		// Set up resource file information.
+		$url    = \plugin_dir_url( AVATAR_PRIVACY_PLUGIN_FILE );
+		$suffix = SCRIPT_DEBUG ? '' : '.min';
+
+		// Set up the localized script data.
+		$data = [
+			'cookie'   => Comments::COOKIE_PREFIX . COOKIEHASH,
+			'checkbox' => Comments::CHECKBOX_FIELD_NAME,
+		];
+
+		\wp_enqueue_script( 'avatar-privacy-wpdiscuz-use-gravatar', "{$url}/public/js/wpdiscuz/use-gravatar{$suffix}.js", [ 'jquery' ], $this->core->get_version(), true );
+		\wp_localize_script( 'avatar-privacy-wpdiscuz-use-gravatar', 'avatarPrivacy', $data );
+	}
+
+	/**
+	 * Sets the "Use Gravatar" cookie.
+	 *
+	 * @param \WP_Comment $comment Comment object.
+	 */
+	public function set_comment_cookies( \WP_Comment $comment ) {
+		$user           = \wp_get_current_user();
+		$cookie_consent = $this->filter_input( INPUT_POST, $this->cookie_consent_name, FILTER_VALIDATE_BOOLEAN );
+
+		$this->comments->set_comment_cookies( $comment, $user, $cookie_consent );
+	}
+
+	/**
+	 * Stores the wpDiscuz form fields for later use.
+	 *
+	 * @param  Form $form The form object.
+	 */
+	public function store_cookie_consent_checkbox( Form $form ) {
+		$form->initFormFields();
+
+		foreach ( $form->getFormCustomFields() as $field_name => $field ) {
+			if ( Field\CookiesConsent::class === $field['type'] ) {
+				$this->cookie_consent_name = $field_name;
+			}
+		}
+	}
+
+	/**
+	 * Filters one of the input super globals to allow for unit testing.
+	 *
+	 * @param  int    $type          One of INPUT_GET, INPUT_POST, INPUT_COOKIE, INPUT_SERVER, or INPUT_ENV.
+	 * @param  string $variable_name Name of a variable to get.
+	 * @param  int    $filter        The ID of the filter to apply.
+	 *
+	 * @return mixed
+	 */
+	protected function filter_input( $type, $variable_name, $filter ) {
+		return \filter_input( $type, $variable_name, $filter ); // @codeCoverageIgnore
+	}
+}

--- a/includes/class-avatar-privacy-factory.php
+++ b/includes/class-avatar-privacy-factory.php
@@ -59,6 +59,7 @@ use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generated_Icons;
 use Avatar_Privacy\Avatar_Handlers\Default_Icons\Static_Icons;
 
 use Avatar_Privacy\Integrations\BBPress_Integration;
+use Avatar_Privacy\Integrations\WPDiscuz_Integration;
 use Avatar_Privacy\Integrations\WP_User_Manager_Integration;
 
 use Avatar_Privacy\Tools\Images;
@@ -270,6 +271,7 @@ class Avatar_Privacy_Factory extends Dice {
 	protected function get_plugin_integrations() {
 		return [
 			[ 'instance' => BBPress_Integration::class ],
+			[ 'instance' => WPDiscuz_Integration::class ],
 			[ 'instance' => WP_User_Manager_Integration::class ],
 		];
 	}

--- a/public/js/wpdiscuz/use-gravatar.js
+++ b/public/js/wpdiscuz/use-gravatar.js
@@ -1,0 +1,18 @@
+/**
+ * Resets the use_gravatar checkbox to the current value after posting a new comment.
+ */
+jQuery( function( $ ) {
+	'use strict';
+
+	var $useGravatarCheckbox = $( '#' + avatarPrivacy.checkbox );
+
+	var resetUseGravatar = function() {
+		var useGravatar = ( Cookies.get( avatarPrivacy.cookie ) != undefined && '' !== Cookies.get( avatarPrivacy.cookie ) ) ? 'checked' : '';
+
+		$useGravatarCheckbox.prop( 'checked', useGravatar );
+	};
+
+	$( document ).bind( 'ajaxComplete', function() {
+		resetUseGravatar();
+	} );
+} );

--- a/public/partials/wpdiscuz/use-gravatar.php
+++ b/public/partials/wpdiscuz/use-gravatar.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2018-2019 Peter Putzer.
+ * Copyright 2012-2013 Johannes Freudendahl.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Avatar_Privacy\Components\Comments;
+use Avatar_Privacy\Tools\Template;
+
+// Allowed HTML tags in the checkbox label.
+$allowed_html = [
+	'a' => [
+		'href'   => true,
+		'rel'    => true,
+		'target' => true,
+	],
+];
+
+// Determine if the checkbox should be checked.
+$cookie_name = Comments::COOKIE_PREFIX . COOKIEHASH;
+$is_checked  = false;
+if ( isset( $_POST[ Comments::CHECKBOX_FIELD_NAME ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- frontend form.
+	// Re-displaying the comment form with validation errors.
+	$is_checked = ! empty( $_POST[ Comments::CHECKBOX_FIELD_NAME ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- frontend form.
+} elseif ( isset( $_COOKIE[ $cookie_name ] ) ) {
+	// Read the value from the cookie, saved with previous comment.
+	$is_checked = \filter_input( INPUT_COOKIE, $cookie_name, FILTER_VALIDATE_BOOLEAN );
+}
+?>
+<!-- div class="comment-form-use-gravatar wpdiscuz-item wpd-field-group wpd-field-checkbox wpd-field-single wpd-has-desc" -->
+<div class="comment-form-use-gravatar wpdiscuz-item wpd-field-group wpd-field-checkbox wpd-field-single wpd-has-desc">
+	<div class="wpd-field-group-title">
+		<div class="wpd-item">
+			<input id="<?php echo \esc_attr( Comments::CHECKBOX_FIELD_NAME ); ?>" name="<?php echo \esc_attr( Comments::CHECKBOX_FIELD_NAME ); ?>" class="wpd-field" type="checkbox" value="true" <?php \checked( $is_checked, true ); ?> />
+			<label
+				class="wpd-field-label wpd-cursor-pointer"
+				for="<?php echo \esc_attr( Comments::CHECKBOX_FIELD_NAME ); ?>"
+			><?php echo \wp_kses( \sprintf( /* translators: 1: gravatar.com URL, 2: rel attribute, 3: target attribute */ \__( 'Display a <a href="%1$s" rel="%2$s" target="%3$s">Gravatar</a> image next to my comments.', 'avatar-privacy' ), __( 'https://en.gravatar.com/', 'avatar-privacy' ), Template::get_gravatar_link_rel(), Template::get_gravatar_link_target() ), $allowed_html ); ?></label>
+		</div>
+	</div>
+	<div class="wpd-field-desc">
+		<i class="far fa-question-circle" aria-hidden="true"></i><span><?php \esc_attr_e( 'If checked, an MD5 hash of your email address will be shared with Gravatar.com. However, that hash will not be made public.', 'avatar-privacy' ); ?></span>
+	</div>
+</div>
+<?php

--- a/readme.txt
+++ b/readme.txt
@@ -107,6 +107,7 @@ No, for registered users the user profile is checked, not the table for the comm
 I used Avatar Privacy together with these plugins:
 
 * [AntiSpam Bee](https://wordpress.org/plugins/antispam-bee/)
+* [Comments – wpDiscuz](https://wordpress.org/plugins/wpdiscuz/)
 * [EWWW Image Optimizer](https://wordpress.org/plugins/ewww-image-optimizer/)
 * [WP User Manager – User Profile Builder & Membership](https://wordpress.org/plugins/wp-user-manager/)
 
@@ -137,7 +138,8 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 = 2.2.0 (unreleased) =
 * _Feature_: Integration for the following plugins had been added:
-  - WP User Manager
+  - [wpDiscuz](https://wordpress.org/plugins/wpdiscuz/)
+  - [WP User Manager](https://wordpress.org/plugins/wp-user-manager/)
 
 = 2.1.0 (2019-04-14) =
 * _Feature_: Improved compatibility with multisite installations. Plugin data will be properly deleted on uninstallation or when a site is removed. ("Large Networks" will still have to take manual action to prevent timeouts.)

--- a/tests/avatar-privacy/integrations/class-wpdiscuz-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-wpdiscuz-integration-test.php
@@ -1,0 +1,273 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\Integrations;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+
+use Avatar_Privacy\Integrations\WPDiscuz_Integration;
+
+/**
+ * Avatar_Privacy\Integrations\WPDiscuz_Integration unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy\Integrations\WPDiscuz_Integration
+ * @usesDefaultClass \Avatar_Privacy\Integrations\WPDiscuz_Integration
+ *
+ * @uses ::__construct
+ */
+class WPDiscuz_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var \Avatar_Privacy\Integrations\WPDiscuz_Integration
+	 */
+	private $sut;
+
+	/**
+	 * A test fixture.
+	 *
+	 * @var \Avatar_Privacy\Core
+	 */
+	private $core;
+
+	/**
+	 * A test fixture.
+	 *
+	 * @var \Avatar_Privacy\Components\Comments
+	 */
+	private $comments;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$filesystem = [
+			'uploads' => [
+				'delete' => [
+					'existing_file.txt'  => 'CONTENT',
+				],
+			],
+			'plugin'  => [
+				'public' => [
+					'partials' => [
+						'wpdiscuz' => [
+							'use-gravatar.php' => 'USE_GRAVATAR_MARKUP',
+						],
+					],
+				],
+			],
+		];
+
+		// Set up virtual filesystem.
+		$root = vfsStream::setup( 'root', null, $filesystem );
+		set_include_path( 'vfs://root/' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_set_include_path
+
+		// Helper mocks.
+		$this->core     = m::mock( \Avatar_Privacy\Core::class );
+		$this->comments = m::mock( \Avatar_Privacy\Components\Comments::class );
+
+		// Partially mock system under test.
+		$this->sut = m::mock( WPDiscuz_Integration::class, [ $this->core, $this->comments ] )->makePartial()->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * Tests ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$mock     = m::mock( WPDiscuz_Integration::class )->makePartial()->shouldAllowMockingProtectedMethods();
+		$core     = m::mock( \Avatar_Privacy\Core::class );
+		$comments = m::mock( \Avatar_Privacy\Components\Comments::class );
+
+		$mock->__construct( $core, $comments );
+
+		$this->assertAttributeSame( $core, 'core', $mock );
+		$this->assertAttributeSame( $comments, 'comments', $mock );
+	}
+
+	/**
+	 * Tests ::check.
+	 *
+	 * @covers ::check
+	 */
+	public function test_check() {
+		$this->assertFalse( $this->sut->check() );
+
+		Functions\when( 'wpDiscuz' )->justReturn( true );
+
+		$this->assertTrue( $this->sut->check() );
+	}
+
+	/**
+	 * Tests ::run.
+	 *
+	 * @covers ::run
+	 */
+	public function test_run() {
+		Actions\expectAdded( 'init' )->once()->with( [ $this->sut, 'init' ] );
+
+		$this->assertNull( $this->sut->run( $this->core ) );
+	}
+
+	/**
+	 * Tests ::init.
+	 *
+	 * @covers ::init
+	 */
+	public function test_init() {
+		Functions\expect( 'is_user_logged_in' )->once()->andReturn( false );
+		Functions\expect( 'is_admin' )->once()->andReturn( false );
+
+		Actions\expectAdded( 'wpdiscuz_submit_button_before' )->once()->with( [ $this->sut, 'print_gravatar_checkbox' ] );
+		Actions\expectAdded( 'wp_enqueue_scripts' )->once()->with( [ $this->sut, 'enqeue_styles_and_scripts' ] );
+		Actions\expectAdded( 'wpdiscuz_form_init' )->once()->with( [ $this->sut, 'store_cookie_consent_checkbox' ] );
+		Actions\expectAdded( 'wpdiscuz_before_save_commentmeta' )->once()->with( [ $this->sut, 'set_comment_cookies' ] );
+
+		$this->assertNull( $this->sut->init() );
+	}
+
+	/**
+	 * Tests ::init.
+	 *
+	 * @covers ::init
+	 */
+	public function test_init_admin() {
+		Functions\expect( 'is_user_logged_in' )->once()->andReturn( false );
+		Functions\expect( 'is_admin' )->once()->andReturn( true );
+
+		Actions\expectAdded( 'wpdiscuz_submit_button_before' )->never();
+		Actions\expectAdded( 'wp_enqueue_scripts' )->never();
+		Actions\expectAdded( 'wpdiscuz_form_init' )->once()->with( [ $this->sut, 'store_cookie_consent_checkbox' ] );
+		Actions\expectAdded( 'wpdiscuz_before_save_commentmeta' )->once()->with( [ $this->sut, 'set_comment_cookies' ] );
+
+		$this->assertNull( $this->sut->init() );
+	}
+
+	/**
+	 * Tests ::init.
+	 *
+	 * @covers ::init
+	 */
+	public function test_init_user_logged_in() {
+		Functions\expect( 'is_user_logged_in' )->once()->andReturn( true );
+		Functions\expect( 'is_admin' )->never();
+
+		Actions\expectAdded( 'wpdiscuz_submit_button_before' )->never();
+		Actions\expectAdded( 'wp_enqueue_scripts' )->never();
+		Actions\expectAdded( 'wpdiscuz_form_init' )->never();
+		Actions\expectAdded( 'wpdiscuz_before_save_commentmeta' )->never();
+
+		$this->assertNull( $this->sut->init() );
+	}
+
+	/**
+	 * Tests ::print_gravatar_checkbox.
+	 *
+	 * @covers ::print_gravatar_checkbox
+	 */
+	public function test_print_gravatar_checkbox() {
+		$this->expectOutputString( 'USE_GRAVATAR_MARKUP' );
+		$this->assertNull( $this->sut->print_gravatar_checkbox() );
+	}
+
+	/**
+	 * Tests ::enqeue_styles_and_scripts.
+	 *
+	 * @covers ::enqeue_styles_and_scripts
+	 */
+	public function test_enqeue_styles_and_scripts() {
+		$version = '6.6.6';
+
+		Functions\expect( 'plugin_dir_url' )->once()->with( AVATAR_PRIVACY_PLUGIN_FILE )->andReturn( 'some/url' );
+
+		$this->core->shouldReceive( 'get_version' )->once()->andReturn( $version );
+
+		Functions\expect( 'wp_enqueue_script' )->once()->with( 'avatar-privacy-wpdiscuz-use-gravatar', m::type( 'string' ), [ 'jquery' ], $version, true );
+		Functions\expect( 'wp_localize_script' )->once()->with( 'avatar-privacy-wpdiscuz-use-gravatar', 'avatarPrivacy', m::type( 'array' ) );
+
+		$this->assertNull( $this->sut->enqeue_styles_and_scripts() );
+	}
+
+	/**
+	 * Tests ::set_comment_cookies.
+	 *
+	 * @covers ::set_comment_cookies
+	 */
+	public function test_set_comment_cookies() {
+		$comment  = m::mock( \WP_Comment::class );
+		$user     = m::mock( \WP_User::class );
+		$consent  = true;
+		$checkbox = 'cookie_consent_checkbox';
+
+		$this->setValue( $this->sut, 'cookie_consent_name', $checkbox, WPDiscuz_Integration::class );
+
+		Functions\expect( 'wp_get_current_user' )->once()->andReturn( $user );
+
+		$this->sut->shouldReceive( 'filter_input' )->once()->andReturn( $consent )->with( INPUT_POST, $checkbox, FILTER_VALIDATE_BOOLEAN )->andReturn( $consent );
+
+		$this->comments->shouldReceive( 'set_comment_cookies' )->once()->with( $comment, $user, $consent );
+
+		$this->assertNull( $this->sut->set_comment_cookies( $comment ) );
+	}
+
+	/**
+	 * Tests ::store_cookie_consent_checkbox.
+	 *
+	 * @covers ::store_cookie_consent_checkbox
+	 */
+	public function test_store_cookie_consent_checkbox() {
+		$form     = m::mock( \wpdFormAttr\Form::class );
+		$checkbox = 'my_consent_checkbox';
+		$fields   = [
+			'field1_name' => [
+				'foo'  => 'bar',
+				'type' => '\Some\Fake\Class',
+			],
+			$checkbox     => [
+				'bar'  => 'foo',
+				'type' => \wpdFormAttr\Field\CookiesConsent::class,
+			],
+		];
+
+		$form->shouldReceive( 'initFormFields' )->once();
+		$form->shouldReceive( 'getFormCustomFields' )->once()->andReturn( $fields );
+
+		$this->assertNull( $this->sut->store_cookie_consent_checkbox( $form ) );
+		$this->assertSame( $checkbox, $this->getValue( $this->sut, 'cookie_consent_name', WPDiscuz_Integration::class ) );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -69,6 +69,9 @@ if ( ! defined( 'OBJECT' ) ) {
 if ( ! defined( 'OBJECT_K' ) ) {
 	define( 'OBJECT_K', 'OBJECT_K' );
 }
+if ( ! defined( 'SCRIPT_DEBUG' ) ) {
+	define( 'SCRIPT_DEBUG', false );
+}
 
 // Avatar Privacy constants.
 if ( ! defined( 'AVATAR_PRIVACY_PLUGIN_FILE' ) ) {


### PR DESCRIPTION
Basic support for wpDiscuz. Fixes #95. Details:
- Adds a "use gravatar" checkbox to the wpDiscuz comment form.
- Takes wpDiscuz cookies consent checkbox into account.
- Resets the checkbox value using JavaScript after wpDiscuz AJAX calls.