### PR TITLE
Refactor plugin integrations as a subclass of Component

### DIFF
--- a/includes/avatar-privacy/components/class-integrations.php
+++ b/includes/avatar-privacy/components/class-integrations.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -37,13 +37,6 @@ use Avatar_Privacy\Core;
 class Integrations implements \Avatar_Privacy\Component {
 
 	/**
-	 * The plugin instance used for setting transients.
-	 *
-	 * @var Core
-	 */
-	private $core;
-
-	/**
 	 * An array of plugin integration instances.
 	 *
 	 * @var Plugin_Integration[]
@@ -60,11 +53,11 @@ class Integrations implements \Avatar_Privacy\Component {
 	/**
 	 * Creates a new instance.
 	 *
-	 * @param Core                 $core         The core API.
+	 * @since 2.2.0 Parameter $core removed.
+	 *
 	 * @param Plugin_Integration[] $integrations An array of plugin integration instances.
 	 */
-	public function __construct( Core $core, array $integrations ) {
-		$this->core         = $core;
+	public function __construct( array $integrations ) {
 		$this->integrations = $integrations;
 	}
 
@@ -75,7 +68,7 @@ class Integrations implements \Avatar_Privacy\Component {
 		foreach ( $this->integrations as $integration ) {
 			if ( $integration->check() ) {
 				$this->active_integrations[] = $integration;
-				$integration->run( $this->core );
+				$integration->run();
 			}
 		}
 	}

--- a/includes/avatar-privacy/integrations/class-bbpress-integration.php
+++ b/includes/avatar-privacy/integrations/class-bbpress-integration.php
@@ -66,10 +66,8 @@ class BBPress_Integration implements Plugin_Integration {
 
 	/**
 	 * Activate the integration.
-	 *
-	 * @param Core $core The plugin instance.
 	 */
-	public function run( Core $core ) {
+	public function run() {
 		if ( ! \is_admin() ) {
 			\add_action( 'init', [ $this, 'init' ] );
 		}

--- a/includes/avatar-privacy/integrations/class-plugin-integration.php
+++ b/includes/avatar-privacy/integrations/class-plugin-integration.php
@@ -32,9 +32,11 @@ use Avatar_Privacy\Core;
  * An interface for plugin integrations.
  *
  * @since      1.1.0
+ * @since      2.2.0 Extends the Component interface now (removing the $core parameter from ::run).
+ *
  * @author     Peter Putzer <github@mundschenk.at>
  */
-interface Plugin_Integration {
+interface Plugin_Integration extends \Avatar_Privacy\Component {
 
 	/**
 	 * Check if the ACF integration should be activated.
@@ -42,11 +44,4 @@ interface Plugin_Integration {
 	 * @return bool
 	 */
 	public function check();
-
-	/**
-	 * Activate the integration.
-	 *
-	 * @param Core $core The plugin instance.
-	 */
-	public function run( Core $core );
 }

--- a/includes/avatar-privacy/integrations/class-wp-user-manager-integration.php
+++ b/includes/avatar-privacy/integrations/class-wp-user-manager-integration.php
@@ -92,10 +92,8 @@ class WP_User_Manager_Integration implements Plugin_Integration {
 
 	/**
 	 * Activate the integration.
-	 *
-	 * @param Core $core The plugin instance.
 	 */
-	public function run( Core $core ) {
+	public function run() {
 		if ( \is_admin() ) {
 			\add_action( 'admin_init', [ $this, 'remove_profile_picture_upload' ] );
 		}

--- a/includes/avatar-privacy/integrations/class-wpdiscuz-integration.php
+++ b/includes/avatar-privacy/integrations/class-wpdiscuz-integration.php
@@ -83,10 +83,8 @@ class WPDiscuz_Integration implements Plugin_Integration {
 
 	/**
 	 * Activate the integration.
-	 *
-	 * @param Core $core The plugin instance.
 	 */
-	public function run( Core $core ) {
+	public function run() {
 		\add_action( 'init', [ $this, 'init' ] );
 	}
 

--- a/tests/avatar-privacy/components/class-integrations-test.php
+++ b/tests/avatar-privacy/components/class-integrations-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -76,14 +76,13 @@ class Integrations_Test extends \Avatar_Privacy\Tests\TestCase {
 		parent::setUp();
 
 		// Mock required helpers.
-		$this->core         = m::mock( Core::class );
 		$this->integrations = [
 			m::mock( Plugin_Integration::class ),
 			m::mock( Plugin_Integration::class ),
 			m::mock( Plugin_Integration::class ),
 		];
 
-		$this->sut = m::mock( Integrations::class, [ $this->core, $this->integrations ] )->makePartial()->shouldAllowMockingProtectedMethods();
+		$this->sut = m::mock( Integrations::class, [ $this->integrations ] )->makePartial()->shouldAllowMockingProtectedMethods();
 	}
 
 	/**
@@ -94,9 +93,8 @@ class Integrations_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_constructor() {
 		$mock = m::mock( Integrations::class )->makePartial();
 
-		$mock->__construct( $this->core, $this->integrations );
+		$mock->__construct( $this->integrations );
 
-		$this->assertAttributeSame( $this->core, 'core', $mock );
 		$this->assertAttributeSame( $this->integrations, 'integrations', $mock );
 	}
 
@@ -119,7 +117,7 @@ class Integrations_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_activate() {
 		foreach ( $this->integrations as $plugin ) {
 			$plugin->shouldReceive( 'check' )->once()->andReturn( true );
-			$plugin->shouldReceive( 'run' )->once()->with( $this->core );
+			$plugin->shouldReceive( 'run' )->once()->with();
 		}
 
 		$this->assertNull( $this->sut->activate() );


### PR DESCRIPTION
Refactor `\Avatar_Privacy\Integrations\Plugin_Integration` to extend `\Avatar_Privacy\Component`.