### PR TITLE
Add support for Ultimate Member plugin

### DIFF
--- a/admin/partials/profile/user-avatar-upload.php
+++ b/admin/partials/profile/user-avatar-upload.php
@@ -30,17 +30,21 @@ use Avatar_Privacy\Tools\Template;
 /**
  * Required template variables:
  *
- * @var string $nonce          The nonce itself.
- * @var string $action         The nonce action.
- * @var string $upload_field   The name of the uploader `<input>` element.
- * @var string $erase_field    The name of the erase checkbox `<input>` element.
- * @var int    $user_id        The ID of the edited user.
- * @var string $current_avatar The previously set user avatar.
- * @var bool   $can_upload     Whether the currently active user can upload files.
- * @var int    $size           The width/height of the avatar preview image (in pixels).
+ * @var string $nonce            The nonce itself.
+ * @var string $action           The nonce action.
+ * @var string $upload_field     The name of the uploader `<input>` element.
+ * @var string $erase_field      The name of the erase checkbox `<input>` element.
+ * @var int    $user_id          The ID of the edited user.
+ * @var string $current_avatar   The previously set user avatar.
+ * @var bool   $can_upload       Whether the currently active user can upload files.
+ * @var bool   $uploads_disabled Whether the uploads system has been disabled completely..
+ * @var int    $size             The width/height of the avatar preview image (in pixels).
  */
 
-if ( $can_upload ) {
+if ( $uploads_disabled ) {
+	// We integrate with some other plugin, so skip the description.
+	$description = '';
+} elseif ( $can_upload ) {
 	if ( empty( $current_avatar ) ) {
 		$description = \sprintf(
 			/* translators: 1: gravatar.com URL, 2: rel attribute, 3: target attribute */

--- a/includes/avatar-privacy/class-factory.php
+++ b/includes/avatar-privacy/class-factory.php
@@ -57,6 +57,7 @@ use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generated_Icons;
 use Avatar_Privacy\Avatar_Handlers\Default_Icons\Static_Icons;
 
 use Avatar_Privacy\Integrations\BBPress_Integration;
+use Avatar_Privacy\Integrations\Ultimate_Member_Integration;
 use Avatar_Privacy\Integrations\WPDiscuz_Integration;
 use Avatar_Privacy\Integrations\WP_User_Manager_Integration;
 
@@ -407,6 +408,7 @@ class Factory extends Dice {
 	protected function get_plugin_integrations() {
 		return [
 			[ 'instance' => BBPress_Integration::class ],
+			[ 'instance' => Ultimate_Member_Integration::class ],
 			[ 'instance' => WPDiscuz_Integration::class ],
 			[ 'instance' => WP_User_Manager_Integration::class ],
 		];

--- a/includes/avatar-privacy/integrations/class-ultimate-member-integration.php
+++ b/includes/avatar-privacy/integrations/class-ultimate-member-integration.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Integrations;
+
+use Avatar_Privacy\Core;
+use Avatar_Privacy\Upload_Handlers\User_Avatar_Upload_Handler;
+
+/**
+ * An integration for Ultimate Member.
+ *
+ * @since      2.3.0
+ * @author     Peter Putzer <github@mundschenk.at>
+ */
+class Ultimate_Member_Integration implements Plugin_Integration {
+
+	/**
+	 * The avatar upload handler.
+	 *
+	 * @var User_Avatar_Upload_Handler
+	 */
+	private $upload;
+
+	/**
+	 * Creates a new instance.
+	 *
+	 * @param User_Avatar_Upload_Handler $upload  The avatar upload handler.
+	 */
+	public function __construct( User_Avatar_Upload_Handler $upload ) {
+		$this->upload = $upload;
+	}
+
+	/**
+	 * Check if the Ultimate Member integration should be activated.
+	 *
+	 * @return bool
+	 */
+	public function check() {
+		return \class_exists( \UM::class ) && \function_exists( 'um_get_user_avatar_data' );
+	}
+
+	/**
+	 * Activate the integration.
+	 */
+	public function run() {
+		// Integrate with Ultimate Member's avatar handling.
+		\add_action( 'init', [ $this, 'integrate_with_ultimate_member_avatars' ] );
+
+		// Disable Ultimate Member's 'use_gravatars' setting a bit earlier to be sure..
+		\add_filter( 'um_settings_structure',    [ $this, 'remove_ultimate_member_gravatar_settings' ], 10, 1 );
+		\add_filter( 'um_options_use_gravatars', '__return_false',                                      10, 1 );
+	}
+
+	/**
+	 * Removes the Ultimate Member avatar filter and disables Avatar Privacy
+	 * profile image upload.
+	 */
+	public function integrate_with_ultimate_member_avatars() {
+		// Remove Ultimate Member avatar filter.
+		\remove_filter( 'get_avatar', 'um_get_avatar', 99999 );
+
+		// Disable profile image uploading.
+		\add_filter( 'avatar_privacy_profile_picture_upload_disabled', '__return_true', 10, 0 );
+
+		// Serve Ultime Member profile pictures via the filesystem cache.
+		\add_filter( 'avatar_privacy_pre_get_user_avatar', [ $this, 'enable_ultimate_member_user_avatars' ],      10, 2 );
+
+		// Invalidate cache when a new image is uploaded.
+		\add_action( 'um_after_upload_db_meta_profile_photo', [ $this->upload, 'invalidate_user_avatar_cache' ], 10, 1 );
+	}
+
+	/**
+	 * Filters the Ultimate Member settings structure to remove conflicting checkboxes
+	 * on Gravatar use.
+	 *
+	 * @param  array $settings_structure The settings page definition.
+	 *
+	 * @return array
+	 */
+	public function remove_ultimate_member_gravatar_settings( array $settings_structure ) {
+		if (
+			isset( $settings_structure['']['sections']['users']['fields'] ) &&
+			\is_array( $settings_structure['']['sections']['users']['fields'] )
+		) {
+			foreach ( $settings_structure['']['sections']['users']['fields'] as &$field ) {
+				if ( 'use_gravatars' === $field['id'] ) {
+					// Make conditional on non-existing setting (hiding it).
+					$field['conditional'] = [ 'avatar_privacy_active', '=', 0 ];
+
+					// That's all.
+					break;
+				}
+			}
+		}
+
+		return $settings_structure;
+	}
+
+	/**
+	 * Retrieves the user avatar from Ultimate Member.
+	 *
+	 * @param  array|null $avatar  Optional. The user avatar information. Default null.
+	 * @param  int        $user_id The user ID.
+	 *
+	 * @return array|null {
+	 *     Optional. The user avatar information. Default null.
+	 *
+	 *     @type string $file The local filename.
+	 *     @type string $type The MIME type.
+	 * }
+	 */
+	public function enable_ultimate_member_user_avatars( array $avatar = null, $user_id ) {
+		// Retrieve Ultimate Member user data.
+		\add_filter( 'um_filter_avatar_cache_time', '__return_null' );
+		$um_profile = /* @scrutinizer ignore-call */ \um_get_user_avatar_data( $user_id, 'original' );
+		\remove_filter( 'um_filter_avatar_cache_time', '__return_null' );
+
+		if ( empty( $um_profile['type'] ) || 'upload' !== $um_profile['type'] || empty( $um_profile['url'] ) ) {
+			return null;
+		}
+
+		$file = \ABSPATH . \wp_make_link_relative( $um_profile['url'] );
+		$type = \wp_check_filetype( $file )['type'];
+
+		return [
+			'file' => $file,
+			'type' => $type,
+		];
+	}
+}

--- a/includes/avatar-privacy/tools/html/class-user-form.php
+++ b/includes/avatar-privacy/tools/html/class-user-form.php
@@ -214,7 +214,17 @@ class User_Form {
 		$upload_field   = $this->user_avatar['field'];
 		$erase_field    = $this->user_avatar['erase'];
 		$current_avatar = \get_user_meta( $user_id, Core::USER_AVATAR_META_KEY, true );
-		$can_upload     = \current_user_can( 'upload_files' );
+
+		/**
+		 * Filters whether native profile picture uploading is disabled for some
+		 * reasone (e.g. because another plugin already provides for that).
+		 *
+		 * @since 2.3.0
+		 *
+		 * @param bool $disabled Default false.
+		 */
+		$uploads_disabled = \apply_filters( 'avatar_privacy_profile_picture_upload_disabled', false );
+		$can_upload       = empty( $uploads_disabled ) && \current_user_can( 'upload_files' );
 
 		// Merge default arguments.
 		$args = \wp_parse_args( $args, [

--- a/public/partials/bbpress/profile/user-avatar-upload.php
+++ b/public/partials/bbpress/profile/user-avatar-upload.php
@@ -29,16 +29,20 @@ use Avatar_Privacy\Tools\Template;
 /**
  * Required template variables:
  *
- * @var string $nonce          The nonce itself.
- * @var string $action         The nonce action.
- * @var string $upload_field   The name of the uploader `<input>` element.
- * @var string $erase_field    The name of the erase checkbox `<input>` element.
- * @var int    $user_id        The ID of the edited user.
- * @var string $current_avatar The previously set user avatar.
- * @var bool   $can_upload     Whether the currently active user can upload files.
+ * @var string $nonce            The nonce itself.
+ * @var string $action           The nonce action.
+ * @var string $upload_field     The name of the uploader `<input>` element.
+ * @var string $erase_field      The name of the erase checkbox `<input>` element.
+ * @var int    $user_id          The ID of the edited user.
+ * @var string $current_avatar   The previously set user avatar.
+ * @var bool   $can_upload       Whether the currently active user can upload files.
+ * @var bool   $uploads_disabled Whether the uploads system has been disabled completely..
  */
 
-if ( $can_upload ) {
+if ( $uploads_disabled ) {
+	// We integrate with some other plugin, so skip the description.
+	$description = '';
+} elseif ( $can_upload ) {
 	if ( empty( $current_avatar ) ) {
 		$description = \sprintf(
 			/* translators: 1: gravatar.com URL, 2: rel attribute, 3: target attribute */

--- a/public/partials/profile/user-avatar-upload.php
+++ b/public/partials/profile/user-avatar-upload.php
@@ -38,11 +38,15 @@ use Avatar_Privacy\Tools\Template;
  * @var int    $user_id          The ID of the edited user.
  * @var string $current_avatar   The previously set user avatar.
  * @var bool   $can_upload       Whether the currently active user can upload files.
+ * @var bool   $uploads_disabled Whether the uploads system has been disabled completely..
  * @var int    $size             The width/height of the avatar preview image (in pixels).
  * @var string $show_description True if the long description should be displayed.
  */
 
-if ( $can_upload ) {
+if ( $uploads_disabled ) {
+	// We integrate with some other plugin, so skip the description.
+	$description = '';
+} elseif ( $can_upload ) {
 	if ( empty( $current_avatar ) ) {
 		$description = \sprintf(
 			/* translators: 1: gravatar.com URL, 2: rel attribute, 3: target attribute */

--- a/tests/avatar-privacy/integrations/class-ultimate-member-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-ultimate-member-integration-test.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2019 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests\Avatar_Privacy\Integrations;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+use org\bovigo\vfs\vfsStream;
+
+use Avatar_Privacy\Integrations\Ultimate_Member_Integration;
+
+use Avatar_Privacy\Upload_Handlers\User_Avatar_Upload_Handler;
+
+
+/**
+ * Avatar_Privacy\Integrations\Ultimate_Member_Integration unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy\Integrations\Ultimate_Member_Integration
+ * @usesDefaultClass \Avatar_Privacy\Integrations\Ultimate_Member_Integration
+ *
+ * @uses ::__construct
+ */
+class Ultimate_Member_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var Ultimate_Member_Integration
+	 */
+	private $sut;
+
+	/**
+	 * Mocked helper object.
+	 *
+	 * @var User_Avatar_Upload_Handler
+	 */
+	private $upload;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$this->upload = m::mock( User_Avatar_Upload_Handler::class );
+
+		$this->sut = m::mock( Ultimate_Member_Integration::class, [ $this->upload ] )->makePartial()->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * Tests ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$mock = m::mock( Ultimate_Member_Integration::class )->makePartial();
+
+		$mock->__construct( $this->upload );
+
+		$this->assertAttributeSame( $this->upload, 'upload', $mock );
+	}
+
+	/**
+	 * Tests ::check.
+	 *
+	 * @covers ::check
+	 */
+	public function test_check() {
+		$this->assertFalse( $this->sut->check() );
+
+		$fake_plugin = m::mock( \UM::class );
+		Functions\when( 'um_get_user_avatar_data' )->justReturn( true );
+
+		$this->assertTrue( $this->sut->check() );
+	}
+
+	/**
+	 * Tests ::run.
+	 *
+	 * @covers ::run
+	 */
+	public function test_run() {
+		Actions\expectAdded( 'init' )->once()->with( [ $this->sut, 'integrate_with_ultimate_member_avatars' ] );
+
+		Filters\expectAdded( 'um_settings_structure' )->once()->with( [ $this->sut, 'remove_ultimate_member_gravatar_settings' ], 10, 1 );
+		Filters\expectAdded( 'um_options_use_gravatars' )->once()->with( '__return_false', 10, 1 );
+
+		$this->assertNull( $this->sut->run() );
+	}
+
+	/**
+	 * Tests ::integrate_with_ultimate_member_avatars.
+	 *
+	 * @covers ::integrate_with_ultimate_member_avatars
+	 */
+	public function test_integrate_with_ultimate_member_avatars() {
+
+		Filters\expectRemoved( 'get_avatar' )->once()->with( 'um_get_avatar', m::type( 'int' ) );
+		Filters\expectAdded( 'avatar_privacy_profile_picture_upload_disabled' )->once()->with( '__return_true', 10, 0 );
+		Filters\expectAdded( 'avatar_privacy_pre_get_user_avatar' )->once()->with( [ $this->sut, 'enable_ultimate_member_user_avatars' ], 10, 2 );
+		Actions\expectAdded( 'um_after_upload_db_meta_profile_photo' )->once()->with( [ $this->upload, 'invalidate_user_avatar_cache' ], 10, 1 );
+
+		$this->assertNull( $this->sut->integrate_with_ultimate_member_avatars() );
+	}
+
+	/**
+	 * Tests ::remove_ultimate_member_gravatar_settings.
+	 *
+	 * @covers ::remove_ultimate_member_gravatar_settings
+	 */
+	public function test_remove_ultimate_member_gravatar_settings() {
+		$structure = [
+			'' => [
+				'sections' => [
+					'foo'   => [],
+					'users' => [
+						'fields' => [
+							[ 'id' => 'foobar' ],
+							[ 'id' => 'use_gravatars' ],
+							[ 'id' => 'barfoo' ],
+						],
+					],
+				],
+			],
+		];
+
+		$conditional = [ 'avatar_privacy_active', '=', 0 ];
+
+		$result = $this->sut->remove_ultimate_member_gravatar_settings( $structure );
+
+		$this->assertInternalType( 'array', $result );
+		$this->assertNotEmpty( $result['']['sections']['users']['fields'] );
+		$this->assertInternalType( 'array', $result['']['sections']['users']['fields'] );
+		$this->assertContains( $conditional, $result['']['sections']['users']['fields'][1] );
+	}
+
+	/**
+	 * Tests ::enable_ultimate_member_user_avatars.
+	 *
+	 * @covers ::enable_ultimate_member_user_avatars
+	 */
+	public function test_enable_ultimate_member_user_avatars() {
+		// Input.
+		$user_id = 42;
+
+		// Intermediary.
+		$file      = 'some/file';
+		$url       = "https://foobar/{$file}";
+		$type      = 'mime/type';
+		$um_avatar = [
+			'url'  => $url,
+			'type' => 'upload',
+		];
+		$absfile   = \ABSPATH . $file;
+
+		// Expected result.
+		$result = [
+			'file' => $absfile,
+			'type' => $type,
+		];
+
+		Filters\expectAdded( 'um_filter_avatar_cache_time' )->once()->with( '__return_null' );
+		Functions\expect( 'um_get_user_avatar_data' )->once()->with( $user_id, 'original' )->andReturn( $um_avatar );
+		Filters\expectRemoved( 'um_filter_avatar_cache_time' )->once()->with( '__return_null' );
+
+		Functions\expect( 'wp_make_link_relative' )->once()->with( $url )->andReturn( $file );
+		Functions\expect( 'wp_check_filetype' )->once()->with( $absfile )->andReturn( [ 'type' => $type ] );
+
+		$this->assertSame( $result, $this->sut->enable_ultimate_member_user_avatars( null, $user_id ) );
+	}
+
+	/**
+	 * Tests ::enable_ultimate_member_user_avatars.
+	 *
+	 * @covers ::enable_ultimate_member_user_avatars
+	 */
+	public function test_enable_ultimate_member_user_avatars_no_avatar() {
+		// Input.
+		$user_id = 42;
+
+		// Intermediary.
+		$file      = 'some/file';
+		$url       = "https://foobar/{$file}";
+		$um_avatar = [
+			'url'  => $url,
+		];
+
+		Filters\expectAdded( 'um_filter_avatar_cache_time' )->once()->with( '__return_null' );
+		Functions\expect( 'um_get_user_avatar_data' )->once()->with( $user_id, 'original' )->andReturn( $um_avatar );
+		Filters\expectRemoved( 'um_filter_avatar_cache_time' )->once()->with( '__return_null' );
+
+		Functions\expect( 'wp_make_link_relative' )->never();
+		Functions\expect( 'wp_check_filetype' )->never();
+
+		$this->assertNull( $this->sut->enable_ultimate_member_user_avatars( null, $user_id ) );
+	}
+}

--- a/tests/avatar-privacy/tools/html/class-user-form-test.php
+++ b/tests/avatar-privacy/tools/html/class-user-form-test.php
@@ -223,6 +223,9 @@ class User_Form_Test extends \Avatar_Privacy\Tests\TestCase {
 			]
 		);
 
+		// FIXME: We should check for template variables.
+		Filters\expectApplied( 'avatar_privacy_profile_picture_upload_disabled' )->once()->with( false )->andReturn( false );
+
 		Functions\expect( 'get_user_meta' )->once()->with( $user_id,  Core::USER_AVATAR_META_KEY, true )->andReturn( [ 'fake avatar' ] );
 		Functions\expect( 'current_user_can' )->once()->with( 'upload_files' )->andReturn( true );
 		Functions\expect( 'wp_parse_args' )->once()->with(


### PR DESCRIPTION
- Profile image uploading can now be disabled via `avatar_privacy_profile_picture_upload_disabled` hook.
- Ultimate Member `use_gravatars` setting is hidden when Avatar Privacy is activated.
- Ultimate Member profile pictures are served via the Avatar Privacy filesystem cache.

Fixes #119. 