### PR TITLE
Interface with WP-CLI API

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -33,6 +33,7 @@ build:
             dependencies:
                 before:
                     - composer require --dev johnpbloch/wordpress-core
+                    - composer require --dev wp-cli/wp-cli
             tests:
                 override:
                     - php-scrutinizer-run --enable-security-analysis

--- a/includes/avatar-privacy/class-controller.php
+++ b/includes/avatar-privacy/class-controller.php
@@ -26,19 +26,7 @@
 
 namespace Avatar_Privacy;
 
-use Avatar_Privacy\Components\Avatar_Handling;
-use Avatar_Privacy\Components\Block_Editor;
-use Avatar_Privacy\Components\Command_Line_Interface;
-use Avatar_Privacy\Components\Comments;
-use Avatar_Privacy\Components\Image_Proxy;
-use Avatar_Privacy\Components\Integrations;
-use Avatar_Privacy\Components\Network_Settings_Page;
-use Avatar_Privacy\Components\Privacy_Tools;
-use Avatar_Privacy\Components\REST_API;
-use Avatar_Privacy\Components\Setup;
-use Avatar_Privacy\Components\Settings_Page;
-use Avatar_Privacy\Components\Shortcodes;
-use Avatar_Privacy\Components\User_Profile;
+use Avatar_Privacy\Component;
 
 /**
  * Initialize Avatar Privacy plugin.
@@ -51,7 +39,7 @@ class Controller {
 	/**
 	 * The settings page handler.
 	 *
-	 * @var Avatar_Privacy\Component[]
+	 * @var Component[]
 	 */
 	private $components = [];
 
@@ -65,51 +53,14 @@ class Controller {
 	/**
 	 * Creates an instance of the plugin controller.
 	 *
-	 * @param Core                   $core             The core API.
-	 * @param Setup                  $setup            The (de-)activation handling.
-	 * @param Image_Proxy            $image_proxy      The image handler.
-	 * @param Avatar_Handling        $avatars          The avatar handler.
-	 * @param Comments               $comments         The comments handler.
-	 * @param User_Profile           $profile          The user profile handler.
-	 * @param Settings_Page          $settings         The admin settings handler.
-	 * @param Network_Settings_Page  $network_settings The network settings handler.
-	 * @param Privacy_Tools          $privacy          The privacy tools handler.
-	 * @param REST_API               $rest_api         The REST API handler.
-	 * @param Integrations           $integrations     The third-party plugin integrations handler.
-	 * @param Shortcodes             $shortcodes       The shortcodes handler.
-	 * @param Block_Editor           $block_editor     The block editor handler.
-	 * @param Command_Line_Interface $cli             The CLI handler.
+	 * @since 2.3.0 Component parameters replaced with factory-cofigured array.
+	 *
+	 * @param Core        $core       The core API.
+	 * @param Component[] $components An array of plugin components.
 	 */
-	public function __construct(
-		Core $core,
-		Setup $setup,
-		Image_Proxy $image_proxy,
-		Avatar_Handling $avatars,
-		Comments $comments,
-		User_Profile $profile,
-		Settings_Page $settings,
-		Network_Settings_Page $network_settings,
-		Privacy_Tools $privacy,
-		REST_API $rest_api,
-		Integrations $integrations,
-		Shortcodes $shortcodes,
-		Block_Editor $block_editor,
-		Command_Line_Interface $cli
-	) {
-		$this->core         = $core;
-		$this->components[] = $setup;
-		$this->components[] = $avatars;
-		$this->components[] = $image_proxy;
-		$this->components[] = $comments;
-		$this->components[] = $profile;
-		$this->components[] = $settings;
-		$this->components[] = $network_settings;
-		$this->components[] = $privacy;
-		$this->components[] = $rest_api;
-		$this->components[] = $integrations;
-		$this->components[] = $shortcodes;
-		$this->components[] = $block_editor;
-		$this->components[] = $cli;
+	public function __construct( Core $core, array $components ) {
+		$this->core       = $core;
+		$this->components = $components;
 	}
 
 	/**

--- a/includes/avatar-privacy/class-controller.php
+++ b/includes/avatar-privacy/class-controller.php
@@ -2,8 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
- * Copyright 2012-2013 Johannes Freudendahl.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/includes/avatar-privacy/class-controller.php
+++ b/includes/avatar-privacy/class-controller.php
@@ -29,6 +29,7 @@ namespace Avatar_Privacy;
 
 use Avatar_Privacy\Components\Avatar_Handling;
 use Avatar_Privacy\Components\Block_Editor;
+use Avatar_Privacy\Components\Command_Line_Interface;
 use Avatar_Privacy\Components\Comments;
 use Avatar_Privacy\Components\Image_Proxy;
 use Avatar_Privacy\Components\Integrations;
@@ -65,19 +66,20 @@ class Controller {
 	/**
 	 * Creates an instance of the plugin controller.
 	 *
-	 * @param Core                  $core             The core API.
-	 * @param Setup                 $setup            The (de-)activation handling.
-	 * @param Image_Proxy           $image_proxy      The image handler.
-	 * @param Avatar_Handling       $avatars          The avatar handler.
-	 * @param Comments              $comments         The comments handler.
-	 * @param User_Profile          $profile          The user profile handler.
-	 * @param Settings_Page         $settings         The admin settings handler.
-	 * @param Network_Settings_Page $network_settings The network settings handler.
-	 * @param Privacy_Tools         $privacy          The privacy tools handler.
-	 * @param REST_API              $rest_api         The REST API handler.
-	 * @param Integrations          $integrations     The third-party plugin integrations handler.
-	 * @param Shortcodes            $shortcodes       The shortcodes handler.
-	 * @param Block_Editor          $block_editor     The block editor handler.
+	 * @param Core                   $core             The core API.
+	 * @param Setup                  $setup            The (de-)activation handling.
+	 * @param Image_Proxy            $image_proxy      The image handler.
+	 * @param Avatar_Handling        $avatars          The avatar handler.
+	 * @param Comments               $comments         The comments handler.
+	 * @param User_Profile           $profile          The user profile handler.
+	 * @param Settings_Page          $settings         The admin settings handler.
+	 * @param Network_Settings_Page  $network_settings The network settings handler.
+	 * @param Privacy_Tools          $privacy          The privacy tools handler.
+	 * @param REST_API               $rest_api         The REST API handler.
+	 * @param Integrations           $integrations     The third-party plugin integrations handler.
+	 * @param Shortcodes             $shortcodes       The shortcodes handler.
+	 * @param Block_Editor           $block_editor     The block editor handler.
+	 * @param Command_Line_Interface $cli             The CLI handler.
 	 */
 	public function __construct(
 		Core $core,
@@ -92,7 +94,8 @@ class Controller {
 		REST_API $rest_api,
 		Integrations $integrations,
 		Shortcodes $shortcodes,
-		Block_Editor $block_editor
+		Block_Editor $block_editor,
+		Command_Line_Interface $cli
 	) {
 		$this->core         = $core;
 		$this->components[] = $setup;
@@ -107,6 +110,7 @@ class Controller {
 		$this->components[] = $integrations;
 		$this->components[] = $shortcodes;
 		$this->components[] = $block_editor;
+		$this->components[] = $cli;
 	}
 
 	/**

--- a/includes/avatar-privacy/class-factory.php
+++ b/includes/avatar-privacy/class-factory.php
@@ -30,9 +30,11 @@ use Dice\Dice;
 
 use Avatar_Privacy\Core;
 use Avatar_Privacy\Component;
+use Avatar_Privacy\CLI;
 use Avatar_Privacy\Settings;
 
 use Avatar_Privacy\Components\Block_Editor;
+use Avatar_Privacy\Components\Command_Line_Interface;
 use Avatar_Privacy\Components\Shortcodes;
 use Avatar_Privacy\Components\User_Profile;
 
@@ -139,6 +141,9 @@ class Factory extends Dice {
 
 			// Components.
 			Component::class                                => self::SHARED,
+			Command_Line_Interface::class                   => [
+				'constructParams' => [ $this->get_cli_commands() ],
+			],
 			Integrations::class                             => [
 				'constructParams' => [ $this->get_plugin_integrations() ],
 			],
@@ -372,6 +377,24 @@ class Factory extends Dice {
 			[ 'instance' => BBPress_Integration::class ],
 			[ 'instance' => WPDiscuz_Integration::class ],
 			[ 'instance' => WP_User_Manager_Integration::class ],
+		];
+	}
+
+	/**
+	 * Retrieves a list of CLI commands.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @return array {
+	 *     An array of `Command` instances in `Dice` syntax.
+	 *
+	 *     @type array {
+	 *         @type string $instance The classname.
+	 *     }
+	 * }
+	 */
+	protected function get_cli_commands() {
+		return [
 		];
 	}
 }

--- a/includes/avatar-privacy/class-factory.php
+++ b/includes/avatar-privacy/class-factory.php
@@ -30,13 +30,10 @@ use Dice\Dice;
 
 use Avatar_Privacy\Core;
 use Avatar_Privacy\Component;
+use Avatar_Privacy\Components;
+use Avatar_Privacy\Controller;
 use Avatar_Privacy\CLI;
 use Avatar_Privacy\Settings;
-
-use Avatar_Privacy\Components\Block_Editor;
-use Avatar_Privacy\Components\Command_Line_Interface;
-use Avatar_Privacy\Components\Shortcodes;
-use Avatar_Privacy\Components\User_Profile;
 
 use Avatar_Privacy\Upload_Handlers\Upload_Handler;
 
@@ -139,12 +136,17 @@ class Factory extends Dice {
 				'constructParams' => [ $this->get_plugin_version( \AVATAR_PRIVACY_PLUGIN_FILE ) ],
 			],
 
+			// The plugin controller.
+			Controller::class                               => [
+				'constructParams' => [ $this->get_components() ],
+			],
+
 			// Components.
 			Component::class                                => self::SHARED,
-			Command_Line_Interface::class                   => [
+			Components\Command_Line_Interface::class        => [
 				'constructParams' => [ $this->get_cli_commands() ],
 			],
-			Integrations::class                             => [
+			Components\Integrations::class                  => [
 				'constructParams' => [ $this->get_plugin_integrations() ],
 			],
 
@@ -279,17 +281,17 @@ class Factory extends Dice {
 				],
 			],
 
-			Block_Editor::class                             => [
+			Components\Block_Editor::class                  => [
 				'substitutions' => [
 					User_Form::class => [ 'instance' => '$FrontendUserForm' ],
 				],
 			],
-			Shortcodes::class                               => [
+			Components\Shortcodes::class                    => [
 				'substitutions' => [
 					User_Form::class => [ 'instance' => '$FrontendUserForm' ],
 				],
 			],
-			User_Profile::class                             => [
+			Components\User_Profile::class                  => [
 				'substitutions' => [
 					User_Form::class => [ 'instance' => '$UserProfileForm' ],
 				],
@@ -326,6 +328,36 @@ class Factory extends Dice {
 		}
 
 		return \get_plugin_data( $plugin_file, false, false )['Version'];
+	}
+
+	/**
+	 * Retrieves the list of plugin components run during normal operations
+	 * (i.e. not including the Uninstallation component).
+	 *
+	 * @return array {
+	 *     An array of `Component` instances in `Dice` syntax.
+	 *
+	 *     @type array {
+	 *         @type string $instance The classname.
+	 *     }
+	 * }
+	 */
+	protected function get_components() {
+		return [
+			[ 'instance' => Components\Setup::class ],
+			[ 'instance' => Components\Image_Proxy::class ],
+			[ 'instance' => Components\Avatar_Handling::class ],
+			[ 'instance' => Components\Comments::class ],
+			[ 'instance' => Components\User_Profile::class ],
+			[ 'instance' => Components\Settings_Page::class ],
+			[ 'instance' => Components\Network_Settings_Page::class ],
+			[ 'instance' => Components\Privacy_Tools::class ],
+			[ 'instance' => Components\REST_API::class ],
+			[ 'instance' => Components\Integrations::class ],
+			[ 'instance' => Components\Shortcodes::class ],
+			[ 'instance' => Components\Block_Editor::class ],
+			[ 'instance' => Components\Command_Line_Interface::class ],
+		];
 	}
 
 	/**

--- a/includes/avatar-privacy/class-factory.php
+++ b/includes/avatar-privacy/class-factory.php
@@ -323,7 +323,7 @@ class Factory extends Dice {
 	 */
 	protected function get_plugin_version( $plugin_file ) {
 		// Load version from plugin data.
-		if ( ! function_exists( 'get_plugin_data' ) ) {
+		if ( ! \function_exists( 'get_plugin_data' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 

--- a/includes/avatar-privacy/class-factory.php
+++ b/includes/avatar-privacy/class-factory.php
@@ -427,6 +427,7 @@ class Factory extends Dice {
 	 */
 	protected function get_cli_commands() {
 		return [
+			[ 'instance' => CLI\Database_Command::class ],
 		];
 	}
 }

--- a/includes/avatar-privacy/class-factory.php
+++ b/includes/avatar-privacy/class-factory.php
@@ -427,6 +427,7 @@ class Factory extends Dice {
 	 */
 	protected function get_cli_commands() {
 		return [
+			[ 'instance' => CLI\Cron_Command::class ],
 			[ 'instance' => CLI\Database_Command::class ],
 			[ 'instance' => CLI\Uninstall_Command::class ],
 		];

--- a/includes/avatar-privacy/class-factory.php
+++ b/includes/avatar-privacy/class-factory.php
@@ -428,6 +428,7 @@ class Factory extends Dice {
 	protected function get_cli_commands() {
 		return [
 			[ 'instance' => CLI\Database_Command::class ],
+			[ 'instance' => CLI\Uninstall_Command::class ],
 		];
 	}
 }

--- a/includes/avatar-privacy/cli/class-abstract-command.php
+++ b/includes/avatar-privacy/cli/class-abstract-command.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\CLI;
+
+use Avatar_Privacy\Core;
+
+/**
+ * An abstract base class for CLI command implementations.
+ *
+ * @since 2.3.0
+ */
+abstract class Abstract_Command implements Command {
+
+	/**
+	 * Clears all of the caches for memory management. Should be called after
+	 * every 100 updates or so.
+	 *
+	 * @global \WP_Object_Cache $wp_object_cache The WordPress object cache.
+	 * @global \wpdb            $wpdb            The WordPress database.
+	 */
+	protected function stop_the_insanity() {
+		global $wpdb, $wp_object_cache;
+
+		// Clean up saved queries.
+		$wpdb->queries = [];
+
+		// FIXME: Check if any of these are at least somewhat universal.
+		if ( \is_object( $wp_object_cache ) ) {
+			if ( \property_exists( $wp_object_cache, 'group_ops' ) ) {
+				$wp_object_cache->group_ops = [];
+			}
+
+			if ( \property_exists( $wp_object_cache, 'stats' ) ) {
+				$wp_object_cache->stats = [];
+			}
+
+			if ( \property_exists( $wp_object_cache, 'memcache_debug' ) ) {
+				$wp_object_cache->memcache_debug = [];
+			}
+
+			if ( \property_exists( $wp_object_cache, 'cache' ) ) {
+				$wp_object_cache->cache = [];
+			}
+
+			// For some large memcached implementations.
+			if ( \method_exists( $wp_object_cache, '__remoteset' ) ) {
+				$wp_object_cache->__remoteset(); // @codeCoverageIgnore
+			}
+		}
+	}
+
+	/**
+	 * Copies the iterator into an array.
+	 *
+	 * This method replaces to the builtin `\iterator_to_array()` to facilitate
+	 * unit testing.
+	 *
+	 * @param  \Iterator $iterator Any iterator.
+	 *
+	 * @return array
+	 */
+	protected function iterator_to_array( \Iterator $iterator ) {
+		$result = [];
+
+		foreach ( $iterator as $key => $item ) {
+			$result[ $key ] = $item;
+		}
+
+		return $result;
+	}
+}

--- a/includes/avatar-privacy/cli/class-command.php
+++ b/includes/avatar-privacy/cli/class-command.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\CLI;
+
+use Avatar_Privacy\Core;
+
+/**
+ * An interface for CLI command implementations.
+ *
+ * @since 2.3.0
+ */
+interface Command {
+
+	/**
+	 * Registers the command (and any optional subcommands).
+	 *
+	 * The method assumes that `\WP_CLI` is available.
+	 *
+	 * @return void
+	 */
+	public function register();
+}

--- a/includes/avatar-privacy/cli/class-cron-command.php
+++ b/includes/avatar-privacy/cli/class-cron-command.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\CLI;
+
+use Avatar_Privacy\Components\Image_Proxy;
+
+use WP_CLI;
+
+/**
+ * CLI commands for working with Avatar Privacy cron jobs.
+ *
+ * @since 2.3.0
+ */
+class Cron_Command extends Abstract_Command {
+
+	/**
+	 * Registers the command (and any optional subcommands).
+	 *
+	 * The method assumes that `\WP_CLI` is available.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		WP_CLI::add_command( 'avatar-privacy cron list', [ $this, 'list_' ] );
+		WP_CLI::add_command( 'avatar-privacy cron delete', [ $this, 'delete' ] );
+	}
+
+	/**
+	 * Displays information on the cron jobs installed by Avatar Privacy.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *    # Show when cron job will run next.
+	 *    $ wp avatar-privacy cron list
+	 *    Success: Cron job will run next at 2019-09-03 20:56:16 on this site.
+	 *
+	 * @subcommand list
+	 *
+	 * @param  array $args       The positional arguments.
+	 * @param  array $assoc_args The associative arguments.
+	 */
+	public function list_( /* @scrutinizer ignore-unused */ array $args, /* @scrutinizer ignore-unused */ array $assoc_args ) {
+		$job  = Image_Proxy::CRON_JOB_ACTION;
+		$next = \wp_next_scheduled( $job );
+
+		if ( false === $next ) {
+			WP_CLI::success( WP_CLI::colorize( "Cron job %B{$job}%n not scheduled on this site." ) );
+		} else {
+			$timestamp = \date( 'Y-m-d H:i:s', $next );
+			WP_CLI::success( WP_CLI::colorize( "Cron job %B{$job}%n will run next at %B{$timestamp}%n on this site." ) );
+		}
+	}
+
+	/**
+	 * Deletes the cron jobs installed by Avatar Privacy.
+	 *
+	 * They will be scheduled again on the next request.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *    # Delete all cron jobs hooked by Avatar Privacy.
+	 *    $ wp avatar-privacy cron delete
+	 *    Success: Cron job avatar_privacy_daily was unscheduled on this site (1 event).
+	 *
+	 * @param  array $args       The positional arguments.
+	 * @param  array $assoc_args The associative arguments.
+	 */
+	public function delete( /* @scrutinizer ignore-unused */ array $args, /* @scrutinizer ignore-unused */ array $assoc_args ) {
+		$job    = Image_Proxy::CRON_JOB_ACTION;
+		$events = \wp_unschedule_hook( $job );
+
+		if ( false === $events ) {
+			WP_CLI::error( WP_CLI::colorize( "Cron job %B{$job}%n could not be unscheduled on this site." ) );
+		} else {
+			$events = ( 1 === $events ) ? "{$events} event" : "{$events} events";
+			WP_CLI::success( WP_CLI::colorize( "Cron job %B{$job}%n was unscheduled on this site (%B{$events}%n)." ) );
+		}
+	}
+}

--- a/includes/avatar-privacy/cli/class-database-command.php
+++ b/includes/avatar-privacy/cli/class-database-command.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\CLI;
+
+use Avatar_Privacy\Core;
+use Avatar_Privacy\Data_Storage\Database;
+
+use WP_CLI;
+use WP_CLI\Formatter;
+use WP_CLI\Iterators\Table as Table_Iterator;
+
+use function WP_CLI\Utils\format_items;
+
+/**
+ * CLI commands for accessing the Avatar Privacy database tables.
+ *
+ * @since 2.3.0
+ */
+class Database_Command extends Abstract_Command {
+
+	/**
+	 * The core API.
+	 *
+	 * @var Core
+	 */
+	private $core;
+
+	/**
+	 * The DB handler.
+	 *
+	 * @var Database
+	 */
+	private $db;
+
+
+	/**
+	 * Creates a new command instance.
+	 *
+	 * @param  Core     $core The core API.
+	 * @param  Database $db   The database handler.
+	 */
+	public function __construct( Core $core, Database $db ) {
+		$this->core = $core;
+		$this->db   = $db;
+	}
+
+	/**
+	 * Registers the command (and any optional subcommands).
+	 *
+	 * The method assumes that `\WP_CLI` is available.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		WP_CLI::add_command( 'avatar-privacy db show', [ $this, 'show' ] );
+		WP_CLI::add_command( 'avatar-privacy db list', [ $this, 'list_' ] );
+	}
+
+	/**
+	 * Displays information about the database configuration of the Avatar Privacy installation.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *    # Output information on the custom table used by Avatar Privacy.
+	 *    $ wp avatar-privacy db show
+	 *    Avatar Privacy Database Information
+	 *    Version: 2.3.0
+	 *    Table name: wp_avatar_privacy
+	 *    The database currently contains 13 rows.
+	 *
+	 * @global \wpdb $wpdb       The WordPress database.
+	 *
+	 * @param  array $args       The positional arguments.
+	 * @param  array $assoc_args The associative arguments.
+	 */
+	public function show( /* @scrutinizer ignore-unused */ array $args, /* @scrutinizer ignore-unused */ array $assoc_args ) {
+		global $wpdb;
+
+		// Query data.
+		$count  = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->avatar_privacy}" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$schema = $wpdb->get_results( "DESCRIBE {$wpdb->avatar_privacy}", \ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
+
+		// Display everything in a nice way.
+		WP_CLI::line( '' );
+		WP_CLI::line( WP_CLI::colorize( '%GAvatar Privacy Database Information%n' ) );
+		WP_CLI::line( '' );
+		WP_CLI::line( WP_CLI::colorize( "Version: %g{$this->core->get_version()}%n" ) );
+		WP_CLI::line( WP_CLI::colorize( "Table name: %g{$this->db->get_table_name()}%n" ) );
+		WP_CLI::line( '' );
+		format_items( 'table', $schema, [ 'Field', 'Type', 'Null', 'Key', 'Default', 'Extra' ] );
+
+		if ( \is_multisite() ) {
+			if ( $this->db->use_global_table() ) {
+				WP_CLI::line( 'The global table is used for all sites in this network.' );
+			} else {
+				WP_CLI::line( 'Each site in this network uses a separate table.' );
+			}
+		}
+
+		WP_CLI::line( '' );
+		WP_CLI::line( WP_CLI::colorize( "The table currently contains %g{$count} rows%n." ) );
+		WP_CLI::line( '' );
+	}
+
+
+	/**
+	 * Lists the contents of Avatar Privacy's consent logging database for comment authors that were not logged in at the time.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--<field>=<value>]
+	 * : Filter by one or more fields (see "Available Fields" section).
+	 *
+	 * [--field=<field>]
+	 * : Prints the value of a single field for each row.
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to show.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - count
+	 *   - ids
+	 *   - yaml
+	 * ---
+	 *
+	 * ## AVAILABLE FIELDS
+	 *
+	 * These fields will be displayed by default for each row:
+	 *
+	 * * id
+	 * * email
+	 * * use_gravatar
+	 * * last_updated
+	 *
+	 * These fields are optionally available:
+	 *
+	 * * hash
+	 * * log_message
+	 *
+	 * ## EXAMPLES
+	 *
+	 *    # Output list of email address for which gravatars are enabled.
+	 *    $ wp avatar-privacy db list --field=email --use_gravatar=1
+	 *    firstname.lastname@example.org
+	 *    office@example.com
+	 *
+	 * @subcommand list
+	 *
+	 * @param  array $args       The positional arguments.
+	 * @param  array $assoc_args The associative arguments.
+	 */
+	public function list_( /* @scrutinizer ignore-unused */ array $args, array $assoc_args ) {
+		$assoc_args = \wp_parse_args( $assoc_args, [
+			'fields' => [ 'id', 'email', 'use_gravatar', 'last_updated' ],
+			'format' => 'table',
+		] );
+
+		// Create query data.
+		$where   = [];
+		$db_cols = [ 'id', 'email', 'hash', 'use_gravatar', 'last_updated', 'log_message' ];
+		foreach ( $db_cols as $col ) {
+			if ( isset( $assoc_args[ $col ] ) ) {
+				$where[ $col ] = $assoc_args[ $col ];
+			}
+		}
+
+		// Load table data.
+		$iterator = new Table_Iterator( [
+			'table'  => $this->db->get_table_name(),
+			'where'  => $where,
+		] );
+
+		// Optionally load only IDs.
+		$items = $iterator;
+		if ( 'ids' === $assoc_args['format'] ) {
+			$items = \wp_list_pluck( $this->iterator_to_array( $iterator ), 'id' );
+		}
+
+		// Display everything in a nice way.
+		$formatter = new Formatter( $assoc_args, null );
+		$formatter->display_items( /* @scrutinizer ignore-type */ $items );
+	}
+}

--- a/includes/avatar-privacy/cli/class-uninstall-command.php
+++ b/includes/avatar-privacy/cli/class-uninstall-command.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\CLI;
+
+use Avatar_Privacy\Components\Setup;
+use Avatar_Privacy\Components\Uninstallation;
+use Avatar_Privacy\Data_Storage\Database;
+
+use WP_CLI;
+
+use function WP_CLI\Utils\get_flag_value;
+
+/**
+ * CLI commands for reoving data added by Avatar Privacy.
+ *
+ * @since 2.3.0
+ */
+class Uninstall_Command extends Abstract_Command {
+
+	/**
+	 * The setup component.
+	 *
+	 * @var Setup
+	 */
+	private $setup;
+
+	/**
+	 * The uninstallation component.
+	 *
+	 * @var Uninstallation
+	 */
+	private $uninstall;
+
+	/**
+	 * The DB handler.
+	 *
+	 * @var Database
+	 */
+	private $db;
+
+	/**
+	 * Creates a new command instance.
+	 *
+	 * @param  Setup          $setup     The setup component.
+	 * @param  Uninstallation $uninstall The uninstallation component.
+	 * @param  Database       $db        The database handler.
+	 */
+	public function __construct( Setup $setup, Uninstallation $uninstall, Database $db ) {
+		$this->setup     = $setup;
+		$this->uninstall = $uninstall;
+		$this->db        = $db;
+	}
+
+	/**
+	 * Registers the command (and any optional subcommands).
+	 *
+	 * The method assumes that `\WP_CLI` is available.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		WP_CLI::add_command( 'avatar-privacy uninstall', [ $this, 'uninstall' ] );
+	}
+
+	/**
+	 * Removes all data from the current site. Optionally, also removes global data on multisite.
+	 *
+	 * Data that will be removed:
+	 * * Cached avatar images
+	 * * Uploaded user avatars
+	 * * Uploaded custom default images
+	 * * Avatar privacy user settings
+	 * * Options created by Avatar Privacy
+	 * * Transients created by Avatar Privacy
+	 * * Network options (on multisite)
+	 * * Network transients (on multisite)
+	 * * The custom database table used for non-logged-in comment author consent logging.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--live]
+	 * : Actually remove the data (instead of only listing it).
+	 *
+	 * [--yes]
+	 * : Do not ask for confirmation when removing data.
+	 *
+	 * [--global]
+	 * : Also uninstall global data (only applicable on multisite installations).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *    # Remove all data from a non-multisite installatin.
+	 *    $ wp avatar-privacy uninstall
+	 *
+	 *    # Remove site-specific and global data from a multisite installation
+	 *    # (site-specific data needs to be deleted from each site seperately).
+	 *    $ wp avatar-privacy uninstall --global
+	 *
+	 * @global \wpdb $wpdb       The WordPress database.
+	 *
+	 * @param  array $args       The positional arguments.
+	 * @param  array $assoc_args The associative arguments.
+	 */
+	public function uninstall( /* @scrutinizer ignore-unused */ array $args, array $assoc_args ) {
+		$live          = get_flag_value( $assoc_args, 'live', false );
+		$remove_global = get_flag_value( $assoc_args, 'global', false );
+		$multisite     = \is_multisite();
+
+		// Abort early if we're not on a multsitie installation.
+		if ( $remove_global && ! $multisite ) {
+			WP_CLI::error( 'This is not a multisite installation.' );
+		}
+
+		// On non-multisite installations, global data is always removed.
+		$remove_global = $remove_global || ! $multisite;
+
+		if ( ! $live ) {
+			WP_CLI::warning( 'Starting dry run.' );
+		}
+
+		// Marker text for site-specific data.
+		$site_id  = \get_current_blog_id();
+		$for_site = $multisite ? " for site {$site_id}" : '';
+
+		// List the data that will be deleted.
+		$this->print_data_to_delete( $for_site, $remove_global );
+
+		// OK, let's do this.
+		if ( $live ) {
+			// Get confirmation.
+			WP_CLI::confirm( 'Are you sure you want to delete this data?', $assoc_args );
+
+			// Actually delete data.
+			$this->delete_data( $site_id, $for_site, $remove_global );
+		} else {
+			WP_CLI::success( 'Dry run finished.' );
+		}
+	}
+
+	/**
+	 * Deletes the data and prints a confirmation message.
+	 *
+	 * @param  int    $site_id       The site ID.
+	 * @param  string $for_site      Label part describing the site ("for site <ID>").
+	 * @param  bool   $remove_global A flag indicating that global data should be removed as well.
+	 */
+	protected function delete_data( $site_id, $for_site, $remove_global ) {
+
+		// Act as if deactivating plugin.
+		$this->setup->deactivate_plugin();
+
+		// Add tasks to uninstallation actions.
+		$this->uninstall->enqueue_cleanup_tasks();
+
+		if ( $remove_global ) {
+			// Remove global data.
+			/** This action is documented in class-uninstallation.php */
+			\do_action( 'avatar_privacy_uninstallation_global' );
+
+			if ( \is_multisite() ) {
+				// Only show extra message on multsite.
+				WP_CLI::success( 'Global data deleted.' );
+			}
+		}
+
+		// Remove site data.
+		/** This action is documented in class-uninstallation.php */
+		\do_action( 'avatar_privacy_uninstallation_site', $site_id );
+
+		WP_CLI::success( "Site data{$for_site} deleted." );
+	}
+
+	/**
+	 * Prints the list of data to be deleted.
+	 *
+	 * @param  string $for_site      Label part describing the site ("for site <ID>").
+	 * @param  bool   $remove_global A flag indicating that global data should be removed as well.
+	 */
+	protected function print_data_to_delete( $for_site, $remove_global ) {
+		if ( $remove_global ) {
+			// List global data to delete.
+			WP_CLI::line( 'Deleting cached avatar images.' );
+			WP_CLI::line( 'Deleting uploaded user avatar and custom default images.' );
+			WP_CLI::line( 'Deleting avatar privacy user settings (user_meta).' );
+
+			if ( \is_multisite() ) {
+				// These do not make sense in single-site environment, even though
+				// they technically do exist.
+				WP_CLI::line( 'Deleting network options.' );
+				WP_CLI::line( 'Deleting network transients.' );
+			}
+		}
+
+		// List site data to delete.
+		WP_CLI::line( "Deleting options{$for_site}." );
+		WP_CLI::line( "Deleting transients{$for_site}." );
+
+		// Show dropped table.
+		$table_name = $this->db->get_table_name();
+		if ( ! $this->db->use_global_table() ) {
+			WP_CLI::line( "Dropping table {$table_name}{$for_site}." );
+		} else {
+			WP_CLI::line( "Dropping global table {$table_name}." );
+		}
+	}
+}

--- a/includes/avatar-privacy/components/class-command-line-interface.php
+++ b/includes/avatar-privacy/components/class-command-line-interface.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Components;
+
+use Avatar_Privacy\Component;
+use Avatar_Privacy\CLI\Command;
+
+/**
+ * The component providing CLI commands.
+ *
+ * @since 2.3.0
+ */
+class Command_Line_Interface implements Component {
+
+	/**
+	 * An array of CLI commands.
+	 *
+	 * @var Command[]
+	 */
+	private $commands;
+
+	/**
+	 * Initialize the class and set its properties.
+	 *
+	 * @param Command[] $commands An array of CLI commands to register.
+	 */
+	public function __construct( array $commands ) {
+		$this->commands = $commands;
+	}
+
+	/**
+	 * Sets up the various hooks for the plugin component.
+	 */
+	public function run() {
+		\add_action( 'cli_init', [ $this, 'register_commands' ] );
+	}
+
+	/**
+	 * Registeres all the different CLI commands.
+	 */
+	public function register_commands() {
+		foreach ( $this->commands as $cmd ) {
+			$cmd->register();
+		}
+	}
+}

--- a/includes/avatar-privacy/components/class-setup.php
+++ b/includes/avatar-privacy/components/class-setup.php
@@ -348,17 +348,14 @@ class Setup implements \Avatar_Privacy\Component {
 	 * Sometimes, the table data needs to updated when upgrading.
 	 *
 	 * @since 2.1.0 Visibility changed to protected.
+	 * @since 2.3.0 Now uses Database::maybe_upgrade_table_data()
 	 *
 	 * @param string $previous_version The previously installed plugin version.
 	 */
 	protected function maybe_update_table_data( $previous_version ) {
-		global $wpdb;
 
 		if ( \version_compare( $previous_version, '0.5', '<' ) ) {
-			$rows = $wpdb->get_results( "SELECT id, email FROM {$wpdb->avatar_privacy} WHERE hash is null" ); // WPCS: db call ok, cache ok.
-			foreach ( $rows as $r ) {
-				$this->core->update_comment_author_hash( $r->id, $r->email );
-			}
+			$this->database->maybe_upgrade_table_data();
 		}
 	}
 

--- a/includes/avatar-privacy/components/class-uninstallation.php
+++ b/includes/avatar-privacy/components/class-uninstallation.php
@@ -114,6 +114,25 @@ class Uninstallation implements \Avatar_Privacy\Component {
 	 * @return void
 	 */
 	public function run() {
+		// Enqueue necessary tasks.
+		$this->enqueue_cleanup_tasks();
+
+		// Clean up the site-specific artifacts.
+		$this->do_site_cleanups();
+
+		/**
+		 * Cleans up any remaining global artifacts.
+		 */
+		\do_action( 'avatar_privacy_uninstallation_global' );
+	}
+
+	/**
+	 * Enqeueus the necessary uninstallation tasks to the `avatar_privacy_uninstallation_site`
+	 * and `avatar_privacy_uninstallation_global` actions.
+	 *
+	 * @since 2.3.0
+	 */
+	public function enqueue_cleanup_tasks() {
 		// Delete cached files.
 		\add_action( 'avatar_privacy_uninstallation_global', [ $this->file_cache, 'invalidate' ], 10, 0 );
 
@@ -133,14 +152,6 @@ class Uninstallation implements \Avatar_Privacy\Component {
 
 		// Drop all our tables.
 		\add_action( 'avatar_privacy_uninstallation_site', [ $this->database, 'drop_table' ], 12, 1 );
-
-		// Clean up the site-specific artifacts.
-		$this->do_site_cleanups();
-
-		/**
-		 * Cleans up any remaining global artifacts.
-		 */
-		\do_action( 'avatar_privacy_uninstallation_global' );
 	}
 
 	/**

--- a/includes/avatar-privacy/components/class-uninstallation.php
+++ b/includes/avatar-privacy/components/class-uninstallation.php
@@ -214,6 +214,7 @@ class Uninstallation implements \Avatar_Privacy\Component {
 		\delete_metadata( 'user', 0, Core::GRAVATAR_USE_META_KEY, null, true );
 		\delete_metadata( 'user', 0, Core::ALLOW_ANONYMOUS_META_KEY, null, true );
 		\delete_metadata( 'user', 0, Core::USER_AVATAR_META_KEY, null, true );
+		\delete_metadata( 'user', 0, Core::EMAIL_HASH_META_KEY, null, true );
 	}
 
 	/**

--- a/includes/avatar-privacy/data-storage/class-database.php
+++ b/includes/avatar-privacy/data-storage/class-database.php
@@ -61,7 +61,9 @@ class Database {
 	/**
 	 * Retrieves the table prefix to use (for a given site or the current site).
 	 *
-	 * @param int|null $site_id Optional. The site ID. Null means the current $blog_id. Default null.
+	 * @global \wpdb    $wpdb    The WordPress Database Access Abstraction.
+	 *
+	 * @param  int|null $site_id Optional. The site ID. Null means the current $blog_id. Default null.
 	 *
 	 * @return string
 	 */
@@ -129,6 +131,8 @@ class Database {
 	 * Creates the plugin's database table if it doesn't already exist. The
 	 * table may be created as a global table for legacy multisite installations.
 	 * Makes the name of the table available through $wpdb->avatar_privacy.
+	 *
+	 * @global \wpdb $wpdb             The WordPress Database Access Abstraction.
 	 *
 	 * @param string $previous_version The previously installed plugin version.
 	 *
@@ -217,6 +221,8 @@ class Database {
 	/**
 	 * Drops the table for the given site.
 	 *
+	 * @global \wpdb $wpdb The WordPress Database Access Abstraction.
+	 *
 	 * @param int|null $site_id Optional. The site ID. Null means the current $blog_id. Ddefault null.
 	 */
 	public function drop_table( $site_id = null ) {
@@ -228,6 +234,8 @@ class Database {
 
 	/**
 	 * Migrates data from the global database to the given site database.
+	 *
+	 * @global \wpdb    $wpdb    The WordPress Database Access Abstraction.
 	 *
 	 * @param  int|null $site_id Optional. The site ID. Null means the current $blog_id. Ddefault null.
 	 *
@@ -304,6 +312,9 @@ class Database {
 	/**
 	 * Prepares the query for inserting or updating the database.
 	 *
+	 *
+	 * @global \wpdb    $wpdb            The WordPress Database Access Abstraction.
+	 *
 	 * @param  object[] $rows_to_update  The table rows to update (existing ID).
 	 * @param  object[] $rows_to_migrate The table rows to insert (new autoincrement ID).
 	 * @param  string   $table           The table name.
@@ -357,6 +368,8 @@ class Database {
 	/**
 	 * Prepares the query for selecting existing rows by email.
 	 *
+	 * @global \wpdb    $wpdb    The WordPress Database Access Abstraction.
+	 *
 	 * @param  string[] $emails  An array of email adresses.
 	 * @param  string   $table   The table name.
 	 *
@@ -377,6 +390,8 @@ class Database {
 
 	/**
 	 * Prepares the query for deleting obsolete rows from the database.
+	 *
+	 * @global \wpdb  $wpdb          The WordPress Database Access Abstraction.
 	 *
 	 * @param  int[]  $ids_to_delete The IDs to delete.
 	 * @param  string $table         The table name.

--- a/includes/avatar-privacy/data-storage/class-database.php
+++ b/includes/avatar-privacy/data-storage/class-database.php
@@ -91,11 +91,13 @@ class Database {
 	/**
 	 * Checks if the given table exists.
 	 *
+	 * @since 2.3.0 Visibility changed to public.
+	 *
 	 * @param  string $table_name A table name.
 	 *
 	 * @return bool
 	 */
-	protected function table_exists( $table_name ) {
+	public function table_exists( $table_name ) {
 		global $wpdb;
 
 		return $table_name === $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ); // WPCS: db call ok, cache ok.

--- a/includes/avatar-privacy/data-storage/class-database.php
+++ b/includes/avatar-privacy/data-storage/class-database.php
@@ -78,11 +78,13 @@ class Database {
 	/**
 	 * Retrieves the table name to use (for a given site or the current site).
 	 *
+	 * @since 2.3.0 Visibility changed to public.
+	 *
 	 * @param int|null $site_id Optional. The site ID. Null means the current $blog_id. Default null.
 	 *
 	 * @return string
 	 */
-	protected function get_table_name( $site_id = null ) {
+	public function get_table_name( $site_id = null ) {
 		return $this->get_table_prefix( $site_id ) . self::TABLE_BASENAME;
 	}
 
@@ -103,9 +105,11 @@ class Database {
 	 * Determines whether this (multisite) installation uses the global table.
 	 * Result is ignored for single-site installations.
 	 *
+	 * @since 2.3.0 Visibility changed to public.
+	 *
 	 * @return bool
 	 */
-	protected function use_global_table() {
+	public function use_global_table() {
 		$global_table = $this->network_options->get( Network_Options::USE_GLOBAL_TABLE, false );
 
 		/**

--- a/tests/avatar-privacy/class-controller-test.php
+++ b/tests/avatar-privacy/class-controller-test.php
@@ -56,21 +56,6 @@ use Mockery as m;
 class Controller_Test extends \Avatar_Privacy\Tests\TestCase {
 
 	/**
-	 * Sets up the fixture, for example, opens a network connection.
-	 * This method is called before a test is executed.
-	 */
-	protected function setUp() { // @codingStandardsIgnoreLine
-		parent::setUp();
-	}
-
-	/**
-	 * Necesssary clean-up work.
-	 */
-	protected function tearDown() { // @codingStandardsIgnoreLine
-		parent::tearDown();
-	}
-
-	/**
 	 * Tests constructor.
 	 *
 	 * @covers ::__construct
@@ -80,18 +65,21 @@ class Controller_Test extends \Avatar_Privacy\Tests\TestCase {
 			\Avatar_Privacy\Controller::class,
 			[
 				m::mock( Core::class ),
-				m::mock( Setup::class ),
-				m::mock( Image_Proxy::class ),
-				m::mock( Avatar_Handling::class ),
-				m::mock( Comments::class ),
-				m::mock( User_Profile::class ),
-				m::mock( Settings_Page::class ),
-				m::mock( Network_Settings_Page::class ),
-				m::mock( Privacy_Tools::class ),
-				m::mock( REST_API::class ),
-				m::mock( Integrations::class ),
-				m::mock( Shortcodes::class ),
-				m::mock( Block_Editor::class ),
+				[
+					// This does not have to include all components anymore.
+					m::mock( Setup::class ),
+					m::mock( Image_Proxy::class ),
+					m::mock( Avatar_Handling::class ),
+					m::mock( Comments::class ),
+					m::mock( User_Profile::class ),
+					m::mock( Settings_Page::class ),
+					m::mock( Network_Settings_Page::class ),
+					m::mock( Privacy_Tools::class ),
+					m::mock( REST_API::class ),
+					m::mock( Integrations::class ),
+					m::mock( Shortcodes::class ),
+					m::mock( Block_Editor::class ),
+				],
 			]
 		)->makePartial();
 

--- a/tests/avatar-privacy/class-factory-test.php
+++ b/tests/avatar-privacy/class-factory-test.php
@@ -118,10 +118,14 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 			[ 'instance' => \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generated_Icons\Identicon_Icon_Provider::class ],
 			[ 'instance' => \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generated_Icons\Wavatar_Icon_Provider::class ],
 		];
+		$cli_commands  = [
+			[ 'instance' => \Avatar_Privacy\CLI\Database_Command::class ],
+		];
 
 		$this->sut->shouldReceive( 'get_plugin_version' )->once()->with( \AVATAR_PRIVACY_PLUGIN_FILE )->andReturn( $version );
 		$this->sut->shouldReceive( 'get_plugin_integrations' )->once()->andReturn( $integrations );
 		$this->sut->shouldReceive( 'get_default_icons' )->once()->andReturn( $default_icons );
+		$this->sut->shouldReceive( 'get_cli_commands' )->once()->andReturn( $cli_commands );
 
 		$result = $this->sut->get_rules();
 
@@ -149,6 +153,7 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 	 *
 	 * @uses Avatar_Privacy\Factory::__construct
 	 * @uses Avatar_Privacy\Factory::get_default_icons
+	 * @uses Avatar_Privacy\Factory::get_cli_commands
 	 * @uses Avatar_Privacy\Factory::get_plugin_integrations
 	 * @uses Avatar_Privacy\Factory::get_plugin_version
 	 * @uses Avatar_Privacy\Factory::get_rules
@@ -191,5 +196,16 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->assertInternalType( 'array', $result );
 		$this->assertContains( [ 'instance' => \Avatar_Privacy\Integrations\BBPress_Integration::class ], $result, 'Default icon missing.', false, true, true );
+	}
+
+	/**
+	 * Test ::get_cli_commands.
+	 *
+	 * @covers ::get_cli_commands
+	 */
+	public function test_get_cli_commands() {
+		$result = $this->sut->get_cli_commands();
+
+		$this->assertInternalType( 'array', $result );
 	}
 }

--- a/tests/avatar-privacy/class-factory-test.php
+++ b/tests/avatar-privacy/class-factory-test.php
@@ -231,5 +231,6 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 		$result = $this->sut->get_cli_commands();
 
 		$this->assertInternalType( 'array', $result );
+		$this->assertContains( [ 'instance' => \Avatar_Privacy\CLI\Database_Command::class ], $result, 'Command missing.', false, true, true );
 	}
 }

--- a/tests/avatar-privacy/class-factory-test.php
+++ b/tests/avatar-privacy/class-factory-test.php
@@ -110,6 +110,10 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 	 */
 	public function test_get_rules() {
 		$version       = '6.6.6';
+		$components    = [
+			[ 'instance' => \Avatar_Privacy\Components\Setup::class ],
+			[ 'instance' => \Avatar_Privacy\Components\Avatar_Handling::class ],
+		];
 		$integrations  = [
 			[ 'instance' => \Avatar_Privacy\Integrations\BBPress_Integration::class ],
 		];
@@ -123,6 +127,7 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 		];
 
 		$this->sut->shouldReceive( 'get_plugin_version' )->once()->with( \AVATAR_PRIVACY_PLUGIN_FILE )->andReturn( $version );
+		$this->sut->shouldReceive( 'get_components' )->once()->andReturn( $components );
 		$this->sut->shouldReceive( 'get_plugin_integrations' )->once()->andReturn( $integrations );
 		$this->sut->shouldReceive( 'get_default_icons' )->once()->andReturn( $default_icons );
 		$this->sut->shouldReceive( 'get_cli_commands' )->once()->andReturn( $cli_commands );
@@ -154,6 +159,7 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @uses Avatar_Privacy\Factory::__construct
 	 * @uses Avatar_Privacy\Factory::get_default_icons
 	 * @uses Avatar_Privacy\Factory::get_cli_commands
+	 * @uses Avatar_Privacy\Factory::get_components
 	 * @uses Avatar_Privacy\Factory::get_plugin_integrations
 	 * @uses Avatar_Privacy\Factory::get_plugin_version
 	 * @uses Avatar_Privacy\Factory::get_rules
@@ -168,6 +174,24 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 		$result2 = \Avatar_Privacy\Factory::get();
 
 		$this->assertSame( $result1, $result2 );
+	}
+
+	/**
+	 * Test ::get_components.
+	 *
+	 * @covers ::get_components
+	 */
+	public function test_get_components() {
+		$result = $this->sut->get_components();
+
+		$this->assertInternalType( 'array', $result );
+
+		// Check some exemplary components.
+		$this->assertContains( [ 'instance' => \Avatar_Privacy\Components\Avatar_Handling::class ], $result, 'Component missing.', false, true, true );
+		$this->assertContains( [ 'instance' => \Avatar_Privacy\Components\Setup::class ], $result, 'Component missing.', false, true, true );
+
+		// Uninstallation must not (!) be included.
+		$this->assertNotContains( [ 'instance' => \Avatar_Privacy\Components\Uninstallation::class ], $result, 'Uninstallation component should not be included.', false, true, true );
 	}
 
 	/**

--- a/tests/avatar-privacy/cli/class-abstract-command-test.php
+++ b/tests/avatar-privacy/cli/class-abstract-command-test.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\CLI;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use Avatar_Privacy\CLI\Abstract_Command;
+
+/**
+ * Avatar_Privacy\CLI\Abstract_Command unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy\CLI\Abstract_Command
+ * @usesDefaultClass \Avatar_Privacy\CLI\Abstract_Command
+ */
+class Abstract_Command_Test extends \Avatar_Privacy\Tests\TestCase {
+
+	/**
+	 * Tests ::stop_the_insanity.
+	 *
+	 * @covers ::stop_the_insanity
+	 */
+	public function test_stop_the_insanity() {
+		global $wpdb;
+		global $wp_object_cache;
+
+		// Fake globals.
+		$wpdb                            = m::mock( \wpdb::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wpdb->queries                   = [ 'foo', 'bar' ];
+		$wp_object_cache                 = m::mock( \WP_Object_Cache::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_object_cache->group_ops      = [ 'foo', 'bar' ];
+		$wp_object_cache->stats          = [ 'foo', 'bar' ];
+		$wp_object_cache->memcache_debug = [ 'foo', 'bar' ];
+		$wp_object_cache->cache          = [ 'foo', 'bar' ];
+
+		$sut = m::mock( Abstract_Command::class );
+
+		$this->assertNull( $sut->stop_the_insanity() );
+
+		$this->assertAttributeEmpty( 'queries', $wpdb );
+		$this->assertAttributeEmpty( 'group_ops', $wp_object_cache );
+		$this->assertAttributeEmpty( 'stats', $wp_object_cache );
+		$this->assertAttributeEmpty( 'memcache_debug', $wp_object_cache );
+		$this->assertAttributeEmpty( 'cache', $wp_object_cache );
+	}
+
+	/**
+	 * Tests ::iterator_to_array
+	 *
+	 * @covers ::iterator_to_array
+	 */
+	public function test_iterator_to_array() {
+		$array = [
+			'foo' => 'bar',
+			'bar' => 'baz',
+			'baz' => 'foo',
+		];
+
+		$sut = m::mock( Abstract_Command::class )->makePartial()->shouldAllowMockingProtectedMethods();
+
+		$iterator = new \ArrayIterator( $array );
+
+		$this->assertSame( $array, $sut->iterator_to_array( $iterator ) );
+	}
+}

--- a/tests/avatar-privacy/cli/class-cron-command-test.php
+++ b/tests/avatar-privacy/cli/class-cron-command-test.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\CLI;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use Avatar_Privacy\CLI\Cron_Command;
+use Avatar_Privacy\Components\Image_Proxy;
+
+/**
+ * Avatar_Privacy\CLI\Cron_Command unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy\CLI\Cron_Command
+ * @usesDefaultClass \Avatar_Privacy\CLI\Cron_Command
+ *
+ * @usesx ::__construct
+ */
+class Cron_Command_Test extends TestCase {
+
+	/**
+	 * The system under test.
+	 *
+	 * @var Cron_Command
+	 */
+	private $sut;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$this->sut = m::mock(
+			Cron_Command::class,
+			[]
+		)->makePartial()->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * Tests ::register.
+	 *
+	 * @covers ::register
+	 */
+	public function test_register() {
+		$this->wp_cli->shouldReceive( 'add_command' )->once()->with( 'avatar-privacy cron list', [ $this->sut, 'list_' ] );
+		$this->wp_cli->shouldReceive( 'add_command' )->once()->with( 'avatar-privacy cron delete', [ $this->sut, 'delete' ] );
+
+		$this->assertNull( $this->sut->register() );
+	}
+
+	/**
+	 * Tests ::list_.
+	 *
+	 * @covers ::list_
+	 */
+	public function test_list_() {
+		$args       = [];
+		$assoc_args = [];
+
+		Functions\expect( 'wp_next_scheduled' )->once()->with( Image_Proxy::CRON_JOB_ACTION )->andReturn( \time() );
+
+		$this->wp_cli->shouldReceive( 'colorize' )->zeroOrMoreTimes();
+		$this->expect_wp_cli_success();
+
+		$this->assertNull( $this->sut->list_( $args, $assoc_args ) );
+	}
+
+	/**
+	 * Tests ::list_.
+	 *
+	 * @covers ::list_
+	 */
+	public function test_list_not_scheduled() {
+		$args       = [];
+		$assoc_args = [];
+
+		Functions\expect( 'wp_next_scheduled' )->once()->with( Image_Proxy::CRON_JOB_ACTION )->andReturn( false );
+
+		$this->wp_cli->shouldReceive( 'colorize' )->zeroOrMoreTimes();
+		$this->expect_wp_cli_success();
+
+		$this->assertNull( $this->sut->list_( $args, $assoc_args ) );
+	}
+
+	/**
+	 * Tests ::delete.
+	 *
+	 * @covers ::delete
+	 */
+	public function test_delete() {
+		$args       = [];
+		$assoc_args = [];
+
+		Functions\expect( 'wp_unschedule_hook' )->once()->with( Image_Proxy::CRON_JOB_ACTION )->andReturn( 1 );
+
+		$this->wp_cli->shouldReceive( 'colorize' )->zeroOrMoreTimes();
+		$this->expect_wp_cli_success();
+
+		$this->assertNull( $this->sut->delete( $args, $assoc_args ) );
+	}
+
+	/**
+	 * Tests ::delete.
+	 *
+	 * @covers ::delete
+	 */
+	public function test_delete_no_events() {
+		$args       = [];
+		$assoc_args = [];
+
+		Functions\expect( 'wp_unschedule_hook' )->once()->with( Image_Proxy::CRON_JOB_ACTION )->andReturn( false );
+
+		$this->wp_cli->shouldReceive( 'colorize' )->zeroOrMoreTimes();
+		$this->expect_wp_cli_error();
+
+		$this->assertNull( $this->sut->delete( $args, $assoc_args ) );
+	}
+}

--- a/tests/avatar-privacy/cli/class-database-command-test.php
+++ b/tests/avatar-privacy/cli/class-database-command-test.php
@@ -45,7 +45,7 @@ use Avatar_Privacy\Data_Storage\Database;
  *
  * @uses ::__construct
  */
-class Database_Command_Test extends \Avatar_Privacy\Tests\TestCase {
+class Database_Command_Test extends TestCase {
 
 	/**
 	 * The system under test.
@@ -69,21 +69,11 @@ class Database_Command_Test extends \Avatar_Privacy\Tests\TestCase {
 	private $database;
 
 	/**
-	 * Alias mock for static WP_CLI methods.
-	 *
-	 * @var \WP_CLI
-	 */
-	private $wp_cli;
-
-	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
 	protected function setUp() {
 		parent::setUp();
-
-		// API class mock.
-		$this->wp_cli = m::mock( 'alias:' . \WP_CLI::class );
 
 		// Helper mocks.
 		$this->core     = m::mock( Core::class );
@@ -351,36 +341,6 @@ class Database_Command_Test extends \Avatar_Privacy\Tests\TestCase {
 			[ true, true, false ],
 			[ true, true, true ],
 		];
-	}
-
-	/**
-	 * Mocks WP_CLI::error.
-	 *
-	 * @param  object|null $expectation Optional. A mockery type expectation, or null. Default null.
-	 */
-	protected function expect_wp_cli_error( $expectation = null ) {
-		$this->expectException( \RuntimeException::class );
-
-		if ( ! empty( $expectation ) ) {
-			$this->wp_cli->shouldReceive( 'error' )->once()->with( $expectation )->andThrow( \RuntimeException::class );
-		} else {
-			$this->wp_cli->shouldReceive( 'error' )->once()->andThrow( \RuntimeException::class );
-		}
-	}
-
-	/**
-	 * Mocks WP_CLI::success.
-	 *
-	 * @param  object|null $expectation Optional. A mockery type expectation, or null. Default null.
-	 */
-	protected function expect_wp_cli_success( $expectation = null ) {
-		$this->wp_cli->shouldReceive( 'error' )->never();
-
-		if ( ! empty( $expectation ) ) {
-			$this->wp_cli->shouldReceive( 'success' )->once()->with( $expectation );
-		} else {
-			$this->wp_cli->shouldReceive( 'success' )->once();
-		}
 	}
 
 	/**

--- a/tests/avatar-privacy/cli/class-database-command-test.php
+++ b/tests/avatar-privacy/cli/class-database-command-test.php
@@ -1,0 +1,334 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\CLI;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use Avatar_Privacy\CLI\Database_Command;
+
+use Avatar_Privacy\Core;
+use Avatar_Privacy\Data_Storage\Database;
+
+/**
+ * Avatar_Privacy\CLI\Database_Command unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy\CLI\Database_Command
+ * @usesDefaultClass \Avatar_Privacy\CLI\Database_Command
+ *
+ * @uses ::__construct
+ */
+class Database_Command_Test extends \Avatar_Privacy\Tests\TestCase {
+
+	/**
+	 * The system under test.
+	 *
+	 * @var Database_Command
+	 */
+	private $sut;
+
+	/**
+	 * The core API.
+	 *
+	 * @var Core
+	 */
+	private $core;
+
+	/**
+	 * The database handler.
+	 *
+	 * @var Database
+	 */
+	private $database;
+
+	/**
+	 * Alias mock for static WP_CLI methods.
+	 *
+	 * @var \WP_CLI
+	 */
+	private $wp_cli;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		// API class mock.
+		$this->wp_cli = m::mock( 'alias:' . \WP_CLI::class );
+
+		// Helper mocks.
+		$this->core     = m::mock( Core::class );
+		$this->database = m::mock( Database::class );
+
+		$this->sut = m::mock(
+			Database_Command::class,
+			[
+				$this->core,
+				$this->database,
+			]
+		)->makePartial()->shouldAllowMockingProtectedMethods();
+
+		// We don't care about colorize.
+		$this->wp_cli->shouldReceive( 'colorize' )->zeroOrMoreTimes()->with( m::type( 'string' ) )->andReturnUsing(
+			function( $arg ) {
+				return $arg;
+			}
+		);
+	}
+
+	/**
+	 * Tests ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$mock = m::mock( Database_Command::class )->makePartial();
+
+		$mock->__construct( $this->core, $this->database );
+
+		$this->assertAttributeSame( $this->core, 'core', $mock );
+		$this->assertAttributeSame( $this->database, 'db', $mock );
+	}
+
+	/**
+	 * Tests ::register.
+	 *
+	 * @covers ::register
+	 */
+	public function test_register() {
+
+		$this->wp_cli->shouldReceive( 'add_command' )->once()->with( 'avatar-privacy db show', [ $this->sut, 'show' ] );
+		$this->wp_cli->shouldReceive( 'add_command' )->once()->with( 'avatar-privacy db list', [ $this->sut, 'list_' ] );
+
+		$this->assertNull( $this->sut->register() );
+	}
+
+	/**
+	 * Tests ::show.
+	 *
+	 * @covers ::show
+	 */
+	public function test_show() {
+		$args       = [];
+		$assoc_args = [];
+
+		// Intermediary data.
+		$table   = 'fake_table';
+		$version = '6.6.6';
+		$count   = 23;
+		$schema  = 'SOME DB SCHEMA DEFINITION';
+
+		// Fake globals.
+		global $wpdb;
+		$wpdb                 = m::mock( \wpdb::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wpdb->avatar_privacy = $table;
+
+		$wpdb->shouldReceive( 'get_var' )->once()->with( "SELECT COUNT(*) FROM {$table}" )->andReturn( $count );
+		$wpdb->shouldReceive( 'get_results' )->once()->with( "DESCRIBE {$wpdb->avatar_privacy}", \ARRAY_A )->andReturn( $schema );
+
+		$this->database->shouldReceive( 'get_table_name' )->once()->andReturn( $table );
+		$this->core->shouldReceive( 'get_version' )->once()->andReturn( $version );
+
+		Functions\expect( 'is_multisite' )->once()->andReturn( false );
+		$this->database->shouldReceive( 'use_global_table' )->never();
+
+		Functions\expect( 'WP_CLI\Utils\format_items' )->once()->with( 'table', $schema, m::type( 'array' ) );
+
+		$this->wp_cli->shouldReceive( 'line' )->atLeast()->once()->with( m::type( 'string' ) );
+
+		$this->assertNull( $this->sut->show( $args, $assoc_args ) );
+	}
+
+	/**
+	 * Tests ::show.
+	 *
+	 * @covers ::show
+	 */
+	public function test_show_multisite() {
+		$args       = [];
+		$assoc_args = [];
+
+		// Intermediary data.
+		$table   = 'fake_table';
+		$version = '6.6.6';
+		$count   = 23;
+		$schema  = 'SOME DB SCHEMA DEFINITION';
+
+		// Fake globals.
+		global $wpdb;
+		$wpdb                 = m::mock( \wpdb::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wpdb->avatar_privacy = $table;
+
+		$wpdb->shouldReceive( 'get_var' )->once()->with( "SELECT COUNT(*) FROM {$table}" )->andReturn( $count );
+		$wpdb->shouldReceive( 'get_results' )->once()->with( "DESCRIBE {$wpdb->avatar_privacy}", \ARRAY_A )->andReturn( $schema );
+
+		$this->database->shouldReceive( 'get_table_name' )->once()->andReturn( $table );
+		$this->core->shouldReceive( 'get_version' )->once()->andReturn( $version );
+
+		Functions\expect( 'is_multisite' )->once()->andReturn( true );
+
+		$this->database->shouldReceive( 'use_global_table' )->once()->andReturn( false );
+		$this->wp_cli->shouldReceive( 'line' )->once()->with( 'Each site in this network uses a separate table.' );
+
+		Functions\expect( 'WP_CLI\Utils\format_items' )->once()->with( 'table', $schema, m::type( 'array' ) );
+
+		$this->wp_cli->shouldReceive( 'line' )->atLeast()->once()->with( m::type( 'string' ) );
+
+		$this->assertNull( $this->sut->show( $args, $assoc_args ) );
+	}
+
+	/**
+	 * Tests ::show.
+	 *
+	 * @covers ::show
+	 */
+	public function test_show_multisite_global_table() {
+		$args       = [];
+		$assoc_args = [];
+
+		// Intermediary data.
+		$table   = 'fake_table';
+		$version = '6.6.6';
+		$count   = 23;
+		$schema  = 'SOME DB SCHEMA DEFINITION';
+
+		// Fake globals.
+		global $wpdb;
+		$wpdb                 = m::mock( \wpdb::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wpdb->avatar_privacy = $table;
+
+		$wpdb->shouldReceive( 'get_var' )->once()->with( "SELECT COUNT(*) FROM {$table}" )->andReturn( $count );
+		$wpdb->shouldReceive( 'get_results' )->once()->with( "DESCRIBE {$wpdb->avatar_privacy}", \ARRAY_A )->andReturn( $schema );
+
+		$this->database->shouldReceive( 'get_table_name' )->once()->andReturn( $table );
+		$this->core->shouldReceive( 'get_version' )->once()->andReturn( $version );
+
+		Functions\expect( 'is_multisite' )->once()->andReturn( true );
+
+		$this->database->shouldReceive( 'use_global_table' )->once()->andReturn( true );
+		$this->wp_cli->shouldReceive( 'line' )->once()->with( 'The global table is used for all sites in this network.' );
+
+		Functions\expect( 'WP_CLI\Utils\format_items' )->once()->with( 'table', $schema, m::type( 'array' ) );
+
+		$this->wp_cli->shouldReceive( 'line' )->atLeast()->once()->with( m::type( 'string' ) );
+
+		$this->assertNull( $this->sut->show( $args, $assoc_args ) );
+	}
+
+	/**
+	 * Tests ::list_.
+	 *
+	 * @covers ::list_
+	 */
+	public function test_list() {
+		// Input.
+		$email  = 'foo@bar.org';
+		$format = 'json';
+		$id     = 42;
+
+		// Arguments.
+		$args       = [];
+		$assoc_args = [
+			'format' => $format,
+			'email'  => $email,
+			'id'     => $id,
+		];
+
+		// Overloaded helper class.
+		$table_iterator = m::mock( 'overload:' . \WP_CLI\Iterators\Table::class, \Iterator::class );
+		$formatter      = m::mock( 'overload:' . \WP_CLI\Formatter::class );
+
+		// Intermediary data.
+		$table   = 'fake_table';
+		$version = '6.6.6';
+		$count   = 23;
+		$schema  = 'SOME DB SCHEMA DEFINITION';
+
+		Functions\expect( 'wp_parse_args' )->once()->with( $assoc_args, m::type( 'array' ) )->andReturn( $assoc_args );
+
+		$this->database->shouldReceive( 'get_table_name' )->once()->andReturn( $table );
+		$table_iterator->shouldReceive( '__construct' )->once()->with(
+			[
+				'table' => $table,
+				'where' => [
+					'email' => $email,
+					'id'    => $id,
+				],
+			]
+		);
+
+		$formatter->shouldReceive( '__construct' )->once()->with( $assoc_args, null );
+		$formatter->shouldReceive( 'display_items' )->once()->with( m::type( \WP_CLI\Iterators\Table::class ) );
+
+		$this->assertNull( $this->sut->list_( $args, $assoc_args ) );
+	}
+
+	/**
+	 * Tests ::list_.
+	 *
+	 * @covers ::list_
+	 */
+	public function test_list_ids() {
+		$args       = [];
+		$assoc_args = [
+			'format' => 'ids',
+		];
+
+		// Overloaded helper class.
+		$table_iterator = m::mock( 'overload:' . \WP_CLI\Iterators\Table::class, \Iterator::class );
+		$formatter      = m::mock( 'overload:' . \WP_CLI\Formatter::class );
+
+		// Intermediary data.
+		$table   = 'fake_table';
+		$version = '6.6.6';
+		$count   = 23;
+		$schema  = 'SOME DB SCHEMA DEFINITION';
+
+		Functions\expect( 'wp_parse_args' )->once()->with( $assoc_args, m::type( 'array' ) )->andReturn( $assoc_args );
+
+		$this->database->shouldReceive( 'get_table_name' )->once()->andReturn( $table );
+		$table_iterator->shouldReceive( '__construct' )->once()->with(
+			[
+				'table' => $table,
+				'where' => [],
+			]
+		);
+
+		$this->sut->shouldReceive( 'iterator_to_array' )->once()->with( m::type( \WP_CLI\Iterators\Table::class ) )->andReturn( [ 'iterator' => 'array' ] );
+		Functions\expect( 'wp_list_pluck' )->once()->with( m::type( 'array' ), 'id' )->andReturn( [ 'id' => 'fake' ] );
+
+		$formatter->shouldReceive( '__construct' )->once()->with( $assoc_args, null );
+		$formatter->shouldReceive( 'display_items' )->once()->with( m::type( 'array' ) );
+
+		$this->assertNull( $this->sut->list_( $args, $assoc_args ) );
+	}
+}

--- a/tests/avatar-privacy/cli/class-testcase.php
+++ b/tests/avatar-privacy/cli/class-testcase.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\CLI;
+
+use Mockery as m;
+
+/**
+ * Special base class for CLI command unit tests.
+ */
+abstract class TestCase extends \Avatar_Privacy\Tests\TestCase {
+
+	/**
+	 * Alias mock for static WP_CLI methods.
+	 *
+	 * @var \WP_CLI
+	 */
+	protected $wp_cli;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		// API class mock.
+		$this->wp_cli = m::mock( 'alias:' . \WP_CLI::class );
+	}
+
+	/**
+	 * Mocks WP_CLI::error.
+	 *
+	 * @param  object|null $expectation Optional. A mockery type expectation, or null. Default null.
+	 */
+	protected function expect_wp_cli_error( $expectation = null ) {
+		$this->expectException( \RuntimeException::class );
+
+		$method = $this->wp_cli->shouldReceive( 'error' )->once();
+
+		if ( ! empty( $expectation ) ) {
+			$method = $method->with( $expectation );
+		}
+
+		$method->andThrow( \RuntimeException::class );
+
+	}
+
+	/**
+	 * Mocks WP_CLI::success.
+	 *
+	 * @param  object|null $expectation    Optional. A mockery type expectation, or null. Default null.
+	 * @param  bool        $more_than_once Optional. Allow the method to be called more than once. Default false.
+	 */
+	protected function expect_wp_cli_success( $expectation = null, $more_than_once = false ) {
+		$this->wp_cli->shouldReceive( 'error' )->never();
+
+		$method = $this->wp_cli->shouldReceive( 'success' );
+
+		if ( $more_than_once ) {
+			$method = $method->atLeast();
+		}
+
+		$method = $method->once();
+
+		if ( ! empty( $expectation ) ) {
+			$method->with( $expectation );
+		}
+	}
+}

--- a/tests/avatar-privacy/cli/class-uninstall-command-test.php
+++ b/tests/avatar-privacy/cli/class-uninstall-command-test.php
@@ -46,7 +46,7 @@ use Avatar_Privacy\Data_Storage\Database;
  *
  * @uses ::__construct
  */
-class Uninstall_Command_Test extends \Avatar_Privacy\Tests\TestCase {
+class Uninstall_Command_Test extends TestCase {
 
 	/**
 	 * The system under test.
@@ -77,21 +77,11 @@ class Uninstall_Command_Test extends \Avatar_Privacy\Tests\TestCase {
 	private $database;
 
 	/**
-	 * Alias mock for static WP_CLI methods.
-	 *
-	 * @var \WP_CLI
-	 */
-	private $wp_cli;
-
-	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
 	protected function setUp() {
 		parent::setUp();
-
-		// API class mock.
-		$this->wp_cli = m::mock( 'alias:' . \WP_CLI::class );
 
 		// Helper mocks.
 		$this->setup     = m::mock( Setup::class );
@@ -186,8 +176,8 @@ class Uninstall_Command_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		if ( $global && ! $multi ) {
 			// The script ends prematurely.
-			$this->expectException( \RuntimeException::class );
-			$this->wp_cli->shouldReceive( 'error' )->once()->with( m::type( 'string' ) )->andThrow( \RuntimeException::class );
+			$this->expect_wp_cli_error( m::type( 'string' ) );
+
 			$this->sut->shouldReceive( 'print_data_to_delete' )->never();
 			$this->sut->shouldReceive( 'delete_data' )->never();
 		} else {
@@ -198,7 +188,7 @@ class Uninstall_Command_Test extends \Avatar_Privacy\Tests\TestCase {
 			if ( ! $live ) {
 				// Dry run.
 				$this->wp_cli->shouldReceive( 'warning' )->once()->with( 'Starting dry run.' );
-				$this->wp_cli->shouldReceive( 'success' )->once()->with( 'Dry run finished.' );
+				$this->expect_wp_cli_success( 'Dry run finished.' );
 				$this->wp_cli->shouldReceive( 'confirm' )->never();
 				$this->sut->shouldReceive( 'delete_data' )->never();
 			} else {
@@ -256,7 +246,7 @@ class Uninstall_Command_Test extends \Avatar_Privacy\Tests\TestCase {
 		}
 
 		// Signalling success.
-		$this->wp_cli->shouldReceive( 'success' )->atLeast()->once()->with( m::type( 'string' ) );
+		$this->expect_wp_cli_success( m::type( 'string' ), true );
 
 		// Run test.
 		$this->assertNull( $this->sut->delete_data( $blog_id, $for_site, $global ) );

--- a/tests/avatar-privacy/cli/class-uninstall-command-test.php
+++ b/tests/avatar-privacy/cli/class-uninstall-command-test.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\CLI;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use Avatar_Privacy\CLI\Uninstall_Command;
+
+use Avatar_Privacy\Components\Setup;
+use Avatar_Privacy\Components\Uninstallation;
+use Avatar_Privacy\Data_Storage\Database;
+
+/**
+ * Avatar_Privacy\CLI\Uninstall_Command unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy\CLI\Uninstall_Command
+ * @usesDefaultClass \Avatar_Privacy\CLI\Uninstall_Command
+ *
+ * @uses ::__construct
+ */
+class Uninstall_Command_Test extends \Avatar_Privacy\Tests\TestCase {
+
+	/**
+	 * The system under test.
+	 *
+	 * @var Uninstall_Command
+	 */
+	private $sut;
+
+	/**
+	 * The setup API.
+	 *
+	 * @var Setup
+	 */
+	private $setup;
+
+	/**
+	 * The uninstall API.
+	 *
+	 * @var Uninstallation
+	 */
+	private $uninstall;
+
+	/**
+	 * The database handler.
+	 *
+	 * @var Database
+	 */
+	private $database;
+
+	/**
+	 * Alias mock for static WP_CLI methods.
+	 *
+	 * @var \WP_CLI
+	 */
+	private $wp_cli;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		// API class mock.
+		$this->wp_cli = m::mock( 'alias:' . \WP_CLI::class );
+
+		// Helper mocks.
+		$this->setup     = m::mock( Setup::class );
+		$this->uninstall = m::mock( Uninstallation::class );
+		$this->database  = m::mock( Database::class );
+
+		$this->sut = m::mock(
+			Uninstall_Command::class,
+			[
+				$this->setup,
+				$this->uninstall,
+				$this->database,
+			]
+		)->makePartial()->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * Tests ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$mock = m::mock( Uninstall_Command::class )->makePartial();
+
+		$mock->__construct( $this->setup, $this->uninstall, $this->database );
+
+		$this->assertAttributeSame( $this->setup, 'setup', $mock );
+		$this->assertAttributeSame( $this->uninstall, 'uninstall', $mock );
+		$this->assertAttributeSame( $this->database, 'db', $mock );
+	}
+
+	/**
+	 * Tests ::register.
+	 *
+	 * @covers ::register
+	 */
+	public function test_register() {
+
+		$this->wp_cli->shouldReceive( 'add_command' )->once()->with( 'avatar-privacy uninstall', [ $this->sut, 'uninstall' ] );
+
+		$this->assertNull( $this->sut->register() );
+	}
+
+	/**
+	 * Provides data for testing ::uninstall.
+	 *
+	 * @return array
+	 */
+	public function provide_uninstall_data() {
+		return [
+			// Not --live, not --global.
+			[ false, false, false ],
+			[ false, false, true ],
+			// Not --live, but --global.
+			[ false, true, false ],
+			[ false, true, true ],
+			// --live, not --global.
+			[ true, false, false ],
+			[ true, false, true ],
+			// --live, --global.
+			[ true, true, false ],
+			[ true, true, true ],
+		];
+	}
+
+	/**
+	 * Tests ::uninstall.
+	 *
+	 * @covers ::uninstall
+	 *
+	 * @dataProvider provide_uninstall_data
+	 *
+	 * @param  bool $live         The --live flag.
+	 * @param  bool $global       The --global flag.
+	 * @param  bool $multi        Optional. Whether this is a multisite installation. Default false.
+	 */
+	public function test_uninstall( $live, $global, $multi = false ) {
+		// Parameter arrays.
+		$args       = [];
+		$assoc_args = [
+			'live'   => $live,
+			'global' => $global,
+		];
+
+		// Intermediary data.
+		$blog_id       = 1;
+		$remove_global = $global || ! $multi;
+
+		Functions\expect( 'WP_CLI\Utils\get_flag_value' )->once()->with( $assoc_args, 'live', false )->andReturn( $live );
+		Functions\expect( 'WP_CLI\Utils\get_flag_value' )->once()->with( $assoc_args, 'global', false )->andReturn( $global );
+		Functions\expect( 'is_multisite' )->once()->andReturn( $multi );
+
+		if ( $global && ! $multi ) {
+			// The script ends prematurely.
+			$this->expectException( \RuntimeException::class );
+			$this->wp_cli->shouldReceive( 'error' )->once()->with( m::type( 'string' ) )->andThrow( \RuntimeException::class );
+			$this->sut->shouldReceive( 'print_data_to_delete' )->never();
+			$this->sut->shouldReceive( 'delete_data' )->never();
+		} else {
+			Functions\expect( 'get_current_blog_id' )->once()->andReturn( $blog_id );
+
+			$this->sut->shouldReceive( 'print_data_to_delete' )->once()->with( m::type( 'string' ), $remove_global );
+
+			if ( ! $live ) {
+				// Dry run.
+				$this->wp_cli->shouldReceive( 'warning' )->once()->with( 'Starting dry run.' );
+				$this->wp_cli->shouldReceive( 'success' )->once()->with( 'Dry run finished.' );
+				$this->wp_cli->shouldReceive( 'confirm' )->never();
+				$this->sut->shouldReceive( 'delete_data' )->never();
+			} else {
+				// Modify data.
+				$this->wp_cli->shouldReceive( 'confirm' )->once()->with( m::type( 'string' ), $assoc_args );
+				$this->sut->shouldReceive( 'delete_data' )->once()->with( $blog_id, m::type( 'string' ), $remove_global );
+			}
+		}
+
+		// Run test.
+		$this->assertNull( $this->sut->uninstall( $args, $assoc_args ) );
+	}
+
+	/**
+	 * Provides data for testing ::delete_data.
+	 *
+	 * @return array
+	 */
+	public function provide_delete_data_data() {
+		return [
+			[ false, false ],
+			[ false, true ],
+			[ true, false ],
+			[ true, true ],
+		];
+	}
+
+
+	/**
+	 * Tests ::delete_data.
+	 *
+	 * @covers ::delete_data
+	 *
+	 * @dataProvider provide_delete_data_data
+	 *
+	 * @param  bool $global The --global flag.
+	 * @param  bool $multi  Optional. Whether this is a multisite installation. Default false.
+	 */
+	public function test_delete_data( $global, $multi = false ) {
+		// Input data.
+		$blog_id  = 1;
+		$for_site = $multi ? "for site {$blog_id}" : '';
+
+		// Modify data.
+		$this->setup->shouldReceive( 'deactivate_plugin' )->once();
+		$this->uninstall->shouldReceive( 'enqueue_cleanup_tasks' )->once();
+		Actions\expectDone( 'avatar_privacy_uninstallation_site' )->once()->with( $blog_id );
+
+		if ( $global ) {
+			Functions\expect( 'is_multisite' )->once()->andReturn( $multi );
+			Actions\expectDone( 'avatar_privacy_uninstallation_global' )->once();
+		} else {
+			Functions\expect( 'is_multisite' )->never();
+			Actions\expectDone( 'avatar_privacy_uninstallation_global' )->never();
+		}
+
+		// Signalling success.
+		$this->wp_cli->shouldReceive( 'success' )->atLeast()->once()->with( m::type( 'string' ) );
+
+		// Run test.
+		$this->assertNull( $this->sut->delete_data( $blog_id, $for_site, $global ) );
+	}
+
+	/**
+	 * Provides data for testing ::print_data_to_delete.
+	 *
+	 * @return array
+	 */
+	public function provide_print_data_to_delete_data() {
+		return [
+			[ false, false, false ],
+			[ false, false, true ],
+			[ false, true, false ],
+			[ false, true, true ],
+			[ true, false, false ],
+			[ true, false, true ],
+			[ true, true, false ],
+			[ true, true, true ],
+		];
+	}
+
+	/**
+	 * Tests ::print_data_to_delete.
+	 *
+	 * @covers ::print_data_to_delete
+	 *
+	 * @dataProvider provide_print_data_to_delete_data
+	 *
+	 * @param  bool $global       The --global flag.
+	 * @param  bool $multi        Optional. Whether this is a multisite installation. Default false.
+	 * @param  bool $global_table Optional. Whether the installation uses the global table. Default true.
+	 */
+	public function test_print_data_to_delete( $global, $multi = false, $global_table = true ) {
+		// Input data.
+		$blog_id  = 1;
+		$for_site = $multi ? "for site {$blog_id}" : '';
+
+		// Intermediary data.
+		$table_name = 'fake_table';
+
+		if ( $global ) {
+			Functions\expect( 'is_multisite' )->once()->andReturn( $multi );
+		} else {
+			Functions\expect( 'is_multisite' )->never();
+		}
+
+		$this->database->shouldReceive( 'get_table_name' )->once()->andReturn( $table_name );
+		$this->database->shouldReceive( 'use_global_table' )->once()->andReturn( $global_table );
+
+		// Script output.
+		$this->wp_cli->shouldReceive( 'line' )->atLeast()->once()->with( m::type( 'string' ) );
+
+		// Run test.
+		$this->assertNull( $this->sut->print_data_to_delete( $for_site, $global ) );
+	}
+}

--- a/tests/avatar-privacy/components/class-command-line-interface-test.php
+++ b/tests/avatar-privacy/components/class-command-line-interface-test.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\Components;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use Avatar_Privacy\Components\Command_Line_Interface;
+
+use Avatar_Privacy\CLI\Commmand;
+
+/**
+ * Avatar_Privacy\Components\Command_Line_Interface unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy\Components\Command_Line_Interface
+ * @usesDefaultClass \Avatar_Privacy\Components\Command_Line_Interface
+ *
+ * @uses ::__construct
+ */
+class Command_Line_Interface_Test extends \Avatar_Privacy\Tests\TestCase {
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var Command_Line_Interface
+	 */
+	private $sut;
+
+	/**
+	 * A mocked CLI command.
+	 *
+	 * @var Command
+	 */
+	private $cmd_one;
+
+	/**
+	 * A mocked CLI command.
+	 *
+	 * @var Command
+	 */
+	private $cmd_two;
+
+	/**
+	 * A mocked CLI command.
+	 *
+	 * @var Command
+	 */
+	private $cmd_three;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		// API class mock.
+		$this->wp_cli = m::mock( 'alias:' . \WP_CLI::class );
+
+		$this->cmd_one   = m::mock( Command::class );
+		$this->cmd_two   = m::mock( Command::class );
+		$this->cmd_three = m::mock( Command::class );
+		$commands        = [
+			$this->cmd_one,
+			$this->cmd_two,
+			$this->cmd_three,
+		];
+
+		$this->sut = m::mock( Command_Line_Interface::class, [ $commands ] )->makePartial()->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * Tests ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$commands = [
+			$this->cmd_one,
+			$this->cmd_two,
+			$this->cmd_three,
+		];
+
+		$mock = m::mock( Command_Line_Interface::class )->makePartial();
+
+		$mock->__construct( $commands );
+
+		$this->assertAttributeSame( $commands, 'commands', $mock );
+	}
+
+
+	/**
+	 * Tests ::run.
+	 *
+	 * @covers ::run
+	 */
+	public function test_run() {
+		Actions\expectAdded( 'cli_init' )->once()->with( [ $this->sut, 'register_commands' ] );
+
+		$this->assertNull( $this->sut->run() );
+	}
+
+	/**
+	 * Tests ::register_commands.
+	 *
+	 * @covers ::register_commands
+	 */
+	public function test_register_commands() {
+		$this->cmd_one->shouldReceive( 'register' )->once();
+		$this->cmd_two->shouldReceive( 'register' )->once();
+		$this->cmd_three->shouldReceive( 'register' )->once();
+
+		$this->assertNull( $this->sut->register_commands() );
+	}
+}

--- a/tests/avatar-privacy/components/class-setup-test.php
+++ b/tests/avatar-privacy/components/class-setup-test.php
@@ -504,26 +504,9 @@ class Setup_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::maybe_update_table_data
 	 */
 	public function test_maybe_update_table_data() {
-		global $wpdb;
-		$wpdb                 = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$wpdb->avatar_privacy = 'avatar_privacy';
-		$previous             = '0.4';
-		$rows                 = [
-			(object) [
-				'id'    => 1,
-				'email' => 'mail@foobar.org',
-			],
-			(object) [
-				'id'    => 3,
-				'email' => 'foo@example.org',
-			],
-		];
+		$previous = '0.4';
 
-		$wpdb->shouldReceive( 'get_results' )->once()->with( "SELECT id, email FROM {$wpdb->avatar_privacy} WHERE hash is null" )->andReturn( $rows );
-
-		foreach ( $rows as $r ) {
-			$this->core->shouldReceive( 'update_comment_author_hash' )->once()->with( $r->id, $r->email );
-		}
+		$this->database->shouldReceive( 'maybe_upgrade_table_data' )->once();
 
 		$this->assertNull( $this->sut->maybe_update_table_data( $previous ) );
 	}
@@ -534,13 +517,9 @@ class Setup_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::maybe_update_table_data
 	 */
 	public function test_maybe_update_table_data_no_need() {
-		global $wpdb;
-		$wpdb                 = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$wpdb->avatar_privacy = 'avatar_privacy';
-		$previous             = '0.5';
+		$previous = '0.5';
 
-		$wpdb->shouldReceive( 'get_results' )->never();
-		$this->core->shouldReceive( 'update_comment_author_hash' )->never();
+		$this->database->shouldReceive( 'maybe_upgrade_table_data' )->never();
 
 		$this->assertNull( $this->sut->maybe_update_table_data( $previous ) );
 	}

--- a/tests/avatar-privacy/components/class-uninstallation-test.php
+++ b/tests/avatar-privacy/components/class-uninstallation-test.php
@@ -268,6 +268,7 @@ class Uninstallation_Test extends \Avatar_Privacy\Tests\TestCase {
 		Functions\expect( 'delete_metadata' )->once()->with( 'user', 0, Core::GRAVATAR_USE_META_KEY, null, true );
 		Functions\expect( 'delete_metadata' )->once()->with( 'user', 0, Core::ALLOW_ANONYMOUS_META_KEY, null, true );
 		Functions\expect( 'delete_metadata' )->once()->with( 'user', 0, Core::USER_AVATAR_META_KEY, null, true );
+		Functions\expect( 'delete_metadata' )->once()->with( 'user', 0, Core::EMAIL_HASH_META_KEY, null, true );
 
 		$this->assertNull( $this->sut->delete_user_meta() );
 	}

--- a/tests/avatar-privacy/components/class-uninstallation-test.php
+++ b/tests/avatar-privacy/components/class-uninstallation-test.php
@@ -165,6 +165,20 @@ class Uninstallation_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::run
 	 */
 	public function test_run() {
+		$this->sut->shouldReceive( 'enqueue_cleanup_tasks' )->once();
+		$this->sut->shouldReceive( 'do_site_cleanups' )->once();
+
+		Actions\expectDone( 'avatar_privacy_uninstallation_global' )->once();
+
+		$this->assertNull( $this->sut->run() );
+	}
+
+	/**
+	 * Tests ::enqueue_cleanup_tasks.
+	 *
+	 * @covers ::enqueue_cleanup_tasks
+	 */
+	public function test_enqeueu_cleanup_tasks() {
 		Actions\expectAdded( 'avatar_privacy_uninstallation_global' )->once()->with( [ $this->file_cache, 'invalidate' ], m::type( 'int' ), 0 );
 		Actions\expectAdded( 'avatar_privacy_uninstallation_global' )->once()->with( [ $this->sut, 'delete_uploaded_avatars' ], m::type( 'int' ), 0 );
 
@@ -182,10 +196,7 @@ class Uninstallation_Test extends \Avatar_Privacy\Tests\TestCase {
 		// Drop all our tables.
 		Actions\expectAdded( 'avatar_privacy_uninstallation_site' )->once()->with( [ $this->database, 'drop_table' ], m::type( 'int' ), 1 );
 
-		$this->sut->shouldReceive( 'do_site_cleanups' )->once();
-		Actions\expectDone( 'avatar_privacy_uninstallation_global' )->once();
-
-		$this->assertNull( $this->sut->run() );
+		$this->assertNull( $this->sut->enqueue_cleanup_tasks() );
 	}
 
 	/**

--- a/tests/avatar-privacy/data-storage/class-database-test.php
+++ b/tests/avatar-privacy/data-storage/class-database-test.php
@@ -572,6 +572,10 @@ class Database_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * Tests ::prepare_insert_update_query.
 	 *
 	 * @covers ::prepare_insert_update_query
+	 *
+	 * @uses Avatar_Privacy\Data_Storage\Database::get_placeholders
+	 * @uses Avatar_Privacy\Data_Storage\Database::get_prepared_values
+	 * @uses Avatar_Privacy\Data_Storage\Database::get_update_clause
 	 */
 	public function test_prepare_insert_update_query() {
 		global $wpdb;
@@ -711,6 +715,179 @@ class Database_Test extends \Avatar_Privacy\Tests\TestCase {
 		$wpdb->shouldReceive( 'prepare' )->never();
 
 		$this->assertSame( $result, $this->sut->prepare_insert_update_query( $rows_to_update, $rows_to_migrate, $table_name ) );
+	}
+
+	/**
+	 * Tests ::prepare_insert_update_query.
+	 *
+	 * @covers ::prepare_insert_update_query
+	 */
+	public function test_prepare_insert_update_query_no_valid_fields() {
+		global $wpdb;
+		$wpdb            = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$network_id      = 5;
+		$site_id         = 3;
+		$rows_to_update  = [
+			3  => (object) [
+				'id'           => 1,
+				'email'        => 'foo@bar.org',
+				'hash'         => 'hash',
+				'last_updated' => '2018-12-17 22:23:08',
+				'log_message'  => "set with comment 8 (site: {$network_id}, blog: {$site_id})",
+				'use_gravatar' => 1,
+			],
+			11 => (object) [
+				'id'           => 7,
+				'email'        => 'xxx@foobar.org',
+				'hash'         => 'hash',
+				'last_updated' => '2018-12-19 10:00:00',
+				'log_message'  => "set with comment 8 (site: {$network_id}, blog: {$site_id})",
+				'use_gravatar' => 1,
+			],
+		];
+		$rows_to_migrate = [
+			(object) [
+				'id'           => 32,
+				'email'        => 'foobar@bar.org',
+				'hash'         => 'hash',
+				'last_updated' => '2018-12-18 10:00:00',
+				'log_message'  => "set with comment 8 (site: {$network_id}, blog: {$site_id})",
+				'use_gravatar' => 0,
+			],
+			(object) [
+				'id'           => 33,
+				'email'        => 'bar@foo.org',
+				'hash'         => 'hash',
+				'last_updated' => '2018-12-18 10:00:00',
+				'log_message'  => "set with comment 8 (site: {$network_id}, blog: {$site_id})",
+				'use_gravatar' => 1,
+			],
+			(object) [
+				'id'           => 66,
+				'email'        => 'x@foobar.org',
+				'hash'         => 'hash',
+				'last_updated' => '2018-12-18 10:00:00',
+				'log_message'  => "set with comment 8 (site: {$network_id}, blog: {$site_id})",
+				'use_gravatar' => 0,
+			],
+		];
+		$table_name      = 'foobar';
+		$fields          = [ 'foobar' ];
+		$result          = false;
+
+		$wpdb->shouldReceive( 'prepare' )->never();
+
+		$this->assertSame( $result, $this->sut->prepare_insert_update_query( $rows_to_update, $rows_to_migrate, $table_name, $fields ) );
+	}
+
+	/**
+	 * Provides data for testing get_update_clause.
+	 *
+	 * @return array
+	 */
+	public function provide_get_update_clause_data() {
+		return [
+			[
+				[ 'email', 'hash', 'use_gravatar' ],
+				"email = VALUES(email),\nhash = VALUES(hash),\nuse_gravatar = VALUES(use_gravatar),\nlast_updated = last_updated,\nlog_message = log_message",
+			],
+			[
+				[ 'log_message' ],
+				"email = email,\nhash = hash,\nuse_gravatar = use_gravatar,\nlast_updated = last_updated,\nlog_message = VALUES(log_message)",
+			],
+			[
+				[ 'email', 'hash', 'use_gravatar', 'last_updated', 'log_message' ],
+				"email = VALUES(email),\nhash = VALUES(hash),\nuse_gravatar = VALUES(use_gravatar),\nlast_updated = VALUES(last_updated),\nlog_message = VALUES(log_message)",
+			],
+
+		];
+	}
+
+	/**
+	 * Tests ::get_update_clause.
+	 *
+	 * @covers ::get_update_clause
+	 *
+	 * @dataProvider provide_get_update_clause_data
+	 *
+	 * @param string[] $fields  A list of columns.
+	 * @param string   $result  The expected result.
+	 */
+	public function test_get_update_clause( array $fields, $result ) {
+		$this->assertSame( $result, $this->sut->get_update_clause( $fields ) );
+	}
+
+	/**
+	 * Tests ::get_prepared_values.
+	 *
+	 * @covers ::get_prepared_values
+	 */
+	public function test_get_prepared_values() {
+		$network_id = 5;
+		$site_id    = 3;
+		$rows       = [
+			3  => (object) [
+				'id'           => 1,
+				'email'        => 'foo@bar.org',
+				'hash'         => 'hash',
+				'last_updated' => '2018-12-17 22:23:08',
+				'log_message'  => "set with comment 8 (site: {$network_id}, blog: {$site_id})",
+				'use_gravatar' => 1,
+			],
+			11 => (object) [
+				'id'           => 7,
+				'email'        => 'xxx@foobar.org',
+				'hash'         => 'hash',
+				'last_updated' => '2018-12-19 10:00:00',
+				'log_message'  => "set with comment 8 (site: {$network_id}, blog: {$site_id})",
+				'use_gravatar' => 1,
+			],
+		];
+		$fields     = [
+			'email',
+			'use_gravatar',
+			'last_updated',
+		];
+		$result     = [
+			3, // real ID.
+			'foo@bar.org',
+			1, // use_gravatar.
+			'2018-12-17 22:23:08',
+			11, // real ID.
+			'xxx@foobar.org',
+			1, // use_gravatar.
+			'2018-12-19 10:00:00',
+		];
+
+		$this->assertSame( $result, $this->sut->get_prepared_values( $rows, $fields, true ) );
+	}
+
+	/**
+	 * Provides data for testing get_placeholders.
+	 *
+	 * @return array
+	 */
+	public function provide_get_placeholders_data() {
+		return [
+			[ [ 'email', 'hash', 'use_gravatar' ], true, '(%d,%s,%s,%d)' ],
+			[ [ 'email', 'hash', 'use_gravatar' ], false, '(NULL,%s,%s,%d)' ],
+			[ [ 'email', 'hash', 'use_gravatar', 'last_updated', 'log_message' ], true, '(%d,%s,%s,%d,%s,%s)' ],
+		];
+	}
+
+	/**
+	 * Tests ::get_placeholders.
+	 *
+	 * @covers ::get_placeholders
+	 *
+	 * @dataProvider provide_get_placeholders_data
+	 *
+	 * @param string[] $fields  A list of columns.
+	 * @param bool     $with_id Whether the ID should be included.
+	 * @param string   $result  The expected result.
+	 */
+	public function test_get_placeholders( array $fields, $with_id, $result ) {
+		$this->assertSame( $result, $this->sut->get_placeholders( $fields, $with_id ) );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -63,6 +63,12 @@ if ( ! defined( 'COOKIE_DOMAIN' ) ) {
 if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', 'wordpress/path/' );
 }
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+if ( ! defined( 'ARRAY_N' ) ) {
+	define( 'ARRAY_N', 'ARRAY_N' );
+}
 if ( ! defined( 'OBJECT' ) ) {
 	define( 'OBJECT', 'OBJECT' );
 }


### PR DESCRIPTION
Adds commands:
- [x] `wp avatar-privacy db show`
- [x] `wp avatar-privacy db list`
- [x] `wp avatar-privacy db create`
- [x] `wp avatar-privacy db upgrade`
- [x] `wp avatar-privacy uninstall`
- [x] `wp avatar-privacy cron list`
- [x] `wp avatar-privacy cron delete`

Fixes #94.