### PR TITLE
Deprecate old functions and add namespaces API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.0 (unreleased)
+*   _Feature_: New template function `\Avatar_Privacy\gravatar_checkbox()` for legacy themes added.
+*   _Change_: `avapr_get_avatar_checkbox()` has been deprecated in favor of
+    `\Avatar_Privacy\get_gravatar_checkbox()`.
+
 ## 2.2.1 (2019-06-08)
 *   _Bugfix_: Compatibility with Windows servers.
 

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 
     "autoload": {
         "classmap": ["includes/"],
-        "files": ["includes/avatar-privacy-functions.php"]
+        "files": ["includes/avatar-privacy-functions.php", "includes/avatar-privacy/functions.php"]
     },
     "autoload-dev": {
         "classmap": ["tests/"]

--- a/includes/avatar-privacy-functions.php
+++ b/includes/avatar-privacy-functions.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,9 +24,9 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
-use Avatar_Privacy\Components\Comments;
+use function Avatar_Privacy\get_gravatar_checkbox;
 
-if ( ! function_exists( 'avapr_get_avatar_checkbox' ) ) {
+if ( ! \function_exists( 'avapr_get_avatar_checkbox' ) ) {
 
 	/**
 	 * Returns the 'use gravatar' checkbox for the comment form.
@@ -34,14 +34,11 @@ if ( ! function_exists( 'avapr_get_avatar_checkbox' ) ) {
 	 * This is intended as a template function for older or highly-customized
 	 * themes. Output the result with echo or print.
 	 *
-	 * @return string       The HTML code for the checkbox or an empty string.
+	 * @deprecated 2.3.0 Use \Avatar_Privacy\get_gravatar_checkbox instead.
+	 *
+	 * @return string The HTML code for the checkbox or an empty string.
 	 */
 	function avapr_get_avatar_checkbox() {
-		// The checkbox is meaningless for logged-in users.
-		if ( \is_user_logged_in() ) {
-			return '';
-		}
-
-		return Comments::get_gravatar_checkbox();
+		return get_gravatar_checkbox();
 	}
 }

--- a/includes/avatar-privacy/functions.php
+++ b/includes/avatar-privacy/functions.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2018-2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy;
+
+use Avatar_Privacy\Components\Comments;
+
+/**
+ * Returns the 'use gravatar' checkbox for the comment form.
+ *
+ * This is intended as a template function for older or highly-customized
+ * themes.  Modern themes should no need to use it. Output the result with echo
+ * or print.
+ *
+ * @since 2.3.0
+ *
+ * @return string The HTML code for the checkbox or an empty string.
+ */
+function get_gravatar_checkbox() {
+	// The checkbox is meaningless for logged-in users.
+	if ( \is_user_logged_in() ) {
+		return '';
+	}
+
+	return Comments::get_gravatar_checkbox();
+}
+
+/**
+ * Prints the 'use gravatar' checkbox for the comment form.
+ *
+ * This is intended as a template function for older or highly-customized
+ * themes. Modern themes should no need to use it.
+ *
+ * @since 2.3.0
+ */
+function gravatar_checkbox() {
+	echo get_gravatar_checkbox(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is already escaped.
+}

--- a/readme.txt
+++ b/readme.txt
@@ -72,7 +72,7 @@ Depending on which options you selected, you might not see a change in the way t
 
 Then you probably don't use a modern theme which makes use of the function `comment_form()` to create the comment form. Check if you can find this function used in `comments.php` or a similar file of your theme. If you do and it still doesn't work, tell me. Otherwise chances are that you do have to add the checkbox manually. Use this function:
 
-`<?php if (function_exists('avapr_get_avatar_checkbox')) echo avapr_get_avatar_checkbox(); ?>`
+`<?php if ( \function_exists( 'Avatar_Privacy\gravatar_checkbox' ) ) { \Avatar_Privacy\gravatar_checkbox(); } ?>`
 
 = What happens if I disable the plugin? Are any of the data altered? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -136,6 +136,10 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 == Changelog ==
 
+= 2.3.0 (unreleased) =
+* _Feature_: New template function `\Avatar_Privacy\gravatar_checkbox()` for legacy themes added.
+* _Change_: `avapr_get_avatar_checkbox()` has been deprecated in favor of `\Avatar_Privacy\get_gravatar_checkbox()`.
+
 = 2.2.1 (2019-06-08) =
 * _Bugfix_: Compatibility with Windows servers.
 

--- a/tests/avatar-privacy/class-functions-test.php
+++ b/tests/avatar-privacy/class-functions-test.php
@@ -24,7 +24,7 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
-namespace Avatar_Privacy\Tests;
+namespace Avatar_Privacy\Tests\Avatar_Privacy;
 
 use Avatar_Privacy\Core;
 
@@ -40,7 +40,7 @@ use Mockery as m;
 /**
  * Unit tests for Avatar Privacy functions.
  */
-class Avatar_Privacy_Functions_Test extends TestCase {
+class Functions_Test extends \Avatar_Privacy\Tests\TestCase {
 
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
@@ -69,27 +69,42 @@ class Avatar_Privacy_Functions_Test extends TestCase {
 	/**
 	 * Tests run method.
 	 *
-	 * @covers ::avapr_get_avatar_checkbox
+	 * @covers \Avatar_Privacy\get_gravatar_checkbox
 	 *
 	 * @uses \Avatar_Privacy\get_gravatar_checkbox
 	 * @uses \Avatar_Privacy\Components\Comments::get_gravatar_checkbox
 	 */
-	public function test_avapr_get_avatar_checkbox() {
+	public function test_get_gravatar_checkbox() {
 		Functions\expect( 'is_user_logged_in' )->once()->andReturn( false );
 
-		$this->assertSame( 'USE_GRAVATAR', \avapr_get_avatar_checkbox() );
+		$this->assertSame( 'USE_GRAVATAR', \Avatar_Privacy\get_gravatar_checkbox() );
 	}
 
 	/**
 	 * Tests run method.
 	 *
-	 * @covers ::avapr_get_avatar_checkbox
+	 * @covers \Avatar_Privacy\get_gravatar_checkbox
 	 *
 	 * @uses \Avatar_Privacy\get_gravatar_checkbox
 	 */
-	public function test_avapr_get_avatar_checkbox_user_is_logged_in() {
+	public function test_get_gravatar_checkbox_user_is_logged_in() {
 		Functions\expect( 'is_user_logged_in' )->once()->andReturn( true );
 
-		$this->assertSame( '', \avapr_get_avatar_checkbox() );
+		$this->assertSame( '', \Avatar_Privacy\get_gravatar_checkbox() );
+	}
+
+	/**
+	 * Tests run method.
+	 *
+	 * @covers \Avatar_Privacy\gravatar_checkbox
+	 *
+	 * @uses \Avatar_Privacy\get_gravatar_checkbox
+	 * @uses \Avatar_Privacy\Components\Comments::get_gravatar_checkbox
+	 */
+	public function test_gravatar_checkbox() {
+		Functions\expect( 'is_user_logged_in' )->once()->andReturn( false );
+
+		$this->expectOutputString( 'USE_GRAVATAR' );
+		$this->assertNull( \Avatar_Privacy\gravatar_checkbox() );
 	}
 }


### PR DESCRIPTION
- Deprecates `avapr_get_avatar_checkbox`.
- Adds new functions `Avatar_Privacy\get_gravatar_checkbox` and `Avatar_Privacy\gravatar_checkbox`.