### PR TITLE
Revert to PHP 5.2 bootstrapping process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ matrix:
         # Current $required_php_version for WordPress:  5.6.20
         # Minimum version for activating Avatar Privacy, aliased to a recent 5.6.x version
         - php:  '5.6'
-          env:  SCOPE=tests
+          env:
+            - PHPCS=1
+            - SCOPE=tests
         # aliased to a recent 7.0 version
         - php:  '7.0'
           env:  SCOPE=tests

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,8 +15,14 @@ module.exports = function(grunt) {
 			autoloader: [
 				"build/tests",
 				"build/composer.*",
+				"build/vendor/scoper-autoload.php",
 				"build/vendor/composer/*.json",
 				"build/vendor/dangoodman"
+			],
+			vendor: [
+				"build/vendor/{jdenticon,mistic100,scripturadesign,splitbrain}/*/*",
+				"!build/vendor/**/src",
+				"!build/vendor/**/partials"
 			],
 		},
 
@@ -82,7 +88,8 @@ module.exports = function(grunt) {
 						'public/**',
 						'includes/**',
 						'!**/scss/**',
-						'!**/tests/**'
+						'!**/tests/**',
+						'vendor/**/partials/**',
 					],
 					dest: 'build/'
 				}],
@@ -310,12 +317,13 @@ module.exports = function(grunt) {
 		'newer:postcss:dist',
 		'newer:minify',
 		'copy:main',
-		'copy:meta',
 		'npmRun:build', // Build blocks.js
 		'composer:build:build-wordpress',
 		'string-replace:namespaces',
+		'clean:vendor',
 		'clean:autoloader',
 		'string-replace:autoloader',
+		'copy:meta',
 	]);
 
 	grunt.registerTask('build-beta', [

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -30,7 +30,7 @@
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at
  * Version: 2.3.0-alpha.1
- * Requires at least: 5.2
+ * Requires at least: 4.9
  * Requires PHP: 5.6
  * License: GNU General Public License v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -38,16 +38,19 @@
  */
 
 // Don't do anything if called directly.
-if ( ! \defined( 'ABSPATH' ) || ! \defined( 'WPINC' ) ) {
-	die;
+if ( ! defined( 'ABSPATH' ) || ! defined( 'WPINC' ) ) {
+	die();
 }
 
 // Make plugin file path available globally.
-const AVATAR_PRIVACY_PLUGIN_PATH = __DIR__;
-const AVATAR_PRIVACY_PLUGIN_FILE = __FILE__;
+if ( ! defined( 'AVATAR_PRIVACY_PLUGIN_FILE' ) ) {
+	define( 'AVATAR_PRIVACY_PLUGIN_FILE', __FILE__ );
+}
+if ( ! defined( 'AVATAR_PRIVACY_PLUGIN_PATH' ) ) {
+	define( 'AVATAR_PRIVACY_PLUGIN_PATH', dirname( __FILE__ ) );
+}
 
-// Initialize autoloader.
-require_once __DIR__ . '/vendor/autoload.php';
+require_once dirname( __FILE__ ) . '/includes/class-avatar-privacy-requirements.php';
 
 /**
  * Load the plugin after checking for the necessary PHP version.
@@ -56,12 +59,14 @@ require_once __DIR__ . '/vendor/autoload.php';
  */
 function avatar_privacy_run() {
 
-	// Check plugin requirements.
-	$requirements = new \Avatar_Privacy\Requirements();
+	$requirements = new Avatar_Privacy_Requirements();
+
 	if ( $requirements->check() ) {
+		// Autoload the rest of your classes.
+		require_once __DIR__ . '/vendor/autoload.php'; // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_dirFound
 
 		// Create and start the plugin.
-		$plugin = \Avatar_Privacy\Factory::get()->create( \Avatar_Privacy\Controller::class );
+		$plugin = Avatar_Privacy_Factory::get()->create( 'Avatar_Privacy\Controller' );
 		$plugin->run();
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": ">=5.6.0",
         "ext-gd": "*",
         "level-2/dice": "^2.0.3",
-        "mundschenk-at/check-wp-requirements": "^2.0",
+        "mundschenk-at/check-wp-requirements": "^1.0",
         "mundschenk-at/wp-data-storage": "^1.0",
         "mundschenk-at/wp-settings-ui": "^1.0",
         "scripturadesign/color": "^0.1.3",
@@ -63,7 +63,7 @@
 
     "scripts": {
         "phpcs": [
-            "phpcs -p -s *.php includes/ admin/ public/ --extensions=php"
+            "phpcs -p -s *.php includes/ admin/ public/ --extensions=php && phpcs -p -s avatar-privacy.php uninstall.php includes/class-avatar-privacy-*requirements.php --runtime-set testVersion 5.2-"
         ],
         "test": [
             "phpunit --testsuite AvatarPrivacy"

--- a/includes/class-avatar-privacy-requirements.php
+++ b/includes/class-avatar-privacy-requirements.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018-2019 Peter Putzer.
+ * Copyright 2018 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,18 +24,18 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
-namespace Avatar_Privacy;
+// We can't rely on autoloading for the requirements check.
+require_once dirname( dirname( __FILE__ ) ) . '/vendor/mundschenk-at/check-wp-requirements/class-mundschenk-wp-requirements.php'; // @codeCoverageIgnore
 
 /**
  * A custom requirements class to check for additional PHP packages and other
  * prerequisites.
  *
  * @since 1.0.0
- * @since 2.3.0 Moved to \Avatar_Privacy\Requirements.
  *
  * @author Peter Putzer <github@mundschenk.at>
  */
-class Requirements extends \Mundschenk\WP_Requirements {
+class Avatar_Privacy_Requirements extends Mundschenk_WP_Requirements {
 
 	/**
 	 * Creates a new requirements instance.
@@ -43,15 +43,15 @@ class Requirements extends \Mundschenk\WP_Requirements {
 	 * @since 2.1.0 Parameter $plugin_file replaced with AVATAR_PRIVACY_PLUGIN_FILE constant.
 	 */
 	public function __construct() {
-		$requirements = [
+		$requirements = array(
 			'php'              => '5.6.0',
 			'multibyte'        => false,
 			'utf-8'            => false,
 			'gd'               => true,
 			'uploads_writable' => true,
-		];
+		);
 
-		parent::__construct( 'Avatar Privacy', \AVATAR_PRIVACY_PLUGIN_FILE, 'avatar-privacy', $requirements );
+		parent::__construct( 'Avatar Privacy', AVATAR_PRIVACY_PLUGIN_FILE, 'avatar-privacy', $requirements );
 	}
 
 	/**
@@ -67,16 +67,16 @@ class Requirements extends \Mundschenk\WP_Requirements {
 	 */
 	protected function get_requirements() {
 		$requirements   = parent::get_requirements();
-		$requirements[] = [
+		$requirements[] = array(
 			'enable_key' => 'gd',
-			'check'      => [ $this, 'check_gd_support' ],
-			'notice'     => [ $this, 'admin_notices_gd_incompatible' ],
-		];
-		$requirements[] = [
+			'check'      => array( $this, 'check_gd_support' ),
+			'notice'     => array( $this, 'admin_notices_gd_incompatible' ),
+		);
+		$requirements[] = array(
 			'enable_key' => 'uploads_writable',
-			'check'      => [ $this, 'check_uploads_writable' ],
-			'notice'     => [ $this, 'admin_notices_uploads_not_writable' ],
-		];
+			'check'      => array( $this, 'check_uploads_writable' ),
+			'notice'     => array( $this, 'admin_notices_uploads_not_writable' ),
+		);
 
 		return $requirements;
 	}
@@ -87,11 +87,11 @@ class Requirements extends \Mundschenk\WP_Requirements {
 	 * @return bool
 	 */
 	protected function check_gd_support() {
-		return \function_exists( 'imagecreatefrompng' )
-			&& \function_exists( 'imagecopy' )
-			&& \function_exists( 'imagedestroy' )
-			&& \function_exists( 'imagepng' )
-			&& \function_exists( 'imagecreatetruecolor' );
+		return function_exists( 'imagecreatefrompng' )
+			&& function_exists( 'imagecopy' )
+			&& function_exists( 'imagedestroy' )
+			&& function_exists( 'imagepng' )
+			&& function_exists( 'imagecreatetruecolor' );
 	}
 
 	/**
@@ -100,10 +100,10 @@ class Requirements extends \Mundschenk\WP_Requirements {
 	public function admin_notices_gd_incompatible() {
 		$this->display_error_notice(
 			/* translators: 1: plugin name 2: GD documentation URL */
-			\__( 'The activated plugin %1$s requires the GD PHP extension to be enabled on your server. Please deactivate this plugin, or <a href="%2$s">enable the extension</a>.', 'avatar-privacy' ),
+			__( 'The activated plugin %1$s requires the GD PHP extension to be enabled on your server. Please deactivate this plugin, or <a href="%2$s">enable the extension</a>.', 'avatar-privacy' ),
 			'<strong>Avatar Privacy</strong>',
 			/* translators: URL with GD PHP extension installation instructions */
-			\__( 'http://php.net/manual/en/image.setup.php', 'avatar-privacy' )
+			__( 'http://php.net/manual/en/image.setup.php', 'avatar-privacy' )
 		);
 	}
 
@@ -113,18 +113,18 @@ class Requirements extends \Mundschenk\WP_Requirements {
 	 * @return bool
 	 */
 	protected function check_uploads_writable() {
-		$uploads = \wp_get_upload_dir();
+		$uploads = wp_get_upload_dir();
 
-		return \is_writable( $uploads['basedir'] );
+		return is_writable( $uploads['basedir'] );
 	}
 
 	/**
-	 * Prints 'GD extension missing' admin notice.
+	 * Prints 'GD extension missing' admin notice
 	 */
 	public function admin_notices_uploads_not_writable() {
 		$this->display_error_notice(
 			/* translators: 1: plugin name */
-			\__( 'The activated plugin %1$s requires write access to the WordPress uploads folder on your server. Please check the folder\'s permissions, or deactivate this plugin.', 'avatar-privacy' ),
+			__( 'The activated plugin %1$s requires write access to the WordPress uploads folder on your server. Please check the folder\'s permissions, or deactivate this plugin.', 'avatar-privacy' ),
 			'<strong>Avatar Privacy</strong>'
 		);
 	}

--- a/includes/class-avatar-privacy-uninstallation-requirements.php
+++ b/includes/class-avatar-privacy-uninstallation-requirements.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018-2019 Peter Putzer.
+ * Copyright 2018 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,28 +24,27 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
-use function Avatar_Privacy\get_gravatar_checkbox;
-
-if ( ! \function_exists( 'avapr_get_avatar_checkbox' ) ) {
-
-	/**
-	 * Returns the 'use gravatar' checkbox for the comment form.
-	 *
-	 * This is intended as a template function for older or highly-customized
-	 * themes. Output the result with echo or print.
-	 *
-	 * @deprecated 2.3.0 Use \Avatar_Privacy\get_gravatar_checkbox instead.
-	 *
-	 * @return string The HTML code for the checkbox or an empty string.
-	 */
-	function avapr_get_avatar_checkbox() {
-		return get_gravatar_checkbox();
-	}
-}
+// We can't rely on autoloading for the requirements check.
+require_once dirname( dirname( __FILE__ ) ) . '/vendor/mundschenk-at/check-wp-requirements/class-mundschenk-wp-requirements.php'; // @codeCoverageIgnore
 
 /**
- * PHP 5.2 compatibility layer.
+ * A custom requirements class to check for the minimum PHP version (and nothing
+ * else) during the uninstallation process .
  *
- * Will be removed once the minimum requireemnt is WordPress 5.2.
+ * @since 2.1.0
+ *
+ * @author Peter Putzer <github@mundschenk.at>
  */
-class_alias( \Avatar_Privacy\Factory::class, \Avatar_Privacy_Factory::class );
+class Avatar_Privacy_Uninstallation_Requirements extends Mundschenk_WP_Requirements {
+
+	/**
+	 * Creates a new requirements instance.
+	 */
+	public function __construct() {
+		$requirements = array(
+			'php' => '5.6.0',
+		);
+
+		parent::__construct( 'Avatar Privacy', AVATAR_PRIVACY_PLUGIN_FILE, 'avatar-privacy', $requirements );
+	}
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,7 +6,7 @@
 	<!-- Set a description for this ruleset. -->
 	<description>A custom set of code standard rules to check for WordPress plugins.</description>
 
-	<config name="minimum_supported_wp_version" value="5.2"/>
+	<config name="minimum_supported_wp_version" value="4.9"/>
 	<config name="testVersion" value="5.6-"/>
 
 	<!-- Include the WordPress ruleset, with exclusions. -->

--- a/readme.txt
+++ b/readme.txt
@@ -4,9 +4,9 @@ Plugin Name: Avatar Privacy
 Plugin URI: https://code.mundschenk.at/avatar-privacy/
 Author URI: https://code.mundschenk.at/
 Tags: gravatar, avatar, privacy, caching, bbpress, buddypress
-Requires at least: 5.2
+Requires at least: 4.9
 Requires PHP: 5.6
-Tested up to: 5.2
+Tested up to: 5.3
 Stable tag: 2.2.1
 License: GPLv2 or later
 

--- a/tests/class-avatar-privacy-requirements-test.php
+++ b/tests/class-avatar-privacy-requirements-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018-2019 Peter Putzer.
+ * Copyright 2018 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,7 +24,7 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
-namespace Avatar_Privacy\Tests\Avatar_Privacy;
+namespace Avatar_Privacy\Tests;
 
 use Brain\Monkey\Actions;
 use Brain\Monkey\Filters;
@@ -36,17 +36,17 @@ use org\bovigo\vfs\vfsStreamDirectory;
 use Mockery as m;
 
 /**
- * Avatar_Privacy\Requirements unit test.
+ * Avatar_Privacy_Requirements unit test.
  *
- * @coversDefaultClass \Avatar_Privacy\Requirements
- * @usesDefaultClass \Avatar_Privacy\Requirements
+ * @coversDefaultClass \Avatar_Privacy_Requirements
+ * @usesDefaultClass \Avatar_Privacy_Requirements
  */
-class Requirements_Test extends \Avatar_Privacy\Tests\TestCase {
+class Avatar_Privacy_Requirements_Test extends TestCase {
 
 	/**
 	 * The system-under-test.
 	 *
-	 * @var \Avatar_Privacy\Requirements
+	 * @var \Avatar_Privacy_Requirements
 	 */
 	private $sut;
 
@@ -57,7 +57,7 @@ class Requirements_Test extends \Avatar_Privacy\Tests\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->sut = m::mock( \Avatar_Privacy\Requirements::class )->makePartial()->shouldAllowMockingProtectedMethods();
+		$this->sut = m::mock( \Avatar_Privacy_Requirements::class )->makePartial()->shouldAllowMockingProtectedMethods();
 	}
 
 	/**
@@ -72,11 +72,11 @@ class Requirements_Test extends \Avatar_Privacy\Tests\TestCase {
 				return \array_merge( $defaults, $args );
 			}
 		);
-		$req = m::mock( \Avatar_Privacy\Requirements::class )->makePartial();
+		$req = m::mock( \Avatar_Privacy_Requirements::class )->makePartial();
 		$req->__construct( 'some_file' );
 
-		$this->assertSame( 'Avatar Privacy', $this->getValue( $req, 'plugin_name', \Mundschenk\WP_Requirements::class ) );
-		$this->assertSame( 'avatar-privacy', $this->getValue( $req, 'textdomain', \Mundschenk\WP_Requirements::class ) );
+		$this->assertSame( 'Avatar Privacy', $this->getValue( $req, 'plugin_name', \Mundschenk_WP_Requirements::class ) );
+		$this->assertSame( 'avatar-privacy', $this->getValue( $req, 'textdomain', \Mundschenk_WP_Requirements::class ) );
 		$this->assertSame(
 			[
 				'php'              => '5.6.0',
@@ -85,7 +85,7 @@ class Requirements_Test extends \Avatar_Privacy\Tests\TestCase {
 				'gd'               => true,
 				'uploads_writable' => true,
 			],
-			$this->getValue( $req, 'install_requirements', \Mundschenk\WP_Requirements::class )
+			$this->getValue( $req, 'install_requirements', \Mundschenk_WP_Requirements::class )
 		);
 	}
 
@@ -108,11 +108,11 @@ class Requirements_Test extends \Avatar_Privacy\Tests\TestCase {
 	 */
 	public function test_check_gd_support() {
 		// Mocking tests for PHP extensions is difficult.
-		$gd = \function_exists( 'imagecreatefrompng' )
-			&& \function_exists( 'imagecopy' )
-			&& \function_exists( 'imagedestroy' )
-			&& \function_exists( 'imagepng' )
-			&& \function_exists( 'imagecreatetruecolor' );
+		$gd = function_exists( 'imagecreatefrompng' )
+			&& function_exists( 'imagecopy' )
+			&& function_exists( 'imagedestroy' )
+			&& function_exists( 'imagepng' )
+			&& function_exists( 'imagecreatetruecolor' );
 
 		$this->assertSame( $gd, $this->sut->check_gd_support() );
 	}

--- a/tests/class-avatar-privacy-uninstallation-requirements-test.php
+++ b/tests/class-avatar-privacy-uninstallation-requirements-test.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2018 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Tests;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+
+use Mockery as m;
+
+/**
+ * Avatar_Privacy_Uninstallation_Requirements unit test.
+ *
+ * @coversDefaultClass \Avatar_Privacy_Uninstallation_Requirements
+ * @usesDefaultClass \Avatar_Privacy_Uninstallation_Requirements
+ */
+class Avatar_Privacy_Uninstallation_Requirements_Test extends TestCase {
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var \Avatar_Privacy_Uninstallation_Requirements
+	 */
+	private $sut;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$this->sut = m::mock( \Avatar_Privacy_Uninstallation_Requirements::class )->makePartial()->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * Test ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+
+		Functions\expect( 'wp_parse_args' )->andReturnUsing(
+			function( $args, $defaults ) {
+				return \array_merge( $defaults, $args );
+			}
+		);
+		$req = m::mock( \Avatar_Privacy_Uninstallation_Requirements::class )->makePartial();
+		$req->__construct( 'some_file' );
+
+		$this->assertSame( 'Avatar Privacy', $this->getValue( $req, 'plugin_name', \Mundschenk_WP_Requirements::class ) );
+		$this->assertSame( 'avatar-privacy', $this->getValue( $req, 'textdomain', \Mundschenk_WP_Requirements::class ) );
+		$this->assertSame(
+			[
+				'php'       => '5.6.0',
+				'multibyte' => false,
+				'utf-8'     => false,
+			],
+			$this->getValue( $req, 'install_requirements', \Mundschenk_WP_Requirements::class )
+		);
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -24,26 +24,36 @@
  */
 
 // Don't do anything if called directly.
-if ( ! \defined( 'WP_UNINSTALL_PLUGIN' ) ) {
-	die;
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	die();
 }
 
 // Make plugin file path available globally (even if we probably don't need it during uninstallaton).
-const AVATAR_PRIVACY_PLUGIN_PATH = __DIR__;
-const AVATAR_PRIVACY_PLUGIN_FILE = __DIR__ . '/avatar-privacy.php';
+if ( ! defined( 'AVATAR_PRIVACY_PLUGIN_FILE' ) ) {
+	define( 'AVATAR_PRIVACY_PLUGIN_FILE', dirname( __FILE__ ) . '/avatar-privacy.php' );
+}
+if ( ! defined( 'AVATAR_PRIVACY_PLUGIN_PATH' ) ) {
+	define( 'AVATAR_PRIVACY_PLUGIN_PATH', dirname( __FILE__ ) );
+}
 
-// Initialize autoloader.
-require_once __DIR__ . '/vendor/autoload.php';
+require_once dirname( __FILE__ ) . '/includes/class-avatar-privacy-uninstallation-requirements.php';
 
 /**
- * Uninstalls the plugin.
+ * Uninstall the plugin after checking for the necessary PHP version.
  *
- * @since 2.3.0 WordPress now requires PHP 5.6, so no further requirements check is necessary.
+ * It's necessary to do this here because our classes rely on namespaces.
  */
 function avatar_privacy_uninstall() {
 
-	// Create and start the uninstallation handler.
-	$uninstaller = \Avatar_Privacy\Factory::get()->create( \Avatar_Privacy\Components\Uninstallation::class );
-	$uninstaller->run();
+	$requirements = new Avatar_Privacy_Uninstallation_Requirements();
+
+	if ( $requirements->check() ) {
+		// Autoload the rest of your classes.
+		require_once __DIR__ . '/vendor/autoload.php'; // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_dirFound
+
+		// Create and start the uninstallation handler.
+		$uninstaller = Avatar_Privacy_Factory::get()->create( 'Avatar_Privacy\Components\Uninstallation' );
+		$uninstaller->run();
+	}
 }
 avatar_privacy_uninstall();


### PR DESCRIPTION
- Reverts minimum WordPress version to 4.9.
- Re-introduces PHP 5.2 compatible bootstrapping (fixes #138).