### PR TITLE
Miscellaneous code fixes

### DIFF
--- a/admin/partials/profile/use-gravatar.php
+++ b/admin/partials/profile/use-gravatar.php
@@ -47,7 +47,7 @@ use Avatar_Privacy\Tools\Template;
 			value="true"
 			<?php \checked( $value ); ?>
 		/>
-		<label for="<?php echo \esc_attr( $field_name ); ?>"><?php echo \wp_kses( sprintf( /* translators: 1: gravatar.com URL, 2: rel attribute, 3: target attribute */ \__( 'Display a <a href="%1$s" rel="%2$s" target="%3$s">Gravatar</a> image for my e-mail address.', 'avatar-privacy' ), \__( 'https://en.gravatar.com/', 'avatar-privacy' ), Template::get_gravatar_link_rel(), Template::get_gravatar_link_target() ), Template::ALLOWED_HTML_LABEL ); ?></label><br />
+		<label for="<?php echo \esc_attr( $field_name ); ?>"><?php echo \wp_kses( \sprintf( /* translators: 1: gravatar.com URL, 2: rel attribute, 3: target attribute */ \__( 'Display a <a href="%1$s" rel="%2$s" target="%3$s">Gravatar</a> image for my e-mail address.', 'avatar-privacy' ), \__( 'https://en.gravatar.com/', 'avatar-privacy' ), Template::get_gravatar_link_rel(), Template::get_gravatar_link_target() ), Template::ALLOWED_HTML_LABEL ); ?></label><br />
 		<p class="description">
 			<?php \esc_html_e( "Uncheck this box if you don't want to display the gravatar for your e-mail address (or don't have an account on Gravatar.com).", 'avatar-privacy' ); ?>
 			<?php \esc_html_e( 'This setting will only take effect if you have not uploaded a local profile picture.', 'avatar-privacy' ); ?>

--- a/includes/avatar-privacy/avatar-handlers/default-icons/class-static-icon-provider.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/class-static-icon-provider.php
@@ -69,6 +69,6 @@ class Static_Icon_Provider extends Abstract_Icon_Provider {
 	public function get_icon_url( $identity, $size ) {
 		$use_size = ( $size > 64 ) ? '128' : '64';
 
-		return plugins_url( "public/images/{$this->icon_basename}-{$use_size}.png", \AVATAR_PRIVACY_PLUGIN_FILE );
+		return \plugins_url( "public/images/{$this->icon_basename}-{$use_size}.png", \AVATAR_PRIVACY_PLUGIN_FILE );
 	}
 }

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-retro.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-retro.php
@@ -88,8 +88,10 @@ class Retro implements Generator {
 		$result = $this->identicon->getImageData(
 			$seed,
 			$size,
-			/* @scrutinizer ignore-type */ RandomColor::one( [ 'luminosity' => 'bright' ] ),
-			/* @scrutinizer ignore-type */ RandomColor::one( [ 'luminosity' => 'light' ] )
+			/* @scrutinizer ignore-type */
+			RandomColor::one( [ 'luminosity' => 'bright' ] ),
+			/* @scrutinizer ignore-type */
+			RandomColor::one( [ 'luminosity' => 'light' ] )
 		);
 
 		// Restore randomness.

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-retro.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-retro.php
@@ -28,6 +28,8 @@ namespace Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators;
 
 use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generator;
 
+use Avatar_Privacy\Tools\Number_Generator;
+
 use Colors\RandomColor;
 
 /**
@@ -48,14 +50,26 @@ class Retro implements Generator {
 	private $identicon;
 
 	/**
+	 * The random number generator.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @var Number_Generator
+	 */
+	protected $number_generator;
+
+	/**
 	 * Creates a new instance.
 	 *
-	 * @since 2.1.0 Parameter $identicon added.
+	 * @since 2.1.0 Parameter `$identicon` added.
+	 * @since 2.3.0 Parameter `$number_generator` added.
 	 *
-	 * @param \Identicon\Identicon $identicon The identicon implementation.
+	 * @param \Identicon\Identicon $identicon        The identicon implementation.
+	 * @param Number_Generator     $number_generator A pseudo-random number generator.
 	 */
-	public function __construct( \Identicon\Identicon $identicon ) {
-		$this->identicon = $identicon;
+	public function __construct( \Identicon\Identicon $identicon, Number_Generator $number_generator ) {
+		$this->identicon        = $identicon;
+		$this->number_generator = $number_generator;
 	}
 
 	/**
@@ -68,7 +82,7 @@ class Retro implements Generator {
 	 */
 	public function build( $seed, $size = 128 ) {
 		// Initialize random number with seed.
-		\mt_srand( (int) \hexdec( \substr( $seed, 0, 8 ) ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_seeding_mt_srand -- we need deterministic "random" numbers.
+		$this->number_generator->seed( $seed );
 
 		// Generate icon.
 		$result = $this->identicon->getImageData(
@@ -79,7 +93,7 @@ class Retro implements Generator {
 		);
 
 		// Restore randomness.
-		\mt_srand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_seeding_mt_srand
+		$this->number_generator->reset();
 
 		return $result;
 	}

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-retro.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-retro.php
@@ -68,7 +68,7 @@ class Retro implements Generator {
 	 */
 	public function build( $seed, $size = 128 ) {
 		// Initialize random number with seed.
-		\mt_srand( (int) hexdec( substr( $seed, 0, 8 ) ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_seeding_mt_srand -- we need deterministic "random" numbers.
+		\mt_srand( (int) \hexdec( \substr( $seed, 0, 8 ) ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_seeding_mt_srand -- we need deterministic "random" numbers.
 
 		// Generate icon.
 		$result = $this->identicon->getImageData(

--- a/includes/avatar-privacy/class-factory.php
+++ b/includes/avatar-privacy/class-factory.php
@@ -261,7 +261,7 @@ class Factory extends Dice {
 					[
 						'nonce'   => 'avatar_privacy_frontend_allow_anonymous_nonce_',
 						'action'  => 'avatar_privacy_frontend_edit_allow_anonymous',
-						'field'   => 'avatar_privacy_frontend-allow_anonymous',
+						'field'   => 'avatar_privacy-frontend-allow_anonymous',
 						'partial' => '/public/partials/profile/allow-anonymous.php',
 					],
 					[
@@ -279,7 +279,7 @@ class Factory extends Dice {
 					[
 						'nonce'   => 'avatar_privacy_tml_profiles_use_gravatar_nonce_',
 						'action'  => 'avatar_privacy_tml_profiles_edit_use_gravatar',
-						'field'   => 'avatar-privacy-tml_profiles-use-gravatar',
+						'field'   => 'avatar-privacy-tml-profiles-use-gravatar',
 						'partial' => '/public/partials/tml-profiles/use-gravatar.php',
 					],
 					[

--- a/includes/avatar-privacy/class-factory.php
+++ b/includes/avatar-privacy/class-factory.php
@@ -348,7 +348,7 @@ class Factory extends Dice {
 	protected function get_plugin_version( $plugin_file ) {
 		// Load version from plugin data.
 		if ( ! \function_exists( 'get_plugin_data' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+			require_once \ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
 		return \get_plugin_data( $plugin_file, false, false )['Version'];

--- a/includes/avatar-privacy/class-settings.php
+++ b/includes/avatar-privacy/class-settings.php
@@ -108,9 +108,9 @@ class Settings {
 					'ui'             => \Avatar_Privacy\Upload_Handlers\UI\File_Upload_Input::class,
 					'tab_id'         => '', // Will be added to the 'discussions' page.
 					'section'        => 'avatars',
-					'help_no_file'   => __( 'No custom default avatar is set. Use the upload field to add a custom default avatar image.', 'avatar-privacy' ),
-					'help_no_upload' => __( 'You do not have media management permissions. To change your custom default avatar, contact the site administrator.', 'avatar-privacy' ),
-					'help_text'      => __( 'Replace the custom default avatar by uploading a new image, or erase it by checking the delete option.', 'avatar-privacy' ),
+					'help_no_file'   => \__( 'No custom default avatar is set. Use the upload field to add a custom default avatar image.', 'avatar-privacy' ),
+					'help_no_upload' => \__( 'You do not have media management permissions. To change your custom default avatar, contact the site administrator.', 'avatar-privacy' ),
+					'help_text'      => \__( 'Replace the custom default avatar by uploading a new image, or erase it by checking the delete option.', 'avatar-privacy' ),
 					'erase_checkbox' => Custom_Default_Icon_Upload_Handler::CHECKBOX_ERASE,
 					'action'         => Custom_Default_Icon_Upload_Handler::ACTION_UPLOAD,
 					'nonce'          => Custom_Default_Icon_Upload_Handler::NONCE_UPLOAD,

--- a/includes/avatar-privacy/components/class-image-proxy.php
+++ b/includes/avatar-privacy/components/class-image-proxy.php
@@ -137,7 +137,7 @@ class Image_Proxy implements \Avatar_Privacy\Component {
 		global $wp;
 		$wp->add_query_var( 'avatar-privacy-file' );
 
-		$basedir = \str_replace( ABSPATH, '', $this->file_cache->get_base_dir() );
+		$basedir = \str_replace( \ABSPATH, '', $this->file_cache->get_base_dir() );
 		\add_rewrite_rule( "^{$basedir}(.*)", [ 'avatar-privacy-file' => '$matches[1]' ], 'top' );
 	}
 
@@ -172,7 +172,7 @@ class Image_Proxy implements \Avatar_Privacy\Component {
 			}
 		}
 
-		$this->send_image( $file, DAY_IN_SECONDS, Images\Type::CONTENT_TYPE[ $extension ] );
+		$this->send_image( $file, \DAY_IN_SECONDS, Images\Type::CONTENT_TYPE[ $extension ] );
 
 		// We're done.
 		$this->exit_request();
@@ -235,14 +235,14 @@ class Image_Proxy implements \Avatar_Privacy\Component {
 			 *
 			 * @param int $max_age The maximum age of the cached files (in seconds). Default 2 days.
 			 */
-			$max_age = \apply_filters( 'avatar_privacy_gravatars_max_age', 2 * DAY_IN_SECONDS );
+			$max_age = \apply_filters( 'avatar_privacy_gravatars_max_age', 2 * \DAY_IN_SECONDS );
 
 			/**
 			 * Filters how often the clean-up cron job for old gravatar images should run.
 			 *
 			 * @param int $interval Time until the cron job should run again (in seconds). Default 1 day.
 			 */
-			$interval = \apply_filters( 'avatar_privacy_gravatars_cleanup_interval', DAY_IN_SECONDS );
+			$interval = \apply_filters( 'avatar_privacy_gravatars_cleanup_interval', \DAY_IN_SECONDS );
 
 			$this->invalidate_cached_images( self::CRON_JOB_LOCK_GRAVATARS, 'gravatar', $interval, $max_age );
 		}
@@ -265,14 +265,14 @@ class Image_Proxy implements \Avatar_Privacy\Component {
 			 *
 			 * @param int $max_age The maximum age of the cached files (in seconds). Default 1 week.
 			 */
-			$max_age = \apply_filters( 'avatar_privacy_all_images_max_age', 7 * DAY_IN_SECONDS );
+			$max_age = \apply_filters( 'avatar_privacy_all_images_max_age', 7 * \DAY_IN_SECONDS );
 
 			/**
 			 * Filters how often the clean-up cron job for old images should run.
 			 *
 			 * @param int $interval Time until the cron job should run again (in seconds). Default 1 week.
 			 */
-			$interval = \apply_filters( 'avatar_privacy_all_images_cleanup_interval', 7 * DAY_IN_SECONDS );
+			$interval = \apply_filters( 'avatar_privacy_all_images_cleanup_interval', 7 * \DAY_IN_SECONDS );
 
 			$this->invalidate_cached_images( self::CRON_JOB_LOCK_ALL_IMAGES, '', $interval, $max_age );
 		}

--- a/includes/avatar-privacy/components/class-privacy-tools.php
+++ b/includes/avatar-privacy/components/class-privacy-tools.php
@@ -94,16 +94,16 @@ class Privacy_Tools implements \Avatar_Privacy\Component {
 	 * @since 2.1.0 Visibility changed to protected.
 	 */
 	protected function add_privacy_notice_content() {
-		$suggested_text = '<strong class="privacy-policy-tutorial">' . __( 'Suggested text:' ) . ' </strong>'; // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- Missing text domain is intentional to use Core translation.
+		$suggested_text = '<strong class="privacy-policy-tutorial">' . \__( 'Suggested text:' ) . ' </strong>'; // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- Missing text domain is intentional to use Core translation.
 
-		$content  = '<h3>' . __( 'Comments', 'avatar-privacy' ) . '</h3>';
-		$content .= '<p class="privacy-policy-tutorial">' . __( 'The information in this subsection supersedes the paragraph on Gravatar in the default "Comments" subsection provided by WordPress.', 'avatar-privacy' ) . '</p>';
-		$content .= "<p>{$suggested_text}" . __( 'At your option, an anonymized string created from your email address (also called a hash) may be provided to the Gravatar service to see if you are using it. The Gravatar service privacy policy is available here: https://automattic.com/privacy/. After approval of your comment, your profile picture is visible to the public in the context of your comment. Neither the hash nor your actual email address will be exposed to the public.', 'avatar-privacy' ) . '</p>';
-		$content .= '<h3>' . __( 'Cookies', 'avatar-privacy' ) . '</h3>';
-		$content .= '<p class="privacy-policy-tutorial">' . __( 'The information in this subsection should be included in addition to the information about any other cookies set by either WordPress or another plugin.', 'avatar-privacy' ) . '</p>';
-		$content .= "<p>{$suggested_text}" . __( 'If you leave a comment on our site and opt-in to display your Gravatar image, your choice will be stored in a cookie. This is for your convenience so that you do not have to fill the checkbox again when you leave another comment. This cookie will last for one year.', 'avatar-privacy' ) . '</p>';
+		$content  = '<h3>' . \__( 'Comments', 'avatar-privacy' ) . '</h3>';
+		$content .= '<p class="privacy-policy-tutorial">' . \__( 'The information in this subsection supersedes the paragraph on Gravatar in the default "Comments" subsection provided by WordPress.', 'avatar-privacy' ) . '</p>';
+		$content .= "<p>{$suggested_text}" . \__( 'At your option, an anonymized string created from your email address (also called a hash) may be provided to the Gravatar service to see if you are using it. The Gravatar service privacy policy is available here: https://automattic.com/privacy/. After approval of your comment, your profile picture is visible to the public in the context of your comment. Neither the hash nor your actual email address will be exposed to the public.', 'avatar-privacy' ) . '</p>';
+		$content .= '<h3>' . \__( 'Cookies', 'avatar-privacy' ) . '</h3>';
+		$content .= '<p class="privacy-policy-tutorial">' . \__( 'The information in this subsection should be included in addition to the information about any other cookies set by either WordPress or another plugin.', 'avatar-privacy' ) . '</p>';
+		$content .= "<p>{$suggested_text}" . \__( 'If you leave a comment on our site and opt-in to display your Gravatar image, your choice will be stored in a cookie. This is for your convenience so that you do not have to fill the checkbox again when you leave another comment. This cookie will last for one year.', 'avatar-privacy' ) . '</p>';
 
-		\wp_add_privacy_policy_content( __( 'Avatar Privacy', 'avatar-privacy' ), $content );
+		\wp_add_privacy_policy_content( \__( 'Avatar Privacy', 'avatar-privacy' ), $content );
 	}
 
 	/**
@@ -115,11 +115,11 @@ class Privacy_Tools implements \Avatar_Privacy\Component {
 	 */
 	public function register_personal_data_exporter( array $exporters ) {
 		$exporters['avatar-privacy-user']           = [
-			'exporter_friendly_name' => __( 'Avatar Privacy Plugin User Data', 'avatar-privacy' ),
+			'exporter_friendly_name' => \__( 'Avatar Privacy Plugin User Data', 'avatar-privacy' ),
 			'callback'               => [ $this, 'export_user_data' ],
 		];
 		$exporters['avatar-privacy-comment-author'] = [
-			'exporter_friendly_name' => __( 'Avatar Privacy Plugin Comment Author Data', 'avatar-privacy' ),
+			'exporter_friendly_name' => \__( 'Avatar Privacy Plugin Comment Author Data', 'avatar-privacy' ),
 			'callback'               => [ $this, 'export_comment_author_data' ],
 		];
 
@@ -135,7 +135,7 @@ class Privacy_Tools implements \Avatar_Privacy\Component {
 	 */
 	public function register_personal_data_eraser( array $erasers ) {
 		$erasers['avatar-privacy'] = [
-			'eraser_friendly_name' => __( 'Avatar Privacy Plugin', 'avatar-privacy' ),
+			'eraser_friendly_name' => \__( 'Avatar Privacy Plugin', 'avatar-privacy' ),
 			'callback'             => [ $this, 'erase_data' ],
 		];
 
@@ -167,19 +167,19 @@ class Privacy_Tools implements \Avatar_Privacy\Component {
 
 		// Export the hashed email.
 		$user_data[] = [
-			'name'  => __( 'User Email Hash', 'avatar-privacy' ),
+			'name'  => \__( 'User Email Hash', 'avatar-privacy' ),
 			'value' => $this->core->get_user_hash( $user->ID ),
 		];
 
 		// Export the `use_gravatar` setting.
 		$user_data[] = [
-			'name'  => __( 'Use Gravatar.com', 'avatar-privacy' ),
+			'name'  => \__( 'Use Gravatar.com', 'avatar-privacy' ),
 			'value' => \get_user_meta( $user->ID, Core::GRAVATAR_USE_META_KEY, true ) === 'true',
 		];
 
 		// Export the `allow_anonymous` setting.
 		$user_data[] = [
-			'name'  => __( 'Logged-out Commenting', 'avatar-privacy' ),
+			'name'  => \__( 'Logged-out Commenting', 'avatar-privacy' ),
 			'value' => \get_user_meta( $user->ID, Core::ALLOW_ANONYMOUS_META_KEY, true ) === 'true',
 		];
 
@@ -188,8 +188,8 @@ class Privacy_Tools implements \Avatar_Privacy\Component {
 		$local_avatar = \get_user_meta( $user->ID, Core::USER_AVATAR_META_KEY, true );
 		if ( ! empty( $local_avatar['file'] ) ) {
 			$user_data[] = [
-				'name'  => __( 'User Profile Picture', 'avatar-privacy' ),
-				'value' => str_replace( \ABSPATH, \trailingslashit( \site_url() ), $local_avatar['file'] ),
+				'name'  => \__( 'User Profile Picture', 'avatar-privacy' ),
+				'value' => \str_replace( \ABSPATH, \trailingslashit( \site_url() ), $local_avatar['file'] ),
 			];
 		}
 
@@ -197,7 +197,7 @@ class Privacy_Tools implements \Avatar_Privacy\Component {
 			'data' => [
 				[
 					'group_id'    => 'user',             // Existing Core group.
-					'group_label' => __( 'User' ),       // // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- Missing text domain is intentional to use Core translation.
+					'group_label' => \__( 'User' ),       // // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- Missing text domain is intentional to use Core translation.
 					'item_id'     => "user-{$user->ID}", // Existing Core item ID.
 					'data'        => $user_data,         // The personal data that should be exported.
 				],
@@ -231,37 +231,37 @@ class Privacy_Tools implements \Avatar_Privacy\Component {
 		$data   = [];
 		$id     = $raw_data->id;
 		$data[] = [
-			'name'  => __( 'Avatar Privacy Comment Author ID', 'avatar-privacy' ),
+			'name'  => \__( 'Avatar Privacy Comment Author ID', 'avatar-privacy' ),
 			'value' => $id,
 		];
 
 		// Export the email.
 		$data[] = [
-			'name'  => __( 'Comment Author Email', 'avatar-privacy' ),
+			'name'  => \__( 'Comment Author Email', 'avatar-privacy' ),
 			'value' => $raw_data->email,
 		];
 
 		// Export the hashed email.
 		$data[] = [
-			'name'  => __( 'Comment Author Email Hash', 'avatar-privacy' ),
+			'name'  => \__( 'Comment Author Email Hash', 'avatar-privacy' ),
 			'value' => $raw_data->hash,
 		];
 
 		// Export the `use_gravatar` setting.
 		$data[] = [
-			'name'  => __( 'Use Gravatar.com', 'avatar-privacy' ),
+			'name'  => \__( 'Use Gravatar.com', 'avatar-privacy' ),
 			'value' => $raw_data->use_gravatar,
 		];
 
 		// Export the last modified date.
 		$data[] = [
-			'name'  => __( 'Last Updated', 'avatar-privacy' ),
+			'name'  => \__( 'Last Updated', 'avatar-privacy' ),
 			'value' => $raw_data->last_updated,
 		];
 
 		// Export the log message.
 		$data[] = [
-			'name'  => __( 'Log Message', 'avatar-privacy' ),
+			'name'  => \__( 'Log Message', 'avatar-privacy' ),
 			'value' => $raw_data->log_message,
 		];
 
@@ -269,7 +269,7 @@ class Privacy_Tools implements \Avatar_Privacy\Component {
 			'data' => [
 				[
 					'group_id'    => 'avatar-privacy',                         // An ID to identify this particular group of information.
-					'group_label' => __( 'Avatar Privacy', 'avatar-privacy' ), // A translatable string to label this group of information.
+					'group_label' => \__( 'Avatar Privacy', 'avatar-privacy' ), // A translatable string to label this group of information.
 					'item_id'     => "avatar-privacy-{$id}",                   // The item ID of what we're exporting.
 					'data'        => $data,                                    // The personal data that should be exported.
 				],

--- a/includes/avatar-privacy/components/class-privacy-tools.php
+++ b/includes/avatar-privacy/components/class-privacy-tools.php
@@ -189,7 +189,7 @@ class Privacy_Tools implements \Avatar_Privacy\Component {
 		if ( ! empty( $local_avatar['file'] ) ) {
 			$user_data[] = [
 				'name'  => __( 'User Profile Picture', 'avatar-privacy' ),
-				'value' => str_replace( ABSPATH, \trailingslashit( \site_url() ), $local_avatar['file'] ),
+				'value' => str_replace( \ABSPATH, \trailingslashit( \site_url() ), $local_avatar['file'] ),
 			];
 		}
 

--- a/includes/avatar-privacy/data-storage/class-database.php
+++ b/includes/avatar-privacy/data-storage/class-database.php
@@ -270,7 +270,7 @@ class Database {
 	protected function db_delta( $queries, $execute = true ) {
 		if ( ! function_exists( 'dbDelta' ) ) {
 			// Load upgrade.php for the dbDelta function.
-			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+			require_once \ABSPATH . 'wp-admin/includes/upgrade.php';
 		}
 
 		return \dbDelta( $queries, $execute );
@@ -320,7 +320,7 @@ class Database {
 		$rows_to_update  = [];
 		$rows_to_migrate = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 			$wpdb->prepare( "SELECT * FROM `{$global_table_name}` WHERE log_message LIKE %s", $like_clause ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			OBJECT_K
+			\OBJECT_K
 		);
 
 		// Check for existing rows for the same email addresses.

--- a/includes/avatar-privacy/integrations/class-wpdiscuz-integration.php
+++ b/includes/avatar-privacy/integrations/class-wpdiscuz-integration.php
@@ -119,11 +119,11 @@ class WPDiscuz_Integration implements Plugin_Integration {
 	public function enqeue_styles_and_scripts() {
 		// Set up resource file information.
 		$url    = \plugin_dir_url( \AVATAR_PRIVACY_PLUGIN_FILE );
-		$suffix = SCRIPT_DEBUG ? '' : '.min';
+		$suffix = \SCRIPT_DEBUG ? '' : '.min';
 
 		// Set up the localized script data.
 		$data = [
-			'cookie'   => Comments::COOKIE_PREFIX . COOKIEHASH,
+			'cookie'   => Comments::COOKIE_PREFIX . \COOKIEHASH,
 			'checkbox' => Comments::CHECKBOX_FIELD_NAME,
 		];
 
@@ -138,7 +138,7 @@ class WPDiscuz_Integration implements Plugin_Integration {
 	 */
 	public function set_comment_cookies( \WP_Comment $comment ) {
 		$user           = \wp_get_current_user();
-		$cookie_consent = $this->filter_input( INPUT_POST, $this->cookie_consent_name, FILTER_VALIDATE_BOOLEAN );
+		$cookie_consent = $this->filter_input( \INPUT_POST, $this->cookie_consent_name, \FILTER_VALIDATE_BOOLEAN );
 
 		$this->comments->set_comment_cookies( $comment, $user, $cookie_consent );
 	}

--- a/includes/avatar-privacy/tools/images/class-image-stream.php
+++ b/includes/avatar-privacy/tools/images/class-image-stream.php
@@ -153,10 +153,10 @@ class Image_Stream {
 				break;
 
 			default:
-				if ( $this->options & STREAM_REPORT_ERRORS ) {
+				if ( $this->options & \STREAM_REPORT_ERRORS ) {
 					\trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 						'Invalid mode specified (mode specified makes no sense for this stream implementation)',
-						E_USER_ERROR
+						\E_USER_ERROR
 					);
 				} else {
 					return false;
@@ -233,17 +233,17 @@ class Image_Stream {
 	 */
 	public function stream_seek( $offset, $whence ) {
 		switch ( $whence ) {
-			case SEEK_SET:
+			case \SEEK_SET:
 				$this->position = $offset;
 				$this->truncate_after_seek();
 				return true;
 
-			case SEEK_CUR:
+			case \SEEK_CUR:
 				$this->position += $offset;
 				$this->truncate_after_seek();
 				return true;
 
-			case SEEK_END:
+			case \SEEK_END:
 				$this->position = \strlen( $this->data ) + $offset;
 				$this->truncate_after_seek();
 				return true;
@@ -273,7 +273,7 @@ class Image_Stream {
 		if ( $current_length > $length ) {
 			$this->data = \substr( $this->data, 0, $length );
 		} elseif ( $current_length < $length ) {
-			$this->data = \str_pad( $this->data, $length, "\0", STR_PAD_RIGHT );
+			$this->data = \str_pad( $this->data, $length, "\0", \STR_PAD_RIGHT );
 		}
 
 		return true;

--- a/includes/avatar-privacy/upload-handlers/class-upload-handler.php
+++ b/includes/avatar-privacy/upload-handlers/class-upload-handler.php
@@ -116,7 +116,7 @@ abstract class Upload_Handler {
 	protected function upload( array $file, $global = false ) {
 		// Enable front end support.
 		if ( ! function_exists( 'wp_handle_upload' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php'; // @codeCoverageIgnore
+			require_once \ABSPATH . 'wp-admin/includes/file.php'; // @codeCoverageIgnore
 		}
 
 		// Should we use a global directory for uploads?

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-retro-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-retro-test.php
@@ -34,6 +34,8 @@ use Mockery as m;
 
 use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Retro;
 
+use Avatar_Privacy\Tools\Number_Generator;
+
 /**
  * Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\Retro unit test.
  *
@@ -66,6 +68,13 @@ class Retro_Test extends \Avatar_Privacy\Tests\TestCase {
 	private $random_color;
 
 	/**
+	 * The random number generator.
+	 *
+	 * @var Number_Generator
+	 */
+	protected $number_generator;
+
+	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
@@ -73,14 +82,18 @@ class Retro_Test extends \Avatar_Privacy\Tests\TestCase {
 		parent::setUp();
 
 		// Helper mocks.
-		$this->identicon    = m::mock( \Identicon\Identicon::class );
-		$this->random_color = m::mock( 'alias:' . \Colors\RandomColor::class );
+		$this->identicon        = m::mock( \Identicon\Identicon::class );
+		$this->random_color     = m::mock( 'alias:' . \Colors\RandomColor::class );
+		$this->number_generator = m::mock( Number_Generator::class );
 
 		// Partially mock system under test.
 		$this->sut = m::mock( Retro::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
 		// Manually invoke the constructor as it is protected.
-		$this->invokeMethod( $this->sut, '__construct', [ $this->identicon ] );
+		$this->invokeMethod( $this->sut, '__construct', [
+			$this->identicon,
+			$this->number_generator,
+		] );
 	}
 
 	/**
@@ -89,12 +102,14 @@ class Retro_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$identicon = m::mock( \Identicon\Identicon::class );
-		$mock      = m::mock( Retro::class )->makePartial()->shouldAllowMockingProtectedMethods();
+		$identicon        = m::mock( \Identicon\Identicon::class );
+		$number_generator = m::mock( Number_Generator::class );
+		$mock             = m::mock( Retro::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $mock, '__construct', [ $identicon ] );
+		$this->invokeMethod( $mock, '__construct', [ $identicon, $number_generator ] );
 
 		$this->assertAttributeSame( $identicon, 'identicon', $mock );
+		$this->assertAttributeSame( $number_generator, 'number_generator', $mock );
 	}
 
 	/**
@@ -110,6 +125,9 @@ class Retro_Test extends \Avatar_Privacy\Tests\TestCase {
 		// Intermediate.
 		$bright_color = 'A bright color definition';
 		$light_color  = 'A light color definition';
+
+		$this->number_generator->shouldReceive( 'seed' )->once()->with( $seed );
+		$this->number_generator->shouldReceive( 'reset' )->once();
 
 		$this->random_color->shouldReceive( 'one' )->once()->with( [ 'luminosity' => 'bright' ] )->andReturn( $bright_color );
 		$this->random_color->shouldReceive( 'one' )->once()->with( [ 'luminosity' => 'light' ] )->andReturn( $light_color );

--- a/tests/avatar-privacy/class-functions-test.php
+++ b/tests/avatar-privacy/class-functions-test.php
@@ -63,7 +63,7 @@ class Functions_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		// Set up virtual filesystem.
 		$root = vfsStream::setup( 'root', null, $filesystem );
-		set_include_path( 'vfs://root/' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_set_include_path
+		\set_include_path( 'vfs://root/' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_set_include_path
 	}
 
 	/**


### PR DESCRIPTION
- Adds global namespace to all remaining constants and functions.
- Makes form IDs more consistent (partial fix for #123).
- Replaces remaining usage of `\mt_srand()` with `\Avatar_Privacy\Tools\Number_Generator::seed()`.