### PR TITLE
Better comment form styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Changelog
 
 ## 2.3.0 (unreleased)
-*   _Feature_: New template function `\Avatar_Privacy\gravatar_checkbox()` for legacy themes added.
+*   _Feature_: New template function `\Avatar_Privacy\gravatar_checkbox()` for
+    legacy themes added.
 *   _Change_: `avapr_get_avatar_checkbox()` has been deprecated in favor of
     `\Avatar_Privacy\get_gravatar_checkbox()`.
+*   _Change_: The ID and name of the `use_gravatar` comment form checkbox has been
+    changed to `avatar-privacy-use-gravatar`. Please update custom CSS rules accordingly.
+*   _Change_: Additional inline styling is added to the `avatar-privacy-use-gravatar`
+    comment form checkbox to work around common theme limitations. Styling can be
+    disabled using the `avatar_privacy_comment_checkbox_disable_inline_style`
+    filter hook.
 
 ## 2.2.1 (2019-06-08)
 *   _Bugfix_: Compatibility with Windows servers.

--- a/includes/avatar-privacy/components/class-comments.php
+++ b/includes/avatar-privacy/components/class-comments.php
@@ -40,7 +40,7 @@ class Comments implements \Avatar_Privacy\Component {
 	/**
 	 * The name of the checkbox field in the comment form.
 	 */
-	const CHECKBOX_FIELD_NAME = 'use_gravatar';
+	const CHECKBOX_FIELD_NAME = 'avatar-privacy-use-gravatar';
 
 	/**
 	 * The prefix of the comment cookie (COOKIEHASH is added at the end).

--- a/public/partials/comments/use-gravatar.php
+++ b/public/partials/comments/use-gravatar.php
@@ -48,7 +48,11 @@ if ( isset( $_POST[ Comments::CHECKBOX_FIELD_NAME ] ) ) { // phpcs:ignore WordPr
 }
 ?>
 <p class="comment-form-use-gravatar">
-	<input id="<?php echo \esc_attr( Comments::CHECKBOX_FIELD_NAME ); ?>" name="<?php echo \esc_attr( Comments::CHECKBOX_FIELD_NAME ); ?>" type="checkbox" value="true" <?php \checked( $is_checked, true ); ?> /><label
+	<input id="<?php echo \esc_attr( Comments::CHECKBOX_FIELD_NAME ); ?>" name="<?php echo \esc_attr( Comments::CHECKBOX_FIELD_NAME ); ?>" type="checkbox" value="true" <?php \checked( $is_checked, true ); ?>
+	<?php if ( ! $disable_style ) : ?>
+		style="margin-right:1ex;"
+	<?php endif; ?>
+	/><label
 	<?php if ( ! $disable_style ) : ?>
 		style="display:inline;"
 	<?php endif; ?>


### PR DESCRIPTION
- Renames `use_gravatar` checkbox to `avatar-privacy-use-gravatar`.
- Adds `margin-right:1ex;` to checkbox unless `avatar_privacy_comment_checkbox_disable_inline_style` returns `true`.

Fixes #127.