### PR TITLE
Windows compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.1 (2019-06-08)
+*   _Bugfix_: Compatibility with Windows servers.
+
 ## 2.2.0 (2019-05-12)
 *   _Feature_: Integration for the following plugins had been added:
     -   [wpDiscuz](https://wordpress.org/plugins/wpdiscuz/)

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -197,7 +197,7 @@ module.exports = function( grunt ) {
 				map: true, // inline sourcemaps.
 				processors: [
 					require('pixrem')(), // add fallbacks for rem units
-					require('autoprefixer')( { browsers: [ '>1%', 'last 2 versions', 'IE 9', 'IE 10' ] } ) // add vendor prefixes
+					require('autoprefixer')() // add vendor prefixes
 				]
 			},
 			dev: {

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -29,7 +29,7 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at
- * Version: 2.2.0
+ * Version: 2.2.1
  * License: GNU General Public License v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: avatar-privacy

--- a/includes/avatar-privacy/upload-handlers/class-custom-default-icon-upload-handler.php
+++ b/includes/avatar-privacy/upload-handlers/class-custom-default-icon-upload-handler.php
@@ -90,8 +90,7 @@ class Custom_Default_Icon_Upload_Handler extends Upload_Handler {
 		}
 
 		$upload_index     = $this->options->get_name( Core::SETTINGS_NAME );
-		$normalized_files = ! empty( $_FILES[ $upload_index ]['name'] ) ? $this->normalize_files_array( /* @scrutinizer ignore-type */ \wp_unslash( $_FILES[ $upload_index ] ) ) : []; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-
+		$normalized_files = ! empty( $_FILES[ $upload_index ]['name'] ) ? $this->normalize_files_array( $_FILES[ $upload_index ] ) : []; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- ::upload uses \wp_handle_upload, $_FILES does not need wp_unslash.
 		if ( ! empty( $normalized_files[ Settings::UPLOAD_CUSTOM_DEFAULT_AVATAR ]['name'] ) ) {
 			// Upload to our custom directory.
 			$icon = $this->upload( $normalized_files[ Settings::UPLOAD_CUSTOM_DEFAULT_AVATAR ], false );

--- a/includes/avatar-privacy/upload-handlers/class-upload-handler.php
+++ b/includes/avatar-privacy/upload-handlers/class-upload-handler.php
@@ -140,6 +140,11 @@ abstract class Upload_Handler {
 		// Move uploaded file.
 		$result = \wp_handle_upload( $file, $args );
 
+		// Ensure normalized path on Windows.
+		if ( ! empty( $result['file'] ) ) {
+			$result['file'] = \wp_normalize_path( $result['file'] );
+		}
+
 		// Restore standard upload directory.
 		\remove_filter( 'upload_dir', [ $this, 'custom_upload_dir' ] );
 

--- a/includes/avatar-privacy/upload-handlers/class-user-avatar-upload-handler.php
+++ b/includes/avatar-privacy/upload-handlers/class-user-avatar-upload-handler.php
@@ -108,10 +108,7 @@ class User_Avatar_Upload_Handler extends Upload_Handler {
 			$this->user_id_being_edited = $user_id;
 
 			// Upload to our custom directory.
-			$avatar = $this->upload(
-				/* @scrutinizer ignore-type */
-				\wp_unslash( $_FILES[ self::FILE_UPLOAD ] ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- ::upload uses \wp_handle_upload.
-			);
+			$avatar = $this->upload( $_FILES[ self::FILE_UPLOAD ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- ::upload uses \wp_handle_upload, $_FILES does not need wp_unslash.
 
 			// Handle upload failures.
 			if ( empty( $avatar['file'] ) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,12 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -181,9 +187,9 @@
       "dev": true
     },
     "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+      "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
       "dev": true
     },
     "array-each": {
@@ -205,18 +211,9 @@
       "dev": true
     },
     "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
     "array-unique": {
@@ -226,9 +223,9 @@
       "dev": true
     },
     "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "dev": true
     },
     "asn1": {
@@ -286,28 +283,29 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
-      "integrity": "sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.0.tgz",
+      "integrity": "sha512-kuip9YilBqhirhHEGHaBTZKXL//xxGnzvsD0FtBQa6z+A69qZD6s/BAX9VzDF1i9VKDquTJDQaPLSEhOnL6FvQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.5.4",
-        "caniuse-lite": "^1.0.30000957",
+        "browserslist": "^4.6.1",
+        "caniuse-lite": "^1.0.30000971",
+        "chalk": "^2.4.2",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.14",
+        "postcss": "^7.0.16",
         "postcss-value-parser": "^3.3.1"
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.5.6",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.6.tgz",
-          "integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
+          "version": "4.6.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
+          "integrity": "sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000963",
-            "electron-to-chromium": "^1.3.127",
-            "node-releases": "^1.1.17"
+            "caniuse-lite": "^1.0.30000971",
+            "electron-to-chromium": "^1.3.137",
+            "node-releases": "^1.1.21"
           }
         },
         "chalk": {
@@ -319,46 +317,37 @@
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
           }
         },
         "node-releases": {
-          "version": "1.1.17",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
-          "integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
+          "version": "1.1.22",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.22.tgz",
+          "integrity": "sha512-O6XpteBuntW1j86mw6LlovBIwTe+sO2+7vi9avQffNeIW4upgnaCVm6xrBWH+KATz7mNNRNNeEpuWB7dT6Cr3w==",
           "dev": true,
           "requires": {
             "semver": "^5.3.0"
           }
         },
         "postcss": {
-          "version": "7.0.15",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.15.tgz",
-          "integrity": "sha512-+avadY713SyQf0m5np7byFzAFZyhPhXyxwp8OVmdd5mKOxm0VzM2AJkKIgBro7gGVk4kYlCDvBVrSqhU5m8E+w==",
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+          "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
             "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         }
       }
@@ -634,9 +623,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000966",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz",
-      "integrity": "sha512-qqLQ/uYrpZmFhPY96VuBkMEo8NhVFBZ9y/Bh+KnvGzGJ5I8hvpIaWlF2pw5gqe4PLAL+ZjsPgMOvoXSpX21Keg==",
+      "version": "1.0.30000973",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000973.tgz",
+      "integrity": "sha512-/F3t/Yo8LEdRSEPCmI15fLu5vepVh9UCg/9inJXF5AAfW7xRRJkbaM2ut52iRMQMnGCLQouLbFdbOA+VEFOIsg==",
       "dev": true
     },
     "caseless": {
@@ -664,9 +653,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz",
-      "integrity": "sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
@@ -1040,9 +1029,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.131",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.131.tgz",
-      "integrity": "sha512-NSO4jLeyGLWrT4mzzfYX8vt1MYCoMI5LxSYAjt0H9+LF/14JyiKJSyyjA6AJTxflZlEM5v3QU33F0ohbPMCAPg==",
+      "version": "1.3.144",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.144.tgz",
+      "integrity": "sha512-jNRFJpfNrYm5uJ4x0q9oYMOfbL0JPOlkNli8GS/5zEmCjnE5jAtoCo4BYajHiqSPqEeAjtTdItL4p7EZw+jSfg==",
       "dev": true
     },
     "emoji-regex": {
@@ -2248,9 +2237,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -3562,15 +3551,15 @@
       }
     },
     "load-grunt-tasks": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-4.0.0.tgz",
-      "integrity": "sha512-w5JYPHpZgMxu9XFR9N9MEzyX8E0mLhQkwQ1qVP4mb3gmuomw8Ww8J49NHMbXqyQliq2LUCqdU7/wW96IVuPCKw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-5.0.0.tgz",
+      "integrity": "sha512-ga8vBA/+JVUB0Q/De9Id75maCIAzSgELWisBkBwxfDpU03fgYH5Ae1Do35hvfothsLWQCjPaTeG1Nya/CQr3gw==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.0",
-        "multimatch": "^2.0.0",
-        "pkg-up": "^2.0.0",
-        "resolve-pkg": "^1.0.0"
+        "arrify": "^2.0.1",
+        "multimatch": "^4.0.0",
+        "pkg-up": "^3.1.0",
+        "resolve-pkg": "^2.0.0"
       }
     },
     "load-json-file": {
@@ -3587,12 +3576,12 @@
       }
     },
     "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
+        "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
       },
       "dependencies": {
@@ -3854,15 +3843,16 @@
       "dev": true
     },
     "multimatch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+      "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
+        "@types/minimatch": "^3.0.3",
+        "array-differ": "^3.0.0",
+        "array-union": "^2.1.0",
+        "arrify": "^2.0.1",
+        "minimatch": "^3.0.4"
       }
     },
     "mute-stream": {
@@ -4159,27 +4149,27 @@
       }
     },
     "p-limit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "^2.0.0"
       }
     },
     "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
     "parent-module": {
@@ -4366,21 +4356,21 @@
       }
     },
     "pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "^3.0.0"
       },
       "dependencies": {
         "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "^3.0.0"
           }
         }
       }
@@ -4663,18 +4653,18 @@
       }
     },
     "resolve-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
     "resolve-pkg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-1.0.0.tgz",
-      "integrity": "sha1-4ZoV54rKLhJEYdySsuOUPvk0lNk=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-2.0.0.tgz",
+      "integrity": "sha512-+1lzwXehGCXSeryaISr6WujZzowloigEofRB+dj75y9RRa/obVcYgbHJd53tdYw8pvZj8GojXaaENws8Ktw/hQ==",
       "dev": true,
       "requires": {
-        "resolve-from": "^2.0.0"
+        "resolve-from": "^5.0.0"
       }
     },
     "resolve-url": {
@@ -4766,9 +4756,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.20.1.tgz",
-      "integrity": "sha512-BnCawee/L5kVG3B/5Jg6BFwASqUwFVE6fj2lnkVuSXDgQ7gMAhY9a2yPeqsKhJMCN+Wgx0r2mAW7XF/aTF5qtA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.20.3.tgz",
+      "integrity": "sha512-kvf+w5XT7FrmFrCKz1gPHqegufG+gxifC8oQesX/s8gkShdeiTqiuvP0c8TvfBwMAuI1YGOgobZQ2KIJGn//jA==",
       "dev": true,
       "requires": {
         "chokidar": "^2.0.0"
@@ -5243,14 +5233,14 @@
       }
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "optional": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "avatar-privacy",
   "devDependencies": {
-    "autoprefixer": "^9.5.1",
+    "autoprefixer": "^9.6.0",
     "eslint-config-wordpress": "^2.0.0",
     "grunt": "^1.0.4",
     "grunt-cli": "^1.3.2",
@@ -18,9 +18,9 @@
     "grunt-string-replace": "^1.3",
     "grunt-wp-deploy": "^2.0",
     "jshint-stylish": "^2.2.1",
-    "load-grunt-tasks": "^4.0",
-    "sass": "^1",
-    "pixrem": "^5.0"
+    "load-grunt-tasks": "^5.0",
+    "pixrem": "^5.0",
+    "sass": "^1.20.3"
   },
   "browserslist": [
     "last 2 version",

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: gravatar, avatar, privacy, caching, bbpress
 Requires at least: 5.1
 Requires PHP: 5.6
 Tested up to: 5.2
-Stable tag: 2.2.0
+Stable tag: 2.2.1
 License: GPLv2 or later
 
 Enhances the privacy of your users and visitors with gravatar opt-in and local avatars.
@@ -135,6 +135,9 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 
 == Changelog ==
+
+= 2.2.1 (2019-06-08) =
+* _Bugfix_: Compatibility with Windows servers.
 
 = 2.2.0 (2019-05-12) =
 * _Feature_: Integration for the following plugins had been added:

--- a/tests/avatar-privacy/upload-handlers/class-custom-default-icon-upload-handler-test.php
+++ b/tests/avatar-privacy/upload-handlers/class-custom-default-icon-upload-handler-test.php
@@ -130,7 +130,7 @@ class Custom_Default_Icon_Upload_Handler_Test extends \Avatar_Privacy\Tests\Test
 	public function test_constructor() {
 		$mock = m::mock( Custom_Default_Icon_Upload_Handler::class )->makePartial();
 
-		$mock->__construct(  $this->core, $this->file_cache, $this->options );
+		$mock->__construct( $this->core, $this->file_cache, $this->options );
 
 		$this->assertAttributeSame( $this->options, 'options', $mock );
 	}

--- a/tests/avatar-privacy/upload-handlers/class-custom-default-icon-upload-handler-test.php
+++ b/tests/avatar-privacy/upload-handlers/class-custom-default-icon-upload-handler-test.php
@@ -196,7 +196,7 @@ class Custom_Default_Icon_Upload_Handler_Test extends \Avatar_Privacy\Tests\Test
 
 		$this->options->shouldReceive( 'get_name' )->once()->with( \Avatar_Privacy\Core::SETTINGS_NAME )->andReturn( 'upload_index' );
 
-		Functions\expect( 'wp_unslash' )->once()->with( $uploaded_file )->andReturn( $uploaded_file );
+		Functions\expect( 'wp_unslash' )->never();
 		$this->sut->shouldReceive( 'normalize_files_array' )->once()->with( $uploaded_file )->andReturn( $normalized_files );
 		$this->sut->shouldReceive( 'upload' )->once()->with( $normalized_files[ \Avatar_Privacy\Settings::UPLOAD_CUSTOM_DEFAULT_AVATAR ], false )->andReturn( $icon );
 		$this->sut->shouldReceive( 'delete_uploaded_icon' )->once()->with( $site_id )->andReturn( true );
@@ -242,7 +242,7 @@ class Custom_Default_Icon_Upload_Handler_Test extends \Avatar_Privacy\Tests\Test
 
 		$this->options->shouldReceive( 'get_name' )->once()->with( \Avatar_Privacy\Core::SETTINGS_NAME )->andReturn( 'upload_index' );
 
-		Functions\expect( 'wp_unslash' )->once()->with( $uploaded_file )->andReturn( $uploaded_file );
+		Functions\expect( 'wp_unslash' )->never();
 		$this->sut->shouldReceive( 'normalize_files_array' )->once()->with( $uploaded_file )->andReturn( $normalized_files );
 		$this->sut->shouldReceive( 'upload' )->once()->with( $normalized_files[ \Avatar_Privacy\Settings::UPLOAD_CUSTOM_DEFAULT_AVATAR ], false )->andReturn( $icon );
 		$this->sut->shouldReceive( 'delete_uploaded_icon' )->never();

--- a/tests/avatar-privacy/upload-handlers/class-user-avatar-upload-handler-test.php
+++ b/tests/avatar-privacy/upload-handlers/class-user-avatar-upload-handler-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -192,7 +192,7 @@ class User_Avatar_Upload_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 		Functions\expect( 'sanitize_key' )->once()->with( $nonce )->andReturn( 'sanitized_nonce' );
 		Functions\expect( 'wp_verify_nonce' )->once()->with( 'sanitized_nonce', User_Avatar_Upload_Handler::ACTION_UPLOAD )->andReturn( true );
 
-		Functions\expect( 'wp_unslash' )->once()->with( $uploaded_file )->andReturn( $uploaded_file );
+		Functions\expect( 'wp_unslash' )->never();
 		$this->sut->shouldReceive( 'upload' )->once()->with( $uploaded_file )->andReturn( $avatar );
 		$this->sut->shouldReceive( 'delete_uploaded_avatar' )->once()->with( $user_id )->andReturn( true );
 		$this->sut->shouldReceive( 'handle_errors' )->never();
@@ -229,7 +229,7 @@ class User_Avatar_Upload_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 		Functions\expect( 'sanitize_key' )->once()->with( $nonce )->andReturn( 'sanitized_nonce' );
 		Functions\expect( 'wp_verify_nonce' )->once()->with( 'sanitized_nonce', User_Avatar_Upload_Handler::ACTION_UPLOAD )->andReturn( true );
 
-		Functions\expect( 'wp_unslash' )->once()->with( $uploaded_file )->andReturn( $uploaded_file );
+		Functions\expect( 'wp_unslash' )->never();
 		$this->sut->shouldReceive( 'upload' )->once()->with( $uploaded_file )->andReturn( $avatar );
 		$this->sut->shouldReceive( 'delete_uploaded_avatar' )->never();
 		$this->sut->shouldReceive( 'handle_errors' )->once()->with( $avatar );


### PR DESCRIPTION
Several fixes for Windows:
- Don't call `wp_unslash` on `$_FILES` (see https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1720 for details).
- Always normalize the path to prevent implicit WordPress `wp_unslash` from wreaking havoc.

Fixes #102.