### PR TITLE
Update integration environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@ build/
 # Test coverage
 tests/coverage/
 
+# PHPUnit
+.phpunit.result.cache
+
 # macOS
 .DS_Store

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -26,6 +26,8 @@ build:
         neo4j: false
         php:
             version: 7.4
+            compile_options: '--with-config-file-path=/home/scrutinizer/.phpenv/versions/7.4.0/etc --with-config-file-scan-dir=/home/scrutinizer/.phpenv/versions/7.4.0/etc/conf.d --prefix=/home/scrutinizer/.phpenv/versions/7.4.0 --libexecdir=/home/scrutinizer/.phpenv/versions/7.4.0/libexec --enable-intl --with-openssl --without-pear --with-gd --enable-gd --with-jpeg-dir=/usr --with-png-dir=/usr --with-freetype-dir=/usr --enable-exif --with-libzip --with-zlib --with-zlib-dir=/usr --with-sodium --with-pdo-sqlite --enable-soap --enable-xmlreader --with-xsl --enable-ftp --with-tidy --with-xmlrpc --enable-sysvsem --enable-sysvshm --enable-sysvmsg --enable-shmop --with-mysqli=mysqlnd --with-pdo-mysql=mysqlnd --enable-pcntl --with-readline --enable-mbstring --with-curl --with-pgsql --with-pdo-pgsql --with-gettext --enable-sockets --with-bz2 --enable-bcmath --enable-calendar --with-libdir=lib --enable-fpm --enable-maintainer-zts --with-gmp --with-kerberos --with-imap --with-imap-ssl --with-apxs2=/usr/bin/apxs --with-ldap --with-pear=/home/scrutinizer/.phpenv/versions/7.4.0/pear'
+
     nodes:
         analysis:
             project_setup:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -25,7 +25,7 @@ build:
         memcached: false
         neo4j: false
         php:
-            version: 7.3
+            version: 7.4
     nodes:
         analysis:
             project_setup:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ matrix:
           env:  SCOPE=tests
         # aliased to a recent 7.3 version
         - php:  '7.3'
+          env:  SCOPE=tests
+        # aliased to a recent 7.4 version
+        - php:  '7.4'
           env:  SCOPE=coverage
 
 # Use this to prepare the system to install prerequisites or dependencies.

--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,12 @@
         "wp-coding-standards/wpcs": "^2",
         "phpcompatibility/phpcompatibility-wp": "^2.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
-        "phpunit/phpunit": "5.*||6.*||7.*",
+        "phpunit/phpunit": "5.*||6.*||7.*||8.*",
         "mikey179/vfsstream": "~1",
         "brain/monkey": "^2.2",
         "roave/security-advisories": "dev-master",
-        "humbug/php-scoper": "^0.12.4"
+        "humbug/php-scoper": "^0.12.4",
+        "symfony/phpunit-bridge": "^5.0"
     },
 
     "autoload": {

--- a/includes/avatar-privacy/cli/class-cron-command.php
+++ b/includes/avatar-privacy/cli/class-cron-command.php
@@ -72,7 +72,7 @@ class Cron_Command extends Abstract_Command {
 		if ( false === $next ) {
 			WP_CLI::success( WP_CLI::colorize( "Cron job %B{$job}%n not scheduled on this site." ) );
 		} else {
-			$timestamp = \date( 'Y-m-d H:i:s', $next );
+			$timestamp = \gmdate( 'Y-m-d H:i:s', $next );
 			WP_CLI::success( WP_CLI::colorize( "Cron job %B{$job}%n will run next at %B{$timestamp}%n on this site." ) );
 		}
 	}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -15,6 +15,8 @@
 		<exclude name ="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />
 		<exclude name ="PEAR.Functions.FunctionCallSignature.MultipleArguments" />
 		<exclude name ="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
+		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
 	</rule>
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />

--- a/tests/avatar-privacy/avatar-handlers/class-default-icons-handler-test.php
+++ b/tests/avatar-privacy/avatar-handlers/class-default-icons-handler-test.php
@@ -150,8 +150,8 @@ class Default_Icons_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $file_cache, $icon_providers );
 
-		$this->assertAttributeSame( $file_cache, 'file_cache', $mock );
-		$this->assertAttributeSame( $icon_providers, 'icon_providers', $mock );
+		$this->assert_attribute_same( $file_cache, 'file_cache', $mock );
+		$this->assert_attribute_same( $icon_providers, 'icon_providers', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/class-default-icons-handler-test.php
+++ b/tests/avatar-privacy/avatar-handlers/class-default-icons-handler-test.php
@@ -99,9 +99,11 @@ class Default_Icons_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'uploads' => [

--- a/tests/avatar-privacy/avatar-handlers/class-gravatar-cache-handler-test.php
+++ b/tests/avatar-privacy/avatar-handlers/class-gravatar-cache-handler-test.php
@@ -141,10 +141,10 @@ class Gravatar_Cache_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $core, $options, $file_cache, $gravatar );
 
-		$this->assertAttributeSame( $core, 'core', $mock );
-		$this->assertAttributeSame( $options, 'options', $mock );
-		$this->assertAttributeSame( $file_cache, 'file_cache', $mock );
-		$this->assertAttributeSame( $gravatar, 'gravatar', $mock );
+		$this->assert_attribute_same( $core, 'core', $mock );
+		$this->assert_attribute_same( $options, 'options', $mock );
+		$this->assert_attribute_same( $file_cache, 'file_cache', $mock );
+		$this->assert_attribute_same( $gravatar, 'gravatar', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/class-gravatar-cache-handler-test.php
+++ b/tests/avatar-privacy/avatar-handlers/class-gravatar-cache-handler-test.php
@@ -91,9 +91,11 @@ class Gravatar_Cache_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'uploads' => [

--- a/tests/avatar-privacy/avatar-handlers/class-user-avatar-handler-test.php
+++ b/tests/avatar-privacy/avatar-handlers/class-user-avatar-handler-test.php
@@ -83,9 +83,11 @@ class User_Avatar_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'uploads' => [

--- a/tests/avatar-privacy/avatar-handlers/class-user-avatar-handler-test.php
+++ b/tests/avatar-privacy/avatar-handlers/class-user-avatar-handler-test.php
@@ -130,9 +130,9 @@ class User_Avatar_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $core, $file_cache, $images );
 
-		$this->assertAttributeSame( $core, 'core', $mock );
-		$this->assertAttributeSame( $file_cache, 'file_cache', $mock );
-		$this->assertAttributeSame( $images, 'images', $mock );
+		$this->assert_attribute_same( $core, 'core', $mock );
+		$this->assert_attribute_same( $file_cache, 'file_cache', $mock );
+		$this->assert_attribute_same( $images, 'images', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/class-abstract-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/class-abstract-icon-provider-test.php
@@ -91,8 +91,8 @@ class Abstract_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $mock, '__construct', [ $valid_types ] );
 
-		$this->assertAttributeSame( \array_flip( $valid_types ), 'valid_types', $mock );
-		$this->assertAttributeSame( 'foobar', 'primary_type', $mock );
+		$this->assert_attribute_same( \array_flip( $valid_types ), 'valid_types', $mock );
+		$this->assert_attribute_same( 'foobar', 'primary_type', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/class-abstract-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/class-abstract-icon-provider-test.php
@@ -61,9 +61,11 @@ class Abstract_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Helper mocks.
 		$this->valid_types = [

--- a/tests/avatar-privacy/avatar-handlers/default-icons/class-abstract-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/class-abstract-icon-provider-test.php
@@ -77,7 +77,7 @@ class Abstract_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->sut = m::mock( Abstract_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
 		// Manually invoke the constructor as it is protected.
-		$this->invokeMethod( $this->sut, '__construct', [ $this->valid_types ] );
+		$this->invoke_method( $this->sut, '__construct', [ $this->valid_types ] );
 	}
 
 	/**
@@ -89,7 +89,7 @@ class Abstract_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$mock        = m::mock( Abstract_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 		$valid_types = [ 'foobar', 'barfoo', 'rhabarber' ];
 
-		$this->invokeMethod( $mock, '__construct', [ $valid_types ] );
+		$this->invoke_method( $mock, '__construct', [ $valid_types ] );
 
 		$this->assert_attribute_same( \array_flip( $valid_types ), 'valid_types', $mock );
 		$this->assert_attribute_same( 'foobar', 'primary_type', $mock );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/class-custom-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/class-custom-icon-provider-test.php
@@ -89,9 +89,11 @@ class Custom_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Helper mocks.
 		$this->file_cache = m::mock( Filesystem_Cache::class );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/class-custom-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/class-custom-icon-provider-test.php
@@ -129,7 +129,7 @@ class Custom_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock = m::mock( Custom_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $mock, '__construct', [ $file_cache, $upload, $core, $images ] );
+		$this->invoke_method( $mock, '__construct', [ $file_cache, $upload, $core, $images ] );
 
 		$this->assert_attribute_same( $file_cache, 'file_cache', $mock );
 		$this->assert_attribute_same( $upload, 'upload', $mock );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/class-custom-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/class-custom-icon-provider-test.php
@@ -131,10 +131,10 @@ class Custom_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $mock, '__construct', [ $file_cache, $upload, $core, $images ] );
 
-		$this->assertAttributeSame( $file_cache, 'file_cache', $mock );
-		$this->assertAttributeSame( $upload, 'upload', $mock );
-		$this->assertAttributeSame( $core, 'core', $mock );
-		$this->assertAttributeSame( $images, 'images', $mock );
+		$this->assert_attribute_same( $file_cache, 'file_cache', $mock );
+		$this->assert_attribute_same( $upload, 'upload', $mock );
+		$this->assert_attribute_same( $core, 'core', $mock );
+		$this->assert_attribute_same( $images, 'images', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/class-generating-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/class-generating-icon-provider-test.php
@@ -63,8 +63,8 @@ class Generating_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $mock, '__construct', [ $generator, $file_cache, $types ] );
 
-		$this->assertAttributeSame( $generator, 'generator', $mock );
-		$this->assertAttributeSame( $file_cache, 'file_cache', $mock );
+		$this->assert_attribute_same( $generator, 'generator', $mock );
+		$this->assert_attribute_same( $file_cache, 'file_cache', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/class-generating-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/class-generating-icon-provider-test.php
@@ -61,7 +61,7 @@ class Generating_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock = m::mock( Generating_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $mock, '__construct', [ $generator, $file_cache, $types ] );
+		$this->invoke_method( $mock, '__construct', [ $generator, $file_cache, $types ] );
 
 		$this->assert_attribute_same( $generator, 'generator', $mock );
 		$this->assert_attribute_same( $file_cache, 'file_cache', $mock );
@@ -83,7 +83,7 @@ class Generating_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		// System-under-test.
 		$sut = m::mock( Generating_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
-		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache, $types ] );
+		$this->invoke_method( $sut, '__construct', [ $generator, $file_cache, $types ] );
 
 		// Input parameters.
 		$identity = 'f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b';

--- a/tests/avatar-privacy/avatar-handlers/default-icons/class-static-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/class-static-icon-provider-test.php
@@ -57,8 +57,8 @@ class Static_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $valid_types, $basename );
 
-		$this->assertAttributeSame( \array_flip( $valid_types ), 'valid_types', $mock, Abstract_Icon_Provider::class );
-		$this->assertAttributeSame( $basename, 'icon_basename', $mock );
+		$this->assert_attribute_same( \array_flip( $valid_types ), 'valid_types', $mock, Abstract_Icon_Provider::class );
+		$this->assert_attribute_same( $basename, 'icon_basename', $mock );
 	}
 
 	/**
@@ -75,8 +75,8 @@ class Static_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $valid_types, $basename );
 
-		$this->assertAttributeSame( [ 'foobar' => 0 ], 'valid_types', $mock, Abstract_Icon_Provider::class );
-		$this->assertAttributeSame( $basename, 'icon_basename', $mock );
+		$this->assert_attribute_same( [ 'foobar' => 0 ], 'valid_types', $mock, Abstract_Icon_Provider::class );
+		$this->assert_attribute_same( $basename, 'icon_basename', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-bird-avatar-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-bird-avatar-icon-provider-test.php
@@ -60,7 +60,7 @@ class Bird_Avatar_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$file_cache = m::mock( Filesystem_Cache::class );
 		$sut        = m::mock( Bird_Avatar_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
+		$this->invoke_method( $sut, '__construct', [ $generator, $file_cache ] );
 
 		$this->assert_attribute_same( $generator, 'generator', $sut );
 		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-bird-avatar-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-bird-avatar-icon-provider-test.php
@@ -62,9 +62,9 @@ class Bird_Avatar_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
 
-		$this->assertAttributeSame( $generator, 'generator', $sut );
-		$this->assertAttributeSame( $file_cache, 'file_cache', $sut );
-		$this->assertAttributeSame( [ 'bird' => 0 ], 'valid_types', $sut );
+		$this->assert_attribute_same( $generator, 'generator', $sut );
+		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );
+		$this->assert_attribute_same( [ 'bird' => 0 ], 'valid_types', $sut );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-cat-avatar-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-cat-avatar-icon-provider-test.php
@@ -60,7 +60,7 @@ class Cat_Avatar_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$file_cache = m::mock( Filesystem_Cache::class );
 		$sut        = m::mock( Cat_Avatar_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
+		$this->invoke_method( $sut, '__construct', [ $generator, $file_cache ] );
 
 		$this->assert_attribute_same( $generator, 'generator', $sut );
 		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-cat-avatar-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-cat-avatar-icon-provider-test.php
@@ -62,9 +62,9 @@ class Cat_Avatar_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
 
-		$this->assertAttributeSame( $generator, 'generator', $sut );
-		$this->assertAttributeSame( $file_cache, 'file_cache', $sut );
-		$this->assertAttributeSame( [ 'cat' => 0 ], 'valid_types', $sut );
+		$this->assert_attribute_same( $generator, 'generator', $sut );
+		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );
+		$this->assert_attribute_same( [ 'cat' => 0 ], 'valid_types', $sut );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-identicon-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-identicon-icon-provider-test.php
@@ -60,7 +60,7 @@ class Identicon_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$file_cache = m::mock( Filesystem_Cache::class );
 		$sut        = m::mock( Identicon_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
+		$this->invoke_method( $sut, '__construct', [ $generator, $file_cache ] );
 
 		$this->assert_attribute_same( $generator, 'generator', $sut );
 		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-identicon-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-identicon-icon-provider-test.php
@@ -62,9 +62,9 @@ class Identicon_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
 
-		$this->assertAttributeSame( $generator, 'generator', $sut );
-		$this->assertAttributeSame( $file_cache, 'file_cache', $sut );
-		$this->assertAttributeSame( [ 'identicon' => 0 ], 'valid_types', $sut );
+		$this->assert_attribute_same( $generator, 'generator', $sut );
+		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );
+		$this->assert_attribute_same( [ 'identicon' => 0 ], 'valid_types', $sut );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-monster-id-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-monster-id-icon-provider-test.php
@@ -62,9 +62,9 @@ class Monster_ID_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
 
-		$this->assertAttributeSame( $generator, 'generator', $sut );
-		$this->assertAttributeSame( $file_cache, 'file_cache', $sut );
-		$this->assertAttributeSame( [ 'monsterid' => 0 ], 'valid_types', $sut );
+		$this->assert_attribute_same( $generator, 'generator', $sut );
+		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );
+		$this->assert_attribute_same( [ 'monsterid' => 0 ], 'valid_types', $sut );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-monster-id-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-monster-id-icon-provider-test.php
@@ -60,7 +60,7 @@ class Monster_ID_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$file_cache = m::mock( Filesystem_Cache::class );
 		$sut        = m::mock( Monster_ID_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
+		$this->invoke_method( $sut, '__construct', [ $generator, $file_cache ] );
 
 		$this->assert_attribute_same( $generator, 'generator', $sut );
 		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-retro-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-retro-icon-provider-test.php
@@ -62,9 +62,9 @@ class Retro_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
 
-		$this->assertAttributeSame( $generator, 'generator', $sut );
-		$this->assertAttributeSame( $file_cache, 'file_cache', $sut );
-		$this->assertAttributeSame( [ 'retro' => 0 ], 'valid_types', $sut );
+		$this->assert_attribute_same( $generator, 'generator', $sut );
+		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );
+		$this->assert_attribute_same( [ 'retro' => 0 ], 'valid_types', $sut );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-retro-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-retro-icon-provider-test.php
@@ -60,7 +60,7 @@ class Retro_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$file_cache = m::mock( Filesystem_Cache::class );
 		$sut        = m::mock( Retro_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
+		$this->invoke_method( $sut, '__construct', [ $generator, $file_cache ] );
 
 		$this->assert_attribute_same( $generator, 'generator', $sut );
 		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-rings-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-rings-icon-provider-test.php
@@ -60,7 +60,7 @@ class Rings_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$file_cache = m::mock( Filesystem_Cache::class );
 		$sut        = m::mock( Rings_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
+		$this->invoke_method( $sut, '__construct', [ $generator, $file_cache ] );
 
 		$this->assert_attribute_same( $generator, 'generator', $sut );
 		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-rings-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-rings-icon-provider-test.php
@@ -62,9 +62,9 @@ class Rings_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
 
-		$this->assertAttributeSame( $generator, 'generator', $sut );
-		$this->assertAttributeSame( $file_cache, 'file_cache', $sut );
-		$this->assertAttributeSame( [ 'rings' => 0 ], 'valid_types', $sut );
+		$this->assert_attribute_same( $generator, 'generator', $sut );
+		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );
+		$this->assert_attribute_same( [ 'rings' => 0 ], 'valid_types', $sut );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-robohash-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-robohash-icon-provider-test.php
@@ -60,7 +60,7 @@ class Robohash_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$file_cache = m::mock( Filesystem_Cache::class );
 		$sut        = m::mock( Robohash_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
+		$this->invoke_method( $sut, '__construct', [ $generator, $file_cache ] );
 
 		$this->assert_attribute_same( $generator, 'generator', $sut );
 		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-robohash-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-robohash-icon-provider-test.php
@@ -62,9 +62,9 @@ class Robohash_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
 
-		$this->assertAttributeSame( $generator, 'generator', $sut );
-		$this->assertAttributeSame( $file_cache, 'file_cache', $sut );
-		$this->assertAttributeSame( [ 'robohash' => 0 ], 'valid_types', $sut );
+		$this->assert_attribute_same( $generator, 'generator', $sut );
+		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );
+		$this->assert_attribute_same( [ 'robohash' => 0 ], 'valid_types', $sut );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-wavatar-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-wavatar-icon-provider-test.php
@@ -60,7 +60,7 @@ class Wavatar_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$file_cache = m::mock( Filesystem_Cache::class );
 		$sut        = m::mock( Wavatar_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
+		$this->invoke_method( $sut, '__construct', [ $generator, $file_cache ] );
 
 		$this->assert_attribute_same( $generator, 'generator', $sut );
 		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-wavatar-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generated-icons/class-wavatar-icon-provider-test.php
@@ -62,9 +62,9 @@ class Wavatar_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $sut, '__construct', [ $generator, $file_cache ] );
 
-		$this->assertAttributeSame( $generator, 'generator', $sut );
-		$this->assertAttributeSame( $file_cache, 'file_cache', $sut );
-		$this->assertAttributeSame( [ 'wavatar' => 0 ], 'valid_types', $sut );
+		$this->assert_attribute_same( $generator, 'generator', $sut );
+		$this->assert_attribute_same( $file_cache, 'file_cache', $sut );
+		$this->assert_attribute_same( [ 'wavatar' => 0 ], 'valid_types', $sut );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-bird-avatar-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-bird-avatar-test.php
@@ -57,9 +57,11 @@ class Bird_Avatar_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Partially mock system under test.
 		$this->sut = m::mock( Bird_Avatar::class )->makePartial()->shouldAllowMockingProtectedMethods();

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-bird-avatar-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-bird-avatar-test.php
@@ -85,7 +85,7 @@ class Bird_Avatar_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->invokeMethod( $mock, '__construct', [ $editor, $png, $number_generator, $transients ] );
 
 		// An attribute of the PNG_Parts_Generator superclass.
-		$this->assertAttributeSame( $editor, 'editor', $mock );
+		$this->assert_attribute_same( $editor, 'editor', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-bird-avatar-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-bird-avatar-test.php
@@ -82,7 +82,7 @@ class Bird_Avatar_Test extends \Avatar_Privacy\Tests\TestCase {
 		$transients       = m::mock( Site_Transients::class );
 		$mock             = m::mock( Bird_Avatar::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $mock, '__construct', [ $editor, $png, $number_generator, $transients ] );
+		$this->invoke_method( $mock, '__construct', [ $editor, $png, $number_generator, $transients ] );
 
 		// An attribute of the PNG_Parts_Generator superclass.
 		$this->assert_attribute_same( $editor, 'editor', $mock );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-cat-avatar-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-cat-avatar-test.php
@@ -85,7 +85,7 @@ class Cat_Avatar_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->invokeMethod( $mock, '__construct', [ $editor, $png, $number_generator, $transients ] );
 
 		// An attribute of the PNG_Parts_Generator superclass.
-		$this->assertAttributeSame( $editor, 'editor', $mock );
+		$this->assert_attribute_same( $editor, 'editor', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-cat-avatar-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-cat-avatar-test.php
@@ -57,9 +57,11 @@ class Cat_Avatar_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Partially mock system under test.
 		$this->sut = m::mock( Cat_Avatar::class )->makePartial()->shouldAllowMockingProtectedMethods();

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-cat-avatar-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-cat-avatar-test.php
@@ -82,7 +82,7 @@ class Cat_Avatar_Test extends \Avatar_Privacy\Tests\TestCase {
 		$transients       = m::mock( Site_Transients::class );
 		$mock             = m::mock( Cat_Avatar::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $mock, '__construct', [ $editor, $png, $number_generator, $transients ] );
+		$this->invoke_method( $mock, '__construct', [ $editor, $png, $number_generator, $transients ] );
 
 		// An attribute of the PNG_Parts_Generator superclass.
 		$this->assert_attribute_same( $editor, 'editor', $mock );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-jdenticon-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-jdenticon-test.php
@@ -74,7 +74,7 @@ class Jdenticon_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->sut = m::mock( Jdenticon::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
 		// Manually invoke the constructor as it is protected.
-		$this->invokeMethod( $this->sut, '__construct', [ $this->identicon ] );
+		$this->invoke_method( $this->sut, '__construct', [ $this->identicon ] );
 	}
 
 	/**
@@ -86,7 +86,7 @@ class Jdenticon_Test extends \Avatar_Privacy\Tests\TestCase {
 		$identicon = m::mock( \Jdenticon\Identicon::class );
 		$mock      = m::mock( Jdenticon::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $mock, '__construct', [ $identicon ] );
+		$this->invoke_method( $mock, '__construct', [ $identicon ] );
 
 		$this->assert_attribute_same( $identicon, 'identicon', $mock );
 	}

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-jdenticon-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-jdenticon-test.php
@@ -88,7 +88,7 @@ class Jdenticon_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $mock, '__construct', [ $identicon ] );
 
-		$this->assertAttributeSame( $identicon, 'identicon', $mock );
+		$this->assert_attribute_same( $identicon, 'identicon', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-jdenticon-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-jdenticon-test.php
@@ -61,9 +61,11 @@ class Jdenticon_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Helper mocks.
 		$this->identicon = m::mock( \Jdenticon\Identicon::class );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
@@ -132,7 +132,7 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->sut = m::mock( Monster_ID::class, [ $editor, $this->png, $this->number_generator, $transients ] )->makePartial()->shouldAllowMockingProtectedMethods();
 
 		// Override necessary properties.
-		$this->setValue( $this->sut, 'parts_dir', vfsStream::url( 'root/plugin/public/images/monster-id' ) );
+		$this->set_value( $this->sut, 'parts_dir', vfsStream::url( 'root/plugin/public/images/monster-id' ) );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
@@ -153,7 +153,7 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->invokeMethod( $mock, '__construct', [ $editor, $png, $number_generator, $transients ] );
 
 		// An attribute of the PNG_Parts_Generator superclass.
-		$this->assertAttributeSame( $editor, 'editor', $mock );
+		$this->assert_attribute_same( $editor, 'editor', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
@@ -175,7 +175,7 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = $this->sut->get_additional_arguments( $seed, $size, $parts );
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertArrayHasKey( 'hue', $result );
 		$this->assertArrayHasKey( 'saturation', $result );
 	}
@@ -230,7 +230,7 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = $this->sut->colorize_image( $resource, $hue, $saturation, $part );
 
-		$this->assertInternalType( 'resource', $result );
+		$this->assert_is_resource( $result );
 
 		// Clean up.
 		\imageDestroy( $resource );
@@ -255,7 +255,7 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = $this->sut->colorize_image( $resource, $hue, $saturation, $part );
 
-		$this->assertInternalType( 'resource', $result );
+		$this->assert_is_resource( $result );
 
 		// Clean up.
 		\imageDestroy( $resource );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
@@ -150,7 +150,7 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 		$transients       = m::mock( Site_Transients::class );
 		$mock             = m::mock( Monster_ID::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $mock, '__construct', [ $editor, $png, $number_generator, $transients ] );
+		$this->invoke_method( $mock, '__construct', [ $editor, $png, $number_generator, $transients ] );
 
 		// An attribute of the PNG_Parts_Generator superclass.
 		$this->assert_attribute_same( $editor, 'editor', $mock );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
@@ -85,9 +85,11 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$png_data = \base64_decode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions
 			'iVBORw0KGgoAAAANSUhEUgAAABwAAAASCAMAAAB/2U7WAAAABl' .

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-parts-generator-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-parts-generator-test.php
@@ -114,7 +114,7 @@ class Parts_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 		$transients = m::mock( Site_Transients::class );
 		$mock       = m::mock( Parts_Generator::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $mock, '__construct', [ $fake_path, $part_types, $rng, $transients ] );
+		$this->invoke_method( $mock, '__construct', [ $fake_path, $part_types, $rng, $transients ] );
 
 		$this->assert_attribute_same( $fake_path, 'parts_dir', $mock );
 		$this->assert_attribute_same( $part_types, 'part_types', $mock );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-parts-generator-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-parts-generator-test.php
@@ -116,10 +116,10 @@ class Parts_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $mock, '__construct', [ $fake_path, $part_types, $rng, $transients ] );
 
-		$this->assertAttributeSame( $fake_path, 'parts_dir', $mock );
-		$this->assertAttributeSame( $part_types, 'part_types', $mock );
-		$this->assertAttributeSame( $rng, 'number_generator', $mock );
-		$this->assertAttributeSame( $transients, 'site_transients', $mock );
+		$this->assert_attribute_same( $fake_path, 'parts_dir', $mock );
+		$this->assert_attribute_same( $part_types, 'part_types', $mock );
+		$this->assert_attribute_same( $rng, 'number_generator', $mock );
+		$this->assert_attribute_same( $transients, 'site_transients', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-parts-generator-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-parts-generator-test.php
@@ -418,7 +418,7 @@ class Parts_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::build_parts_array
 	 */
 	public function test_build_parts_array() {
-		$empty_parts  = \array_fill_keys( $this->getValue( $this->sut, 'part_types' ), [] );
+		$empty_parts  = \array_fill_keys( $this->get_value( $this->sut, 'part_types' ), [] );
 		$parts        = [ 'unsorted' => 'parts' ];
 		$sorted_parts = [ 'sorted' => 'parts' ];
 
@@ -435,7 +435,7 @@ class Parts_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::build_parts_array
 	 */
 	public function test_build_parts_array_error() {
-		$empty_parts  = \array_fill_keys( $this->getValue( $this->sut, 'part_types' ), [] );
+		$empty_parts  = \array_fill_keys( $this->get_value( $this->sut, 'part_types' ), [] );
 		$parts        = [ 'unsorted' => 'parts' ];
 		$sorted_parts = [ 'sorted' => 'parts' ];
 

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-parts-generator-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-parts-generator-test.php
@@ -78,9 +78,11 @@ class Parts_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Properties.
 		$this->parts_dir = '/some/fake/parts/dir';

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-parts-generator-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-parts-generator-test.php
@@ -277,7 +277,7 @@ class Parts_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 			'mouth' => 'mouth_6.png',
 		];
 
-		$this->assertInternalType( 'array', $this->sut->get_additional_arguments( $seed, $size, $parts ) );
+		$this->assert_is_array( $this->sut->get_additional_arguments( $seed, $size, $parts ) );
 	}
 
 	/**
@@ -310,7 +310,7 @@ class Parts_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 		// Run test.
 		$result = $this->sut->randomize_parts( $parts );
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertSame( \array_keys( $parts ), \array_keys( $result ) );
 	}
 

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-png-parts-generator-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-png-parts-generator-test.php
@@ -189,9 +189,9 @@ class PNG_Parts_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 			[ $fake_path, $part_types, $size, $editor, $png, $numbers, $transients ]
 		);
 
-		$this->assertAttributeSame( $size, 'size', $mock );
-		$this->assertAttributeSame( $editor, 'editor', $mock );
-		$this->assertAttributeSame( $png, 'png', $mock );
+		$this->assert_attribute_same( $size, 'size', $mock );
+		$this->assert_attribute_same( $editor, 'editor', $mock );
+		$this->assert_attribute_same( $png, 'png', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-png-parts-generator-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-png-parts-generator-test.php
@@ -246,7 +246,7 @@ class PNG_Parts_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 		];
 
 		// Override necessary properties.
-		$this->setValue( $this->sut, 'parts_dir', vfsStream::url( 'root/plugin/public/images/monster-id' ) );
+		$this->set_value( $this->sut, 'parts_dir', vfsStream::url( 'root/plugin/public/images/monster-id' ) );
 
 		// Run test.
 		$this->assertSame( $result, $this->sut->read_parts_from_filesystem( $parts ) );
@@ -262,7 +262,7 @@ class PNG_Parts_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 		$parts = \array_fill_keys( [ 'body', 'arms', 'legs', 'mouth' ], [] );
 
 		// Override necessary properties.
-		$this->setValue( $this->sut, 'parts_dir', vfsStream::url( 'root/plugin/public/images/monster-id-empty' ) );
+		$this->set_value( $this->sut, 'parts_dir', vfsStream::url( 'root/plugin/public/images/monster-id-empty' ) );
 
 		// Run test.
 		$this->assertSame( $parts, $this->sut->read_parts_from_filesystem( $parts ) );
@@ -438,8 +438,8 @@ class PNG_Parts_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 		];
 
 		// Override the parts directory and types.
-		$this->setValue( $this->sut, 'parts_dir', $this->real_image_path );
-		$this->setValue( $this->sut, 'part_types', $part_types );
+		$this->set_value( $this->sut, 'parts_dir', $this->real_image_path );
+		$this->set_value( $this->sut, 'part_types', $part_types );
 
 		$this->sut->shouldReceive( 'get_parts' )->once()->andReturn( $parts );
 
@@ -477,8 +477,8 @@ class PNG_Parts_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 		$expected = "'body_1.png' => [ [ 22, 99 ], [ 17, 90 ] ],\n'body_2.png' => [ [ 14, 104 ], [ 16, 89 ] ],\n'arms_S8.png' => [ [ 2, 119 ], [ 18, 98 ] ],\n";
 
 		// Override the parts directory and types.
-		$this->setValue( $this->sut, 'parts_dir', $this->real_image_path );
-		$this->setValue( $this->sut, 'part_types', $part_types );
+		$this->set_value( $this->sut, 'parts_dir', $this->real_image_path );
+		$this->set_value( $this->sut, 'part_types', $part_types );
 
 		$this->sut->shouldReceive( 'get_parts' )->once()->andReturn( $parts );
 

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-png-parts-generator-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-png-parts-generator-test.php
@@ -183,7 +183,7 @@ class PNG_Parts_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 		$transients = m::mock( Site_Transients::class );
 		$mock       = m::mock( PNG_Parts_Generator::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod(
+		$this->invoke_method(
 			$mock,
 			'__construct',
 			[ $fake_path, $part_types, $size, $editor, $png, $numbers, $transients ]

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-png-parts-generator-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-png-parts-generator-test.php
@@ -105,9 +105,11 @@ class PNG_Parts_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$png_data = \base64_decode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions
 			'iVBORw0KGgoAAAANSUhEUgAAABwAAAASCAMAAAB/2U7WAAAABl' .

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-retro-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-retro-test.php
@@ -77,9 +77,11 @@ class Retro_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Helper mocks.
 		$this->identicon        = m::mock( \Identicon\Identicon::class );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-retro-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-retro-test.php
@@ -92,7 +92,7 @@ class Retro_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->sut = m::mock( Retro::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
 		// Manually invoke the constructor as it is protected.
-		$this->invokeMethod( $this->sut, '__construct', [
+		$this->invoke_method( $this->sut, '__construct', [
 			$this->identicon,
 			$this->number_generator,
 		] );
@@ -108,7 +108,7 @@ class Retro_Test extends \Avatar_Privacy\Tests\TestCase {
 		$number_generator = m::mock( Number_Generator::class );
 		$mock             = m::mock( Retro::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $mock, '__construct', [ $identicon, $number_generator ] );
+		$this->invoke_method( $mock, '__construct', [ $identicon, $number_generator ] );
 
 		$this->assert_attribute_same( $identicon, 'identicon', $mock );
 		$this->assert_attribute_same( $number_generator, 'number_generator', $mock );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-retro-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-retro-test.php
@@ -110,8 +110,8 @@ class Retro_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $mock, '__construct', [ $identicon, $number_generator ] );
 
-		$this->assertAttributeSame( $identicon, 'identicon', $mock );
-		$this->assertAttributeSame( $number_generator, 'number_generator', $mock );
+		$this->assert_attribute_same( $identicon, 'identicon', $mock );
+		$this->assert_attribute_same( $number_generator, 'number_generator', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-robohash-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-robohash-test.php
@@ -141,7 +141,7 @@ class Robohash_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->invokeMethod( $mock, '__construct', [ $number_generator, $transients ] );
 
 		// An attribute of the Parts_Generator superclass.
-		$this->assertAttributeSame( $transients, 'site_transients', $mock );
+		$this->assert_attribute_same( $transients, 'site_transients', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-robohash-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-robohash-test.php
@@ -122,7 +122,7 @@ class Robohash_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->sut = m::mock( Robohash::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
 		// Override the parts directory as the constructor is never invoked.
-		$this->setValue( $this->sut, 'number_generator', $this->number_generator );
+		$this->set_value( $this->sut, 'number_generator', $this->number_generator );
 	}
 
 	/**
@@ -237,7 +237,7 @@ class Robohash_Test extends \Avatar_Privacy\Tests\TestCase {
 		$number_of_files = \count( $files, \COUNT_RECURSIVE ) - \count( $files );
 
 		// Override necessary properties.
-		$this->setValue( $this->sut, 'parts_dir', vfsStream::url( 'root/plugin/public/images/robohash' ) );
+		$this->set_value( $this->sut, 'parts_dir', vfsStream::url( 'root/plugin/public/images/robohash' ) );
 
 		$this->sut->shouldReceive( 'prepare_svg_part' )->times( $number_of_files )->with( m::type( 'string' ) )->andReturn( 'PREPARED_SVG_PART' );
 
@@ -255,7 +255,7 @@ class Robohash_Test extends \Avatar_Privacy\Tests\TestCase {
 		$parts = \array_fill_keys( [ 'body', 'arms', 'mouth', 'eyes', 'accessory' ], [] );
 
 		// Override necessary properties.
-		$this->setValue( $this->sut, 'parts_dir', vfsStream::url( 'root/plugin/public/images/robohash-empty' ) );
+		$this->set_value( $this->sut, 'parts_dir', vfsStream::url( 'root/plugin/public/images/robohash-empty' ) );
 
 		// Run test.
 		$this->assertSame( $parts, $this->sut->read_parts_from_filesystem( $parts ) );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-robohash-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-robohash-test.php
@@ -161,7 +161,7 @@ class Robohash_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = $this->sut->get_additional_arguments( $seed, $size, $parts );
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertArrayHasKey( 'color', $result );
 		$this->assertArrayHasKey( 'bg_color', $result );
 	}

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-robohash-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-robohash-test.php
@@ -138,7 +138,7 @@ class Robohash_Test extends \Avatar_Privacy\Tests\TestCase {
 		$number_generator = m::mock( Number_Generator::class );
 		$mock             = m::mock( Robohash::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $mock, '__construct', [ $number_generator, $transients ] );
+		$this->invoke_method( $mock, '__construct', [ $number_generator, $transients ] );
 
 		// An attribute of the Parts_Generator superclass.
 		$this->assert_attribute_same( $transients, 'site_transients', $mock );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-robohash-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-robohash-test.php
@@ -73,9 +73,11 @@ class Robohash_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'plugin' => [

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar-test.php
@@ -117,8 +117,8 @@ class Wavatar_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->sut = m::mock( Wavatar::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
 		// Override necessary properties as the constructor is never invoked.
-		$this->setValue( $this->sut, 'png', $this->png );
-		$this->setValue( $this->sut, 'number_generator', $this->number_generator );
+		$this->set_value( $this->sut, 'png', $this->png );
+		$this->set_value( $this->sut, 'number_generator', $this->number_generator );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar-test.php
@@ -139,7 +139,7 @@ class Wavatar_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->invokeMethod( $mock, '__construct', [ $editor, $png, $number_generator, $transients ] );
 
 		// An attribute of the PNG_Parts_Generator superclass.
-		$this->assertAttributeSame( $editor, 'editor', $mock );
+		$this->assert_attribute_same( $editor, 'editor', $mock );
 	}
 
 	/**
@@ -269,7 +269,7 @@ class Wavatar_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->assertSame( $data, $this->sut->build( $seed, $size ) );
 
-		$this->assertAttributeSame( $seed, 'current_seed', $this->sut );
+		$this->assert_attribute_same( $seed, 'current_seed', $this->sut );
 
 		return $this->sut;
 	}

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar-test.php
@@ -136,7 +136,7 @@ class Wavatar_Test extends \Avatar_Privacy\Tests\TestCase {
 		$transients       = m::mock( Site_Transients::class );
 		$mock             = m::mock( Wavatar::class )->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->invokeMethod( $mock, '__construct', [ $editor, $png, $number_generator, $transients ] );
+		$this->invoke_method( $mock, '__construct', [ $editor, $png, $number_generator, $transients ] );
 
 		// An attribute of the PNG_Parts_Generator superclass.
 		$this->assert_attribute_same( $editor, 'editor', $mock );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar-test.php
@@ -159,7 +159,7 @@ class Wavatar_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = $this->sut->get_additional_arguments( $seed, $size, $parts );
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertArrayHasKey( 'background_hue', $result );
 		$this->assertArrayHasKey( 'wavatar_hue', $result );
 	}

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar-test.php
@@ -75,9 +75,11 @@ class Wavatar_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$png_data = \base64_decode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions
 			'iVBORw0KGgoAAAANSUhEUgAAABwAAAASCAMAAAB/2U7WAAAABl' .

--- a/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-bowling-pin-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-bowling-pin-icon-provider-test.php
@@ -58,8 +58,8 @@ class Bowling_Pin_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $sut, '__construct', [] );
 
-		$this->assertAttributeSame( $types, 'valid_types', $sut );
-		$this->assertAttributeSame( 'shaded-cone', 'icon_basename', $sut );
+		$this->assert_attribute_same( $types, 'valid_types', $sut );
+		$this->assert_attribute_same( 'shaded-cone', 'icon_basename', $sut );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-bowling-pin-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-bowling-pin-icon-provider-test.php
@@ -56,7 +56,7 @@ class Bowling_Pin_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$sut   = m::mock( Bowling_Pin_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 		$types = \array_flip( [ 'bowling-pin', 'im-user-offline' ] );
 
-		$this->invokeMethod( $sut, '__construct', [] );
+		$this->invoke_method( $sut, '__construct', [] );
 
 		$this->assert_attribute_same( $types, 'valid_types', $sut );
 		$this->assert_attribute_same( 'shaded-cone', 'icon_basename', $sut );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-mystery-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-mystery-icon-provider-test.php
@@ -56,7 +56,7 @@ class Mystery_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$sut   = m::mock( Mystery_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 		$types = \array_flip( [ 'mystery', 'mystery-man', 'mm' ] );
 
-		$this->invokeMethod( $sut, '__construct', [] );
+		$this->invoke_method( $sut, '__construct', [] );
 
 		$this->assert_attribute_same( $types, 'valid_types', $sut );
 		$this->assert_attribute_same( 'mystery', 'icon_basename', $sut );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-mystery-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-mystery-icon-provider-test.php
@@ -58,7 +58,7 @@ class Mystery_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $sut, '__construct', [] );
 
-		$this->assertAttributeSame( $types, 'valid_types', $sut );
-		$this->assertAttributeSame( 'mystery', 'icon_basename', $sut );
+		$this->assert_attribute_same( $types, 'valid_types', $sut );
+		$this->assert_attribute_same( 'mystery', 'icon_basename', $sut );
 	}
 }

--- a/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-silhouette-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-silhouette-icon-provider-test.php
@@ -56,7 +56,7 @@ class Silhouette_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$sut   = m::mock( Silhouette_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 		$types = \array_flip( [ 'silhouette', 'view-media-artist' ] );
 
-		$this->invokeMethod( $sut, '__construct', [] );
+		$this->invoke_method( $sut, '__construct', [] );
 
 		$this->assert_attribute_same( $types, 'valid_types', $sut );
 		$this->assert_attribute_same( 'silhouette', 'icon_basename', $sut );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-silhouette-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-silhouette-icon-provider-test.php
@@ -58,8 +58,8 @@ class Silhouette_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $sut, '__construct', [] );
 
-		$this->assertAttributeSame( $types, 'valid_types', $sut );
-		$this->assertAttributeSame( 'silhouette', 'icon_basename', $sut );
+		$this->assert_attribute_same( $types, 'valid_types', $sut );
+		$this->assert_attribute_same( 'silhouette', 'icon_basename', $sut );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-speech-bubble-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-speech-bubble-icon-provider-test.php
@@ -58,8 +58,8 @@ class Speech_Bubble_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->invokeMethod( $sut, '__construct', [] );
 
-		$this->assertAttributeSame( $types, 'valid_types', $sut );
-		$this->assertAttributeSame( 'comment-bubble', 'icon_basename', $sut );
+		$this->assert_attribute_same( $types, 'valid_types', $sut );
+		$this->assert_attribute_same( 'comment-bubble', 'icon_basename', $sut );
 	}
 
 	/**

--- a/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-speech-bubble-icon-provider-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/static-icons/class-speech-bubble-icon-provider-test.php
@@ -56,7 +56,7 @@ class Speech_Bubble_Icon_Provider_Test extends \Avatar_Privacy\Tests\TestCase {
 		$sut   = m::mock( Speech_Bubble_Icon_Provider::class )->makePartial()->shouldAllowMockingProtectedMethods();
 		$types = \array_flip( [ 'bubble', 'comment' ] );
 
-		$this->invokeMethod( $sut, '__construct', [] );
+		$this->invoke_method( $sut, '__construct', [] );
 
 		$this->assert_attribute_same( $types, 'valid_types', $sut );
 		$this->assert_attribute_same( 'comment-bubble', 'icon_basename', $sut );

--- a/tests/avatar-privacy/class-controller-test.php
+++ b/tests/avatar-privacy/class-controller-test.php
@@ -100,7 +100,7 @@ class Controller_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @param \Avatar_Privacy\Controller $controller Required.
 	 */
 	public function test_run( $controller ) {
-		foreach ( $this->getValue( $controller, 'components', \Avatar_Privacy\Controller::class ) as $component ) {
+		foreach ( $this->get_value( $controller, 'components' ) as $component ) {
 			$component->shouldReceive( 'run' )->once();
 		}
 

--- a/tests/avatar-privacy/class-core-test.php
+++ b/tests/avatar-privacy/class-core-test.php
@@ -270,7 +270,7 @@ class Core_Test extends \Avatar_Privacy\Tests\TestCase {
 		];
 
 		// Prepare state - settings have alreaddy been loaded.
-		$this->setValue( $this->sut, 'settings', $original, \Avatar_Privacy\Core::class );
+		$this->set_value( $this->sut, 'settings', $original );
 
 		$this->options->shouldReceive( 'get' )
 			->never();
@@ -299,7 +299,7 @@ class Core_Test extends \Avatar_Privacy\Tests\TestCase {
 		];
 
 		// Prepare state - settings have alreaddy been loaded.
-		$this->setValue( $this->sut, 'settings', $original, \Avatar_Privacy\Core::class );
+		$this->set_value( $this->sut, 'settings', $original );
 
 		$this->options->shouldReceive( 'get' )
 			->once()
@@ -331,7 +331,7 @@ class Core_Test extends \Avatar_Privacy\Tests\TestCase {
 		];
 
 		// Prepare state - settings have alreaddy been loaded.
-		$this->setValue( $this->sut, 'settings', $original, \Avatar_Privacy\Core::class );
+		$this->set_value( $this->sut, 'settings', $original );
 
 		$this->options->shouldReceive( 'get' )
 			->once()
@@ -364,7 +364,7 @@ class Core_Test extends \Avatar_Privacy\Tests\TestCase {
 		];
 
 		// Prepare state - settings have alreaddy been loaded.
-		$this->setValue( $this->sut, 'settings', $original, \Avatar_Privacy\Core::class );
+		$this->set_value( $this->sut, 'settings', $original );
 
 		$this->options->shouldReceive( 'get' )
 			->once()

--- a/tests/avatar-privacy/class-core-test.php
+++ b/tests/avatar-privacy/class-core-test.php
@@ -191,26 +191,28 @@ class Core_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * Tests ::get_instance without a previous call to ::_get_instance (i.e. _doing_it_wrong).
 	 *
 	 * @covers ::get_instance
-	 *
-	 * @expectedException \BadMethodCallException
-	 * @expectedExceptionMessage Avatar_Privacy\Core::get_instance called without prior plugin intialization.
 	 */
 	public function test_get_instance_failing() {
+		$this->expectException( \BadMethodCallException::class );
+		$this->expectExceptionMessage( 'Avatar_Privacy\Core::get_instance called without prior plugin intialization.' );
+
 		$core = \Avatar_Privacy\Core::get_instance();
-		$this->assertInstanceOf( \Avatar_Privacy\Core::class, $core );
 	}
 
 	/**
 	 * Tests ::get_instance without a previous call to ::_get_instance (i.e. _doing_it_wrong).
 	 *
 	 * @covers ::set_instance
-	 *
-	 * @expectedException \BadMethodCallException
-	 * @expectedExceptionMessage Avatar_Privacy\Core::set_instance called more than once.
 	 */
 	public function test_set_instance_failing() {
 		$core = m::mock( \Avatar_Privacy\Core::class );
+
+		// The first call is OK.
 		\Avatar_Privacy\Core::set_instance( $core );
+
+		// The second call fails with an exception.
+		$this->expectException( \BadMethodCallException::class );
+		$this->expectExceptionMessage( 'Avatar_Privacy\Core::set_instance called more than once.' );
 		\Avatar_Privacy\Core::set_instance( $core );
 	}
 

--- a/tests/avatar-privacy/class-core-test.php
+++ b/tests/avatar-privacy/class-core-test.php
@@ -105,9 +105,11 @@ class Core_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() { // @codingStandardsIgnoreLine
-		parent::setUp();
+	protected function set_up() { // @codingStandardsIgnoreLine
+		parent::set_up();
 
 		// Mock required helpers.
 		$this->transients      = m::mock( Transients::class );
@@ -134,12 +136,14 @@ class Core_Test extends \Avatar_Privacy\Tests\TestCase {
 
 	/**
 	 * Necesssary clean-up work.
+	 *
+	 * @since 2.3.3 Renamed to `tear_down`.
 	 */
-	protected function tearDown() { // @codingStandardsIgnoreLine
+	protected function tear_down() { // @codingStandardsIgnoreLine
 		// Reset singleton.
 		$this->setStaticValue( \Avatar_Privacy\Core::class, 'instance', null );
 
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/avatar-privacy/class-core-test.php
+++ b/tests/avatar-privacy/class-core-test.php
@@ -141,7 +141,7 @@ class Core_Test extends \Avatar_Privacy\Tests\TestCase {
 	 */
 	protected function tear_down() { // @codingStandardsIgnoreLine
 		// Reset singleton.
-		$this->setStaticValue( \Avatar_Privacy\Core::class, 'instance', null );
+		$this->set_static_value( \Avatar_Privacy\Core::class, 'instance', null );
 
 		parent::tear_down();
 	}

--- a/tests/avatar-privacy/class-factory-test.php
+++ b/tests/avatar-privacy/class-factory-test.php
@@ -54,9 +54,11 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() { // @codingStandardsIgnoreLine
-		parent::setUp();
+	protected function set_up() { // @codingStandardsIgnoreLine
+		parent::set_up();
 
 		$filesystem = [
 			'wordpress' => [

--- a/tests/avatar-privacy/class-factory-test.php
+++ b/tests/avatar-privacy/class-factory-test.php
@@ -136,7 +136,7 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = $this->sut->get_rules();
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertArrayHasKey( \Avatar_Privacy\Core::class, $result );
 		$this->assertArrayHasKey( \Avatar_Privacy\Avatar_Handlers\Gravatar_Cache_Handler::class, $result );
 	}
@@ -186,7 +186,7 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_get_components() {
 		$result = $this->sut->get_components();
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 
 		// Check some exemplary components.
 		$this->assertContains( [ 'instance' => \Avatar_Privacy\Components\Avatar_Handling::class ], $result, 'Component missing.', false, true, true );
@@ -204,7 +204,7 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_get_default_icons() {
 		$result = $this->sut->get_default_icons();
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertContains( [ 'instance' => \Avatar_Privacy\Avatar_Handlers\Default_Icons\Static_Icons\Mystery_Icon_Provider::class ], $result, 'Default icon missing.', false, true, true );
 		$this->assertContains( [ 'instance' => \Avatar_Privacy\Avatar_Handlers\Default_Icons\Generated_Icons\Identicon_Icon_Provider::class ], $result, 'Default icon missing.', false, true, true );
 		$this->assertContains( [ 'instance' => \Avatar_Privacy\Avatar_Handlers\Default_Icons\Static_Icons\Speech_Bubble_Icon_Provider::class ], $result, 'Default icon missing.', false, true, true );
@@ -220,7 +220,7 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_get_plugin_integrations() {
 		$result = $this->sut->get_plugin_integrations();
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertContains( [ 'instance' => \Avatar_Privacy\Integrations\BBPress_Integration::class ], $result, 'Default icon missing.', false, true, true );
 	}
 
@@ -232,7 +232,7 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_get_cli_commands() {
 		$result = $this->sut->get_cli_commands();
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertContains( [ 'instance' => \Avatar_Privacy\CLI\Database_Command::class ], $result, 'Command missing.', false, true, true );
 	}
 }

--- a/tests/avatar-privacy/class-factory-test.php
+++ b/tests/avatar-privacy/class-factory-test.php
@@ -101,8 +101,9 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 		// Manually call constructor.
 		$this->sut->__construct();
 
-		$this->assertAttributeCount( \count( $rules ), 'rules', $this->sut );
-		$this->assertAttributeInternalType( 'array', 'rules', $this->sut );
+		$resulting_rules = $this->get_value( $this->sut, 'rules' );
+		$this->assert_is_array( $resulting_rules );
+		$this->assertCount( \count( $rules ), $resulting_rules );
 	}
 
 	/**

--- a/tests/avatar-privacy/class-functions-test.php
+++ b/tests/avatar-privacy/class-functions-test.php
@@ -45,9 +45,11 @@ class Functions_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'plugin' => [

--- a/tests/avatar-privacy/class-settings-test.php
+++ b/tests/avatar-privacy/class-settings-test.php
@@ -75,7 +75,7 @@ class Settings_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = $this->sut->get_fields( $information_header );
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertContainsOnly( 'string', \array_keys( $result ) );
 		$this->assertContainsOnly( 'array', $result );
 		$this->assertSame( $result[ Settings::INFORMATION_HEADER ]['elements'], [ $information_header ] );
@@ -91,7 +91,7 @@ class Settings_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_get_defaults() {
 		$result = $this->sut->get_defaults();
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertNotContainsOnly( 'array', $result );
 		$this->assertSame( '', $result[ Options::INSTALLED_VERSION ] );
 	}
@@ -104,7 +104,7 @@ class Settings_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_get_network_fields() {
 		$result = $this->sut->get_network_fields();
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertContainsOnly( 'string', \array_keys( $result ) );
 		$this->assertContainsOnly( 'array', $result );
 	}

--- a/tests/avatar-privacy/class-settings-test.php
+++ b/tests/avatar-privacy/class-settings-test.php
@@ -54,9 +54,11 @@ class Settings_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		Functions\when( '__' )->returnArg();
 

--- a/tests/avatar-privacy/cli/class-abstract-command-test.php
+++ b/tests/avatar-privacy/cli/class-abstract-command-test.php
@@ -64,11 +64,11 @@ class Abstract_Command_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->assertNull( $sut->stop_the_insanity() );
 
-		$this->assertAttributeEmpty( 'queries', $wpdb );
-		$this->assertAttributeEmpty( 'group_ops', $wp_object_cache );
-		$this->assertAttributeEmpty( 'stats', $wp_object_cache );
-		$this->assertAttributeEmpty( 'memcache_debug', $wp_object_cache );
-		$this->assertAttributeEmpty( 'cache', $wp_object_cache );
+		$this->assertEmpty( $this->get_value( $wpdb, 'queries' ) );
+		$this->assertEmpty( $this->get_value( $wp_object_cache, 'group_ops' ) );
+		$this->assertEmpty( $this->get_value( $wp_object_cache, 'stats' ) );
+		$this->assertEmpty( $this->get_value( $wp_object_cache, 'memcache_debug' ) );
+		$this->assertEmpty( $this->get_value( $wp_object_cache, 'cache' ) );
 	}
 
 	/**

--- a/tests/avatar-privacy/cli/class-cron-command-test.php
+++ b/tests/avatar-privacy/cli/class-cron-command-test.php
@@ -55,9 +55,11 @@ class Cron_Command_Test extends TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->sut = m::mock(
 			Cron_Command::class,

--- a/tests/avatar-privacy/cli/class-database-command-test.php
+++ b/tests/avatar-privacy/cli/class-database-command-test.php
@@ -71,9 +71,11 @@ class Database_Command_Test extends TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Helper mocks.
 		$this->core     = m::mock( Core::class );

--- a/tests/avatar-privacy/cli/class-database-command-test.php
+++ b/tests/avatar-privacy/cli/class-database-command-test.php
@@ -107,8 +107,8 @@ class Database_Command_Test extends TestCase {
 
 		$mock->__construct( $this->core, $this->database );
 
-		$this->assertAttributeSame( $this->core, 'core', $mock );
-		$this->assertAttributeSame( $this->database, 'db', $mock );
+		$this->assert_attribute_same( $this->core, 'core', $mock );
+		$this->assert_attribute_same( $this->database, 'db', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/cli/class-testcase.php
+++ b/tests/avatar-privacy/cli/class-testcase.php
@@ -43,9 +43,11 @@ abstract class TestCase extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// API class mock.
 		$this->wp_cli = m::mock( 'alias:' . \WP_CLI::class );

--- a/tests/avatar-privacy/cli/class-uninstall-command-test.php
+++ b/tests/avatar-privacy/cli/class-uninstall-command-test.php
@@ -110,9 +110,9 @@ class Uninstall_Command_Test extends TestCase {
 
 		$mock->__construct( $this->setup, $this->uninstall, $this->database );
 
-		$this->assertAttributeSame( $this->setup, 'setup', $mock );
-		$this->assertAttributeSame( $this->uninstall, 'uninstall', $mock );
-		$this->assertAttributeSame( $this->database, 'db', $mock );
+		$this->assert_attribute_same( $this->setup, 'setup', $mock );
+		$this->assert_attribute_same( $this->uninstall, 'uninstall', $mock );
+		$this->assert_attribute_same( $this->database, 'db', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/cli/class-uninstall-command-test.php
+++ b/tests/avatar-privacy/cli/class-uninstall-command-test.php
@@ -79,9 +79,11 @@ class Uninstall_Command_Test extends TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Helper mocks.
 		$this->setup     = m::mock( Setup::class );

--- a/tests/avatar-privacy/components/class-avatar-handling-test.php
+++ b/tests/avatar-privacy/components/class-avatar-handling-test.php
@@ -249,7 +249,10 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 			}
 		}
 
-		$this->assertArraySubset( [ 'url' => $result ], $this->sut->get_avatar_data( $args, $id_or_email ) );
+		$avatar_response = $this->sut->get_avatar_data( $args, $id_or_email );
+
+		$this->assertArrayHasKey( 'url', $avatar_response );
+		$this->assertSame( $result, $avatar_response['url'] );
 	}
 
 	/**

--- a/tests/avatar-privacy/components/class-avatar-handling-test.php
+++ b/tests/avatar-privacy/components/class-avatar-handling-test.php
@@ -94,9 +94,11 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Ubiquitous functions.
 		Functions\when( '__' )->returnArg();

--- a/tests/avatar-privacy/components/class-avatar-handling-test.php
+++ b/tests/avatar-privacy/components/class-avatar-handling-test.php
@@ -126,9 +126,9 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $this->core, $this->options, $this->gravatar );
 
-		$this->assertAttributeSame( $this->core, 'core', $mock );
-		$this->assertAttributeSame( $this->options, 'options', $mock );
-		$this->assertAttributeSame( $this->gravatar, 'gravatar', $mock );
+		$this->assert_attribute_same( $this->core, 'core', $mock );
+		$this->assert_attribute_same( $this->options, 'options', $mock );
+		$this->assert_attribute_same( $this->gravatar, 'gravatar', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/components/class-avatar-handling-test.php
+++ b/tests/avatar-privacy/components/class-avatar-handling-test.php
@@ -299,7 +299,7 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 			Filters\expectApplied( 'avatar_privacy_enable_gravatar_check' )->never();
 		}
 
-		$this->assertSame( $expected, $this->invokeMethod( $this->sut, 'should_show_gravatar', [ $user_id, $email, $id_or_email, $age, &$mime ] ) );
+		$this->assertSame( $expected, $this->invoke_method( $this->sut, 'should_show_gravatar', [ $user_id, $email, $id_or_email, $age, &$mime ] ) );
 		if ( $show_gravatar && $check_enabled ) {
 			$this->assertSame( $mimetype, $mime );
 		}
@@ -515,7 +515,7 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 			$this->sut->shouldReceive( 'get_age' )->once()->with( $comment_date_gmt )->andReturn( $now - \strtotime( $comment_date_gmt ) );
 		}
 
-		$this->assertSame( $result, $this->invokeMethod( $this->sut, 'parse_comment', [ $comment ] ) );
+		$this->assertSame( $result, $this->invoke_method( $this->sut, 'parse_comment', [ $comment ] ) );
 	}
 
 	/**
@@ -530,7 +530,7 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		Functions\expect( 'mysql2date' )->once()->with( 'U', $date )->andReturn( $now - $age );
 
-		$result = $this->invokeMethod( $this->sut, 'get_age', [ $date ] );
+		$result = $this->invoke_method( $this->sut, 'get_age', [ $date ] );
 		$this->assertGreaterThanOrEqual( 550, $result );
 		$this->assertLessThanOrEqual( 560, $result );
 	}

--- a/tests/avatar-privacy/components/class-block-editor-test.php
+++ b/tests/avatar-privacy/components/class-block-editor-test.php
@@ -73,9 +73,11 @@ class Block_Editor_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'plugin'    => [

--- a/tests/avatar-privacy/components/class-block-editor-test.php
+++ b/tests/avatar-privacy/components/class-block-editor-test.php
@@ -115,8 +115,8 @@ class Block_Editor_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $this->core, $this->form );
 
-		$this->assertAttributeSame( $this->core, 'core', $mock );
-		$this->assertAttributeSame( $this->form, 'form', $mock );
+		$this->assert_attribute_same( $this->core, 'core', $mock );
+		$this->assert_attribute_same( $this->form, 'form', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/components/class-command-line-interface-test.php
+++ b/tests/avatar-privacy/components/class-command-line-interface-test.php
@@ -114,7 +114,7 @@ class Command_Line_Interface_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $commands );
 
-		$this->assertAttributeSame( $commands, 'commands', $mock );
+		$this->assert_attribute_same( $commands, 'commands', $mock );
 	}
 
 

--- a/tests/avatar-privacy/components/class-command-line-interface-test.php
+++ b/tests/avatar-privacy/components/class-command-line-interface-test.php
@@ -77,9 +77,11 @@ class Command_Line_Interface_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// API class mock.
 		$this->wp_cli = m::mock( 'alias:' . \WP_CLI::class );

--- a/tests/avatar-privacy/components/class-comments-test.php
+++ b/tests/avatar-privacy/components/class-comments-test.php
@@ -65,9 +65,11 @@ class Comments_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'plugin'    => [
@@ -456,6 +458,7 @@ class Comments_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::set_comment_cookies
 	 *
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 * @requires extension xdebug
 	 */
 	public function test_set_comment_cookies() {
@@ -491,6 +494,7 @@ class Comments_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::set_comment_cookies
 	 *
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 * @requires extension xdebug
 	 */
 	public function test_set_comment_cookies_no_consent() {
@@ -523,6 +527,7 @@ class Comments_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::set_comment_cookies
 	 *
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 * @requires extension xdebug
 	 */
 	public function test_set_comment_cookies_user_exists() {

--- a/tests/avatar-privacy/components/class-comments-test.php
+++ b/tests/avatar-privacy/components/class-comments-test.php
@@ -109,7 +109,7 @@ class Comments_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $this->core );
 
-		$this->assertAttributeSame( $this->core, 'core', $mock );
+		$this->assert_attribute_same( $this->core, 'core', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/components/class-image-proxy-test.php
+++ b/tests/avatar-privacy/components/class-image-proxy-test.php
@@ -117,9 +117,11 @@ class Image_Proxy_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'uploads'   => [
@@ -381,6 +383,7 @@ class Image_Proxy_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::send_image
 	 *
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 * @requires extension xdebug
 	 */
 	public function test_send_image() {
@@ -408,6 +411,7 @@ class Image_Proxy_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::send_image
 	 *
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 * @requires extension xdebug
 	 */
 	public function test_send_image_invalid_file() {

--- a/tests/avatar-privacy/components/class-image-proxy-test.php
+++ b/tests/avatar-privacy/components/class-image-proxy-test.php
@@ -173,10 +173,10 @@ class Image_Proxy_Test extends \Avatar_Privacy\Tests\TestCase {
 			$this->default_icons
 		);
 
-		$this->assertAttributeSame( $this->site_transients, 'site_transients', $mock );
-		$this->assertAttributeSame( $this->options, 'options', $mock );
-		$this->assertAttributeSame( $this->file_cache, 'file_cache', $mock );
-		$this->assertAttributeSame(
+		$this->assert_attribute_same( $this->site_transients, 'site_transients', $mock );
+		$this->assert_attribute_same( $this->options, 'options', $mock );
+		$this->assert_attribute_same( $this->file_cache, 'file_cache', $mock );
+		$this->assert_attribute_same(
 			[
 				Avatar_Handler::GRAVATAR       => $this->gravatar,
 				Avatar_Handler::USER_AVATAR    => $this->user_avatar,

--- a/tests/avatar-privacy/components/class-integrations-test.php
+++ b/tests/avatar-privacy/components/class-integrations-test.php
@@ -97,7 +97,7 @@ class Integrations_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $this->integrations );
 
-		$this->assertAttributeSame( $this->integrations, 'integrations', $mock );
+		$this->assert_attribute_same( $this->integrations, 'integrations', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/components/class-integrations-test.php
+++ b/tests/avatar-privacy/components/class-integrations-test.php
@@ -71,9 +71,11 @@ class Integrations_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Mock required helpers.
 		$this->integrations = [

--- a/tests/avatar-privacy/components/class-network-settings-page-test.php
+++ b/tests/avatar-privacy/components/class-network-settings-page-test.php
@@ -217,7 +217,7 @@ class Network_Settings_Page_Test extends \Avatar_Privacy\Tests\TestCase {
 			$migrate   => m::mock( \Mundschenk\UI\Controls\Submit_Input::class ),
 		];
 		$control_count = \count( $controls );
-		$this->setValue( $this->sut, 'controls', $controls, Network_Settings_Page::class );
+		$this->set_value( $this->sut, 'controls', $controls );
 
 		// Function results.
 		$use_global_table_name = 'prefix_use_global_table';
@@ -278,7 +278,7 @@ class Network_Settings_Page_Test extends \Avatar_Privacy\Tests\TestCase {
 			'option3' => m::mock( \Mundschenk\UI\Controls\Number_Input::class ),
 		];
 		$control_count = \count( $controls );
-		$this->setValue( $this->sut, 'controls', $controls, Network_Settings_Page::class );
+		$this->set_value( $this->sut, 'controls', $controls );
 
 		// URLs.
 		$network_admin_url              = 'https://network.admin/url/settings.php';
@@ -410,7 +410,7 @@ class Network_Settings_Page_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		// Notice already triggered.
 		$triggered = [ $setting_name => true ];
-		$this->setValue( $this->sut, 'triggered_notice', $triggered, Network_Settings_Page::class );
+		$this->set_value( $this->sut, 'triggered_notice', $triggered );
 
 		Functions\expect( 'add_settings_error' )->never();
 

--- a/tests/avatar-privacy/components/class-network-settings-page-test.php
+++ b/tests/avatar-privacy/components/class-network-settings-page-test.php
@@ -147,10 +147,10 @@ class Network_Settings_Page_Test extends \Avatar_Privacy\Tests\TestCase {
 			$this->multisite
 		);
 
-		$this->assertAttributeSame( $this->core, 'core', $mock );
-		$this->assertAttributeSame( $this->network_options, 'network_options', $mock );
-		$this->assertAttributeSame( $this->settings, 'settings', $mock );
-		$this->assertAttributeSame( $this->multisite, 'multisite', $mock );
+		$this->assert_attribute_same( $this->core, 'core', $mock );
+		$this->assert_attribute_same( $this->network_options, 'network_options', $mock );
+		$this->assert_attribute_same( $this->settings, 'settings', $mock );
+		$this->assert_attribute_same( $this->multisite, 'multisite', $mock );
 	}
 
 

--- a/tests/avatar-privacy/components/class-network-settings-page-test.php
+++ b/tests/avatar-privacy/components/class-network-settings-page-test.php
@@ -97,9 +97,11 @@ class Network_Settings_Page_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		Functions\when( '__' )->returnArg();
 
@@ -172,6 +174,7 @@ class Network_Settings_Page_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::run
 	 *
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_run_network_admin() {
 		// External input.

--- a/tests/avatar-privacy/components/class-privacy-tools-test.php
+++ b/tests/avatar-privacy/components/class-privacy-tools-test.php
@@ -98,8 +98,8 @@ class Privacy_Tools_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $this->core, $this->cache );
 
-		$this->assertAttributeSame( $this->core, 'core', $mock );
-		$this->assertAttributeSame( $this->cache, 'cache', $mock );
+		$this->assert_attribute_same( $this->core, 'core', $mock );
+		$this->assert_attribute_same( $this->cache, 'cache', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/components/class-privacy-tools-test.php
+++ b/tests/avatar-privacy/components/class-privacy-tools-test.php
@@ -72,9 +72,11 @@ class Privacy_Tools_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Ubiquitous functions.
 		Functions\when( '__' )->returnArg();

--- a/tests/avatar-privacy/components/class-rest-api-test.php
+++ b/tests/avatar-privacy/components/class-rest-api-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -54,9 +54,11 @@ class REST_API_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->sut = m::mock( REST_API::class )->makePartial()->shouldAllowMockingProtectedMethods();
 	}

--- a/tests/avatar-privacy/components/class-rest-api-test.php
+++ b/tests/avatar-privacy/components/class-rest-api-test.php
@@ -100,8 +100,12 @@ class REST_API_Test extends \Avatar_Privacy\Tests\TestCase {
 		Functions\expect( 'rest_get_avatar_sizes' )->once()->andReturn( $sizes );
 		Functions\expect( 'get_avatar_url' )->times( \count( $sizes ) )->with( $user, m::type( 'array' ) )->andReturn( 'another/url1', 'another/url2' );
 
+		// Run method.
 		$this->assertSame( $response, $this->sut->fix_rest_user_avatars( $response, $user ) );
-		$this->assertArraySubset( [ 'avatar_urls' => [] ], $response->data );
+
+		// Check if response data is different from its initial state.
+		$this->assertArrayHasKey( 'avatar_urls', $response->data );
+		$this->assertSame( $expected, $response->data['avatar_urls'] );
 	}
 
 	/**
@@ -129,7 +133,11 @@ class REST_API_Test extends \Avatar_Privacy\Tests\TestCase {
 		Functions\expect( 'rest_get_avatar_sizes' )->once()->andReturn( $sizes );
 		Functions\expect( 'get_avatar_url' )->times( \count( $sizes ) )->with( $comment, m::type( 'array' ) )->andReturn( 'another/url1', 'another/url2' );
 
+		// Run method.
 		$this->assertSame( $response, $this->sut->fix_rest_comment_author_avatars( $response, $comment ) );
-		$this->assertArraySubset( [ 'author_avatar_urls' => $expected ], $response->data );
+
+		// Check if response data is different from its initial state.
+		$this->assertArrayHasKey( 'author_avatar_urls', $response->data );
+		$this->assertSame( $expected, $response->data['author_avatar_urls'] );
 	}
 }

--- a/tests/avatar-privacy/components/class-settings-page-test.php
+++ b/tests/avatar-privacy/components/class-settings-page-test.php
@@ -297,7 +297,7 @@ class Settings_Page_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = $this->sut->sanitize_settings( $input );
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertSame( $old_avatar, $result[ Settings::UPLOAD_CUSTOM_DEFAULT_AVATAR ] );
 		$this->assertFalse( $result['setting1'] );
 		$this->assertSame( 'foo', $result['setting2'] );
@@ -339,7 +339,7 @@ class Settings_Page_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = $this->sut->sanitize_settings( $input );
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertSame( $old_avatar, $result[ Settings::UPLOAD_CUSTOM_DEFAULT_AVATAR ] );
 		$this->assertTrue( $result['setting1'] );
 		$this->assertSame( 'foo', $result['setting2'] );
@@ -376,7 +376,7 @@ class Settings_Page_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = $this->sut->sanitize_settings( $input );
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertSame( $new_avatar, $result[ Settings::UPLOAD_CUSTOM_DEFAULT_AVATAR ] );
 		$this->assertFalse( $result['setting1'] );
 		$this->assertFalse( isset( $result['setting2'] ) );

--- a/tests/avatar-privacy/components/class-settings-page-test.php
+++ b/tests/avatar-privacy/components/class-settings-page-test.php
@@ -131,10 +131,10 @@ class Settings_Page_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $this->core, $this->options, $this->upload, $this->settings );
 
-		$this->assertAttributeSame( $this->core, 'core', $mock );
-		$this->assertAttributeSame( $this->options, 'options', $mock );
-		$this->assertAttributeSame( $this->upload, 'upload', $mock );
-		$this->assertAttributeSame( $this->settings, 'settings', $mock );
+		$this->assert_attribute_same( $this->core, 'core', $mock );
+		$this->assert_attribute_same( $this->options, 'options', $mock );
+		$this->assert_attribute_same( $this->upload, 'upload', $mock );
+		$this->assert_attribute_same( $this->settings, 'settings', $mock );
 	}
 
 
@@ -177,7 +177,7 @@ class Settings_Page_Test extends \Avatar_Privacy\Tests\TestCase {
 	 */
 	public function test_settings_head() {
 		$this->assertNull( $this->sut->settings_head() );
-		$this->assertAttributeSame( true, 'buffering', $this->sut );
+		$this->assert_attribute_same( true, 'buffering', $this->sut );
 
 		// Clean up.
 		\ob_end_flush();
@@ -198,7 +198,7 @@ class Settings_Page_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->expectOutputString( 'AVATARS_DISABLED_SCRIPT' );
 
 		$this->assertNull( $this->sut->settings_footer() );
-		$this->assertAttributeSame( false, 'buffering', $this->sut );
+		$this->assert_attribute_same( false, 'buffering', $this->sut );
 	}
 
 	/**

--- a/tests/avatar-privacy/components/class-settings-page-test.php
+++ b/tests/avatar-privacy/components/class-settings-page-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -89,9 +89,11 @@ class Settings_Page_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'plugin'    => [
@@ -205,6 +207,7 @@ class Settings_Page_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::register_settings
 	 *
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_register_settings() {
 		// External input.

--- a/tests/avatar-privacy/components/class-settings-page-test.php
+++ b/tests/avatar-privacy/components/class-settings-page-test.php
@@ -193,7 +193,7 @@ class Settings_Page_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		// Fake settings_head.
 		\ob_start();
-		$this->setValue( $this->sut, 'buffering', true, Settings_Page::class );
+		$this->set_value( $this->sut, 'buffering', true );
 
 		$this->expectOutputString( 'AVATARS_DISABLED_SCRIPT' );
 

--- a/tests/avatar-privacy/components/class-setup-test.php
+++ b/tests/avatar-privacy/components/class-setup-test.php
@@ -163,13 +163,13 @@ class Setup_Test extends \Avatar_Privacy\Tests\TestCase {
 			$this->multisite
 		);
 
-		$this->assertAttributeSame( $this->core, 'core', $mock );
-		$this->assertAttributeSame( $this->transients, 'transients', $mock );
-		$this->assertAttributeSame( $this->site_transients, 'site_transients', $mock );
-		$this->assertAttributeSame( $this->options, 'options', $mock );
-		$this->assertAttributeSame( $this->network_options, 'network_options', $mock );
-		$this->assertAttributeSame( $this->database, 'database', $mock );
-		$this->assertAttributeSame( $this->multisite, 'multisite', $mock );
+		$this->assert_attribute_same( $this->core, 'core', $mock );
+		$this->assert_attribute_same( $this->transients, 'transients', $mock );
+		$this->assert_attribute_same( $this->site_transients, 'site_transients', $mock );
+		$this->assert_attribute_same( $this->options, 'options', $mock );
+		$this->assert_attribute_same( $this->network_options, 'network_options', $mock );
+		$this->assert_attribute_same( $this->database, 'database', $mock );
+		$this->assert_attribute_same( $this->multisite, 'multisite', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/components/class-setup-test.php
+++ b/tests/avatar-privacy/components/class-setup-test.php
@@ -116,9 +116,11 @@ class Setup_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Helper mocks.
 		$this->core            = m::mock( Core::class );

--- a/tests/avatar-privacy/components/class-setup-test.php
+++ b/tests/avatar-privacy/components/class-setup-test.php
@@ -268,7 +268,7 @@ class Setup_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->sut->shouldReceive( 'flush_rewrite_rules_soon' )->once();
 
 		// Preserve pass-by-reference.
-		$this->assertNull( $this->invokeMethod( $this->sut, 'plugin_updated', [ $previous, &$settings ] ) );
+		$this->assertNull( $this->invoke_method( $this->sut, 'plugin_updated', [ $previous, &$settings ] ) );
 
 		$this->assertFalse( isset( $settings['mode_optin'] ) );
 		$this->assertFalse( isset( $settings['use_gravatar'] ) );
@@ -298,7 +298,7 @@ class Setup_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->sut->shouldReceive( 'flush_rewrite_rules_soon' )->once();
 
 		// Preserve pass-by-reference.
-		$this->assertNull( $this->invokeMethod( $this->sut, 'plugin_updated', [ $previous, &$settings ] ) );
+		$this->assertNull( $this->invoke_method( $this->sut, 'plugin_updated', [ $previous, &$settings ] ) );
 
 		$this->assertFalse( isset( $settings['mode_optin'] ) );
 		$this->assertFalse( isset( $settings['use_gravatar'] ) );
@@ -328,7 +328,7 @@ class Setup_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->sut->shouldReceive( 'flush_rewrite_rules_soon' )->once();
 
 		// Preserve pass-by-reference.
-		$this->assertNull( $this->invokeMethod( $this->sut, 'plugin_updated', [ $previous, &$settings ] ) );
+		$this->assertNull( $this->invoke_method( $this->sut, 'plugin_updated', [ $previous, &$settings ] ) );
 
 		$this->assertFalse( isset( $settings['mode_optin'] ) );
 		$this->assertFalse( isset( $settings['use_gravatar'] ) );
@@ -358,7 +358,7 @@ class Setup_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->sut->shouldReceive( 'flush_rewrite_rules_soon' )->once();
 
 		// Preserve pass-by-reference.
-		$this->assertNull( $this->invokeMethod( $this->sut, 'plugin_updated', [ $previous, &$settings ] ) );
+		$this->assertNull( $this->invoke_method( $this->sut, 'plugin_updated', [ $previous, &$settings ] ) );
 
 		$this->assertFalse( isset( $settings['mode_optin'] ) );
 		$this->assertFalse( isset( $settings['use_gravatar'] ) );

--- a/tests/avatar-privacy/components/class-shortcodes-test.php
+++ b/tests/avatar-privacy/components/class-shortcodes-test.php
@@ -103,7 +103,7 @@ class Shortcodes_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $this->form );
 
-		$this->assertAttributeSame( $this->form, 'form', $mock );
+		$this->assert_attribute_same( $this->form, 'form', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/components/class-shortcodes-test.php
+++ b/tests/avatar-privacy/components/class-shortcodes-test.php
@@ -67,9 +67,11 @@ class Shortcodes_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'plugin'    => [

--- a/tests/avatar-privacy/components/class-uninstallation-test.php
+++ b/tests/avatar-privacy/components/class-uninstallation-test.php
@@ -111,9 +111,11 @@ class Uninstallation_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'uploads'    => [

--- a/tests/avatar-privacy/components/class-uninstallation-test.php
+++ b/tests/avatar-privacy/components/class-uninstallation-test.php
@@ -153,12 +153,12 @@ class Uninstallation_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $this->options, $this->network_options, $this->transients, $this->site_transients, $this->database, $this->file_cache );
 
-		$this->assertAttributeSame( $this->options, 'options', $mock );
-		$this->assertAttributeSame( $this->network_options, 'network_options', $mock );
-		$this->assertAttributeSame( $this->transients, 'transients', $mock );
-		$this->assertAttributeSame( $this->site_transients, 'site_transients', $mock );
-		$this->assertAttributeSame( $this->database, 'database', $mock );
-		$this->assertAttributeSame( $this->file_cache, 'file_cache', $mock );
+		$this->assert_attribute_same( $this->options, 'options', $mock );
+		$this->assert_attribute_same( $this->network_options, 'network_options', $mock );
+		$this->assert_attribute_same( $this->transients, 'transients', $mock );
+		$this->assert_attribute_same( $this->site_transients, 'site_transients', $mock );
+		$this->assert_attribute_same( $this->database, 'database', $mock );
+		$this->assert_attribute_same( $this->file_cache, 'file_cache', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/components/class-user-profile-test.php
+++ b/tests/avatar-privacy/components/class-user-profile-test.php
@@ -64,9 +64,11 @@ class User_Profile_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->form = m::mock( User_Form::class );
 

--- a/tests/avatar-privacy/components/class-user-profile-test.php
+++ b/tests/avatar-privacy/components/class-user-profile-test.php
@@ -85,7 +85,7 @@ class User_Profile_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $this->form );
 
-		$this->assertAttributeSame( $this->form, 'form', $mock );
+		$this->assert_attribute_same( $this->form, 'form', $mock );
 	}
 
 
@@ -144,7 +144,7 @@ class User_Profile_Test extends \Avatar_Privacy\Tests\TestCase {
 	 */
 	public function test_admin_head() {
 		$this->assertNull( $this->sut->admin_head() );
-		$this->assertAttributeSame( true, 'buffering', $this->sut );
+		$this->assert_attribute_same( true, 'buffering', $this->sut );
 
 		// Clean up.
 		\ob_end_flush();
@@ -161,7 +161,7 @@ class User_Profile_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->set_value( $this->sut, 'buffering', true );
 
 		$this->assertNull( $this->sut->admin_footer() );
-		$this->assertAttributeSame( false, 'buffering', $this->sut );
+		$this->assert_attribute_same( false, 'buffering', $this->sut );
 	}
 
 	/**

--- a/tests/avatar-privacy/components/class-user-profile-test.php
+++ b/tests/avatar-privacy/components/class-user-profile-test.php
@@ -158,7 +158,7 @@ class User_Profile_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_admin_footer() {
 		// Fake settings_head.
 		\ob_start();
-		$this->setValue( $this->sut, 'buffering', true, User_Profile::class );
+		$this->set_value( $this->sut, 'buffering', true );
 
 		$this->assertNull( $this->sut->admin_footer() );
 		$this->assertAttributeSame( false, 'buffering', $this->sut );
@@ -187,7 +187,7 @@ class User_Profile_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->assertSame( $content, $this->sut->replace_profile_picture_section( $content ) );
 
 		// Set `markup`.
-		$this->setValue( $this->sut, 'markup', 'FOOBAR', User_Profile::class );
+		$this->set_value( $this->sut, 'markup', 'FOOBAR' );
 
 		// Content should be unchanged because the pattern does not match.
 		$content = 'some content with <tr class="foobar">foobar</tr>';
@@ -212,6 +212,6 @@ class User_Profile_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->form->shouldReceive( 'get_allow_anonymous_checkbox' )->once()->with( $user->ID )->andReturn( 'BAZ' );
 
 		$this->assertNull( $this->sut->add_user_profile_fields( $user ) );
-		$this->assertSame( 'FOOBARBAZ', $this->getValue( $this->sut, 'markup', User_Profile::class ) );
+		$this->assertSame( 'FOOBARBAZ', $this->get_value( $this->sut, 'markup' ) );
 	}
 }

--- a/tests/avatar-privacy/data-storage/class-cache-test.php
+++ b/tests/avatar-privacy/data-storage/class-cache-test.php
@@ -66,7 +66,7 @@ class Cache_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = new Cache();
 
-		$this->assertAttributeSame( Cache::PREFIX, 'prefix', $result );
-		$this->assertAttributeSame( Cache::GROUP, 'group', $result );
+		$this->assert_attribute_same( Cache::PREFIX, 'prefix', $result );
+		$this->assert_attribute_same( Cache::GROUP, 'group', $result );
 	}
 }

--- a/tests/avatar-privacy/data-storage/class-cache-test.php
+++ b/tests/avatar-privacy/data-storage/class-cache-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -45,9 +45,11 @@ class Cache_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		Functions\when( '__' )->returnArg();
 	}

--- a/tests/avatar-privacy/data-storage/class-database-test.php
+++ b/tests/avatar-privacy/data-storage/class-database-test.php
@@ -111,8 +111,8 @@ class Database_Test extends \Avatar_Privacy\Tests\TestCase {
 		$mock = m::mock( Database::class )->makePartial();
 		$mock->__construct( $this->core, $this->network_options );
 
-		$this->assertAttributeSame( $this->core, 'core', $mock );
-		$this->assertAttributeSame( $this->network_options, 'network_options', $mock );
+		$this->assert_attribute_same( $this->core, 'core', $mock );
+		$this->assert_attribute_same( $this->network_options, 'network_options', $mock );
 		$this->assertAttributeInternalType( 'array', 'placeholder', $mock );
 	}
 
@@ -340,7 +340,7 @@ class Database_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->assertAttributeContains( Database::TABLE_BASENAME, 'tables', $db );
 		$this->assertAttributeNotContains( Database::TABLE_BASENAME, 'ms_global_tables', $db );
-		$this->assertAttributeSame( $table_name, Database::TABLE_BASENAME, $db );
+		$this->assert_attribute_same( $table_name, Database::TABLE_BASENAME, $db );
 	}
 
 	/**
@@ -363,7 +363,7 @@ class Database_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->assertAttributeContains( Database::TABLE_BASENAME, 'tables', $db );
 		$this->assertAttributeNotContains( Database::TABLE_BASENAME, 'ms_global_tables', $db );
-		$this->assertAttributeSame( $table_name, Database::TABLE_BASENAME, $db );
+		$this->assert_attribute_same( $table_name, Database::TABLE_BASENAME, $db );
 	}
 
 	/**
@@ -386,7 +386,7 @@ class Database_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->assertAttributeNotContains( Database::TABLE_BASENAME, 'tables', $db );
 		$this->assertAttributeContains( Database::TABLE_BASENAME, 'ms_global_tables', $db );
-		$this->assertAttributeSame( $table_name, Database::TABLE_BASENAME, $db );
+		$this->assert_attribute_same( $table_name, Database::TABLE_BASENAME, $db );
 	}
 
 	/**

--- a/tests/avatar-privacy/data-storage/class-database-test.php
+++ b/tests/avatar-privacy/data-storage/class-database-test.php
@@ -113,7 +113,7 @@ class Database_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->assert_attribute_same( $this->core, 'core', $mock );
 		$this->assert_attribute_same( $this->network_options, 'network_options', $mock );
-		$this->assertAttributeInternalType( 'array', 'placeholder', $mock );
+		$this->assert_is_array( $this->get_value( $mock, 'placeholder' ) );
 	}
 
 	/**

--- a/tests/avatar-privacy/data-storage/class-database-test.php
+++ b/tests/avatar-privacy/data-storage/class-database-test.php
@@ -338,8 +338,8 @@ class Database_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->assertNull( $this->sut->register_table( $db, $table_name ) );
 
-		$this->assertAttributeContains( Database::TABLE_BASENAME, 'tables', $db );
-		$this->assertAttributeNotContains( Database::TABLE_BASENAME, 'ms_global_tables', $db );
+		$this->assert_attribute_contains( Database::TABLE_BASENAME, 'tables', $db );
+		$this->assert_attribute_not_contains( Database::TABLE_BASENAME, 'ms_global_tables', $db );
 		$this->assert_attribute_same( $table_name, Database::TABLE_BASENAME, $db );
 	}
 
@@ -361,8 +361,8 @@ class Database_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->assertNull( $this->sut->register_table( $db, $table_name ) );
 
-		$this->assertAttributeContains( Database::TABLE_BASENAME, 'tables', $db );
-		$this->assertAttributeNotContains( Database::TABLE_BASENAME, 'ms_global_tables', $db );
+		$this->assert_attribute_contains( Database::TABLE_BASENAME, 'tables', $db );
+		$this->assert_attribute_not_contains( Database::TABLE_BASENAME, 'ms_global_tables', $db );
 		$this->assert_attribute_same( $table_name, Database::TABLE_BASENAME, $db );
 	}
 
@@ -384,8 +384,8 @@ class Database_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->assertNull( $this->sut->register_table( $db, $table_name ) );
 
-		$this->assertAttributeNotContains( Database::TABLE_BASENAME, 'tables', $db );
-		$this->assertAttributeContains( Database::TABLE_BASENAME, 'ms_global_tables', $db );
+		$this->assert_attribute_not_contains( Database::TABLE_BASENAME, 'tables', $db );
+		$this->assert_attribute_contains( Database::TABLE_BASENAME, 'ms_global_tables', $db );
 		$this->assert_attribute_same( $table_name, Database::TABLE_BASENAME, $db );
 	}
 

--- a/tests/avatar-privacy/data-storage/class-database-test.php
+++ b/tests/avatar-privacy/data-storage/class-database-test.php
@@ -73,9 +73,11 @@ class Database_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'wordpress' => [

--- a/tests/avatar-privacy/data-storage/class-filesystem-cache-test.php
+++ b/tests/avatar-privacy/data-storage/class-filesystem-cache-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -55,9 +55,11 @@ class Filesystem_Cache_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'uploads' => [

--- a/tests/avatar-privacy/data-storage/class-network-options-test.php
+++ b/tests/avatar-privacy/data-storage/class-network-options-test.php
@@ -73,7 +73,7 @@ class Network_Options_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = new Network_Options();
 
-		$this->assertAttributeSame( Network_Options::PREFIX, 'prefix', $result );
+		$this->assert_attribute_same( Network_Options::PREFIX, 'prefix', $result );
 	}
 
 	/**

--- a/tests/avatar-privacy/data-storage/class-network-options-test.php
+++ b/tests/avatar-privacy/data-storage/class-network-options-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -52,9 +52,11 @@ class Network_Options_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		Functions\when( '__' )->returnArg();
 

--- a/tests/avatar-privacy/data-storage/class-options-test.php
+++ b/tests/avatar-privacy/data-storage/class-options-test.php
@@ -71,7 +71,7 @@ class Options_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_constructor() {
 		$result = new Options();
 
-		$this->assertAttributeSame( Options::PREFIX, 'prefix', $result );
+		$this->assert_attribute_same( Options::PREFIX, 'prefix', $result );
 	}
 
 	/**

--- a/tests/avatar-privacy/data-storage/class-options-test.php
+++ b/tests/avatar-privacy/data-storage/class-options-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -52,9 +52,11 @@ class Options_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		Functions\when( '__' )->returnArg();
 

--- a/tests/avatar-privacy/data-storage/class-site-transients-test.php
+++ b/tests/avatar-privacy/data-storage/class-site-transients-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -45,9 +45,11 @@ class Site_Transients_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		Functions\when( '__' )->returnArg();
 	}

--- a/tests/avatar-privacy/data-storage/class-site-transients-test.php
+++ b/tests/avatar-privacy/data-storage/class-site-transients-test.php
@@ -66,6 +66,6 @@ class Site_Transients_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = new Site_Transients();
 
-		$this->assertAttributeSame( Site_Transients::PREFIX, 'prefix', $result );
+		$this->assert_attribute_same( Site_Transients::PREFIX, 'prefix', $result );
 	}
 }

--- a/tests/avatar-privacy/data-storage/class-transients-test.php
+++ b/tests/avatar-privacy/data-storage/class-transients-test.php
@@ -66,6 +66,6 @@ class Transients_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = new Transients();
 
-		$this->assertAttributeSame( Transients::PREFIX, 'prefix', $result );
+		$this->assert_attribute_same( Transients::PREFIX, 'prefix', $result );
 	}
 }

--- a/tests/avatar-privacy/data-storage/class-transients-test.php
+++ b/tests/avatar-privacy/data-storage/class-transients-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -45,9 +45,11 @@ class Transients_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		Functions\when( '__' )->returnArg();
 	}

--- a/tests/avatar-privacy/integrations/class-bbpress-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-bbpress-integration-test.php
@@ -111,7 +111,7 @@ class BBPress_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $form );
 
-		$this->assertAttributeSame( $form, 'form', $mock );
+		$this->assert_attribute_same( $form, 'form', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/integrations/class-bbpress-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-bbpress-integration-test.php
@@ -66,9 +66,11 @@ class BBPress_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'uploads' => [

--- a/tests/avatar-privacy/integrations/class-buddypress-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-buddypress-integration-test.php
@@ -87,7 +87,7 @@ class BuddyPress_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $this->upload );
 
-		$this->assertAttributeSame( $this->upload, 'upload', $mock );
+		$this->assert_attribute_same( $this->upload, 'upload', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/integrations/class-buddypress-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-buddypress-integration-test.php
@@ -66,9 +66,11 @@ class BuddyPress_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->upload = m::mock( User_Avatar_Upload_Handler::class );
 

--- a/tests/avatar-privacy/integrations/class-theme-my-login-profiles-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-theme-my-login-profiles-integration-test.php
@@ -88,7 +88,7 @@ class Theme_My_Login_Profiles_Integration_Test extends \Avatar_Privacy\Tests\Tes
 
 		$mock->__construct( $this->form );
 
-		$this->assertAttributeSame( $this->form, 'form', $mock );
+		$this->assert_attribute_same( $this->form, 'form', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/integrations/class-theme-my-login-profiles-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-theme-my-login-profiles-integration-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -67,9 +67,11 @@ class Theme_My_Login_Profiles_Integration_Test extends \Avatar_Privacy\Tests\Tes
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->form = m::mock( User_Form::class );
 

--- a/tests/avatar-privacy/integrations/class-ultimate-member-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-ultimate-member-integration-test.php
@@ -87,7 +87,7 @@ class Ultimate_Member_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $this->upload );
 
-		$this->assertAttributeSame( $this->upload, 'upload', $mock );
+		$this->assert_attribute_same( $this->upload, 'upload', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/integrations/class-ultimate-member-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-ultimate-member-integration-test.php
@@ -66,9 +66,11 @@ class Ultimate_Member_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->upload = m::mock( User_Avatar_Upload_Handler::class );
 

--- a/tests/avatar-privacy/integrations/class-ultimate-member-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-ultimate-member-integration-test.php
@@ -158,9 +158,9 @@ class Ultimate_Member_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = $this->sut->remove_ultimate_member_gravatar_settings( $structure );
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertNotEmpty( $result['']['sections']['users']['fields'] );
-		$this->assertInternalType( 'array', $result['']['sections']['users']['fields'] );
+		$this->assert_is_array( $result['']['sections']['users']['fields'] );
 		$this->assertContains( $conditional, $result['']['sections']['users']['fields'][1] );
 	}
 

--- a/tests/avatar-privacy/integrations/class-wp-user-manager-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-wp-user-manager-integration-test.php
@@ -186,7 +186,7 @@ class WP_User_Manager_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_maybe_flush_cache_after_saving_user_avatar() {
 		$user_id = 42;
 
-		$this->setValue( $this->sut, 'flush_cache', true, WP_User_Manager_Integration::class );
+		$this->set_value( $this->sut, 'flush_cache', true );
 
 		$this->upload->shouldReceive( 'invalidate_user_avatar_cache' )->once()->with( $user_id );
 
@@ -201,7 +201,7 @@ class WP_User_Manager_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_maybe_flush_cache_after_saving_user_avatar_do_not_flush() {
 		$user_id = 42;
 
-		$this->setValue( $this->sut, 'flush_cache', false, WP_User_Manager_Integration::class );
+		$this->set_value( $this->sut, 'flush_cache', false );
 
 		$this->upload->shouldReceive( 'invalidate_user_avatar_cache' )->never();
 

--- a/tests/avatar-privacy/integrations/class-wp-user-manager-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-wp-user-manager-integration-test.php
@@ -90,7 +90,7 @@ class WP_User_Manager_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $this->upload );
 
-		$this->assertAttributeSame( $this->upload, 'upload', $mock );
+		$this->assert_attribute_same( $this->upload, 'upload', $mock );
 	}
 
 	/**
@@ -158,7 +158,7 @@ class WP_User_Manager_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->assertSame( $save, $this->sut->maybe_mark_user_avater_for_cache_flushing( $save, $value, $field ) );
 
-		$this->assertAttributeSame( true, 'flush_cache', $this->sut );
+		$this->assert_attribute_same( true, 'flush_cache', $this->sut );
 	}
 
 	/**
@@ -175,7 +175,7 @@ class WP_User_Manager_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->assertSame( $save, $this->sut->maybe_mark_user_avater_for_cache_flushing( $save, $value, $field ) );
 
-		$this->assertAttributeSame( false, 'flush_cache', $this->sut );
+		$this->assert_attribute_same( false, 'flush_cache', $this->sut );
 	}
 
 	/**

--- a/tests/avatar-privacy/integrations/class-wp-user-manager-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-wp-user-manager-integration-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -69,9 +69,11 @@ class WP_User_Manager_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->upload = m::mock( User_Avatar_Upload_Handler::class );
 

--- a/tests/avatar-privacy/integrations/class-wpdiscuz-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-wpdiscuz-integration-test.php
@@ -236,7 +236,7 @@ class WPDiscuz_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 		$consent  = true;
 		$checkbox = 'cookie_consent_checkbox';
 
-		$this->setValue( $this->sut, 'cookie_consent_name', $checkbox, WPDiscuz_Integration::class );
+		$this->set_value( $this->sut, 'cookie_consent_name', $checkbox );
 
 		Functions\expect( 'wp_get_current_user' )->once()->andReturn( $user );
 
@@ -270,6 +270,6 @@ class WPDiscuz_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 		$form->shouldReceive( 'getFormCustomFields' )->once()->andReturn( $fields );
 
 		$this->assertNull( $this->sut->store_cookie_consent_checkbox( $form ) );
-		$this->assertSame( $checkbox, $this->getValue( $this->sut, 'cookie_consent_name', WPDiscuz_Integration::class ) );
+		$this->assertSame( $checkbox, $this->get_value( $this->sut, 'cookie_consent_name' ) );
 	}
 }

--- a/tests/avatar-privacy/integrations/class-wpdiscuz-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-wpdiscuz-integration-test.php
@@ -71,9 +71,11 @@ class WPDiscuz_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'uploads' => [

--- a/tests/avatar-privacy/integrations/class-wpdiscuz-integration-test.php
+++ b/tests/avatar-privacy/integrations/class-wpdiscuz-integration-test.php
@@ -118,8 +118,8 @@ class WPDiscuz_Integration_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $core, $comments );
 
-		$this->assertAttributeSame( $core, 'core', $mock );
-		$this->assertAttributeSame( $comments, 'comments', $mock );
+		$this->assert_attribute_same( $core, 'core', $mock );
+		$this->assert_attribute_same( $comments, 'comments', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/tools/class-multisite-test.php
+++ b/tests/avatar-privacy/tools/class-multisite-test.php
@@ -52,9 +52,11 @@ class Multisite_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->sut = m::mock( Multisite::class )->makePartial()->shouldAllowMockingProtectedMethods();
 	}

--- a/tests/avatar-privacy/tools/class-number-generator-test.php
+++ b/tests/avatar-privacy/tools/class-number-generator-test.php
@@ -164,8 +164,8 @@ class Number_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 		$result1 = $this->sut->get( $min, $max );
 		$result2 = $this->sut->get( $min, $max );
 
-		$this->assertInternalType( 'int', $result1 );
-		$this->assertInternalType( 'int', $result2 );
+		$this->assert_is_int( $result1 );
+		$this->assert_is_int( $result2 );
 		$this->assertLessThanOrEqual( $max, $result1 );
 		$this->assertLessThanOrEqual( $max, $result2 );
 		$this->assertGreaterThanOrEqual( $min, $result1 );

--- a/tests/avatar-privacy/tools/class-number-generator-test.php
+++ b/tests/avatar-privacy/tools/class-number-generator-test.php
@@ -52,9 +52,11 @@ class Number_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->sut = m::mock( Number_Generator::class )->makePartial()->shouldAllowMockingProtectedMethods();
 	}

--- a/tests/avatar-privacy/tools/html/class-user-form-test.php
+++ b/tests/avatar-privacy/tools/html/class-user-form-test.php
@@ -96,10 +96,10 @@ class User_Form_Test extends \Avatar_Privacy\Tests\TestCase {
 		$mock = m::mock( User_Form::class )->makePartial()->shouldAllowMockingProtectedMethods();
 		$mock->__construct( $upload, $use_gravatar, $allow_anonymous, $user_avatar );
 
-		$this->assertAttributeSame( $upload, 'upload', $mock );
-		$this->assertAttributeSame( $use_gravatar, 'use_gravatar', $mock );
-		$this->assertAttributeSame( $allow_anonymous, 'allow_anonymous', $mock );
-		$this->assertAttributeSame( $user_avatar, 'user_avatar', $mock );
+		$this->assert_attribute_same( $upload, 'upload', $mock );
+		$this->assert_attribute_same( $use_gravatar, 'use_gravatar', $mock );
+		$this->assert_attribute_same( $allow_anonymous, 'allow_anonymous', $mock );
+		$this->assert_attribute_same( $user_avatar, 'user_avatar', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/tools/html/class-user-form-test.php
+++ b/tests/avatar-privacy/tools/html/class-user-form-test.php
@@ -59,9 +59,11 @@ class User_Form_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'plugin'    => [

--- a/tests/avatar-privacy/tools/images/class-editor-test.php
+++ b/tests/avatar-privacy/tools/images/class-editor-test.php
@@ -72,9 +72,11 @@ class Editor_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'folder' => [],
@@ -166,6 +168,7 @@ class Editor_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::create_from_image_resource
 	 *
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_create_from_image_resource_not_a_resource() {
 		$not_a_resource = '';

--- a/tests/avatar-privacy/tools/images/class-editor-test.php
+++ b/tests/avatar-privacy/tools/images/class-editor-test.php
@@ -115,9 +115,9 @@ class Editor_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $url, $mocked_stream_class );
 
-		$this->assertAttributeSame( $url, 'stream_url', $mock );
-		$this->assertAttributeSame( $mocked_stream_class, 'stream_class', $mock );
-		$this->assertAttributeSame( 'stream/with/path', 'handle', $mock );
+		$this->assert_attribute_same( $url, 'stream_url', $mock );
+		$this->assert_attribute_same( $mocked_stream_class, 'stream_class', $mock );
+		$this->assert_attribute_same( 'stream/with/path', 'handle', $mock );
 	}
 
 

--- a/tests/avatar-privacy/tools/images/class-editor-test.php
+++ b/tests/avatar-privacy/tools/images/class-editor-test.php
@@ -382,7 +382,7 @@ class Editor_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		// Set up instance state.
 		$stream_matcher = m::pattern( '#^' . \preg_quote( $stream, '/[\w/]+$#' ) . '#' );
-		$this->setValue( $this->sut, 'stream_url', $stream, Editor::class );
+		$this->set_value( $this->sut, 'stream_url', $stream );
 
 		Functions\expect( 'wp_get_image_mime' )->once()->with( $stream_matcher )->andReturn( $mime_type );
 		$this->sut->shouldReceive( 'delete_stream' )->once()->with( $stream_matcher );

--- a/tests/avatar-privacy/tools/images/class-image-stream-test.php
+++ b/tests/avatar-privacy/tools/images/class-image-stream-test.php
@@ -609,7 +609,7 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->sut->shouldReceive( 'handle_exists' )->once()->with( 'foo' );
 
-		$data = $this->invokeStaticMethod( $classname, 'get_data_reference', [ 'foo' ] );
+		$data = $this->invoke_static_method( $classname, 'get_data_reference', [ 'foo' ] );
 		$this->assertSame( '', $data );
 	}
 
@@ -623,11 +623,11 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_handle_exists() {
 		$classname = \get_class( $this->sut );
 
-		$this->assertFalse( $this->invokeStaticMethod( $classname, 'handle_exists', [ 'foobar' ] ) );
+		$this->assertFalse( $this->invoke_static_method( $classname, 'handle_exists', [ 'foobar' ] ) );
 
-		$this->invokeStaticMethod( $classname, 'get_data_reference', [ 'foobar' ] );
+		$this->invoke_static_method( $classname, 'get_data_reference', [ 'foobar' ] );
 
-		$this->assertTrue( $this->invokeStaticMethod( $classname, 'handle_exists', [ 'foobar' ] ) );
+		$this->assertTrue( $this->invoke_static_method( $classname, 'handle_exists', [ 'foobar' ] ) );
 	}
 
 	/**
@@ -696,12 +696,12 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$handle = 'a new handle';
 
-		$this->invokeStaticMethod( $classname, 'get_data_reference', [ $handle ] );
-		$this->assertTrue( $this->invokeStaticMethod( $classname, 'handle_exists', [ $handle ] ) );
+		$this->invoke_static_method( $classname, 'get_data_reference', [ $handle ] );
+		$this->assertTrue( $this->invoke_static_method( $classname, 'handle_exists', [ $handle ] ) );
 
 		$this->assertNull( $classname::delete_handle( $handle ) );
 
-		$this->assertFalse( $this->invokeStaticMethod( $classname, 'handle_exists', [ $handle ] ) );
+		$this->assertFalse( $this->invoke_static_method( $classname, 'handle_exists', [ $handle ] ) );
 	}
 
 	/**

--- a/tests/avatar-privacy/tools/images/class-image-stream-test.php
+++ b/tests/avatar-privacy/tools/images/class-image-stream-test.php
@@ -516,7 +516,7 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = $this->sut->url_stat( $path, $flags );
 
-		$this->assertInternalType( 'array', $result );
+		$this->assert_is_array( $result );
 		$this->assertArrayHasKey( 'size', $result );
 		$this->assertSame( 4, $result['size'] );
 	}

--- a/tests/avatar-privacy/tools/images/class-image-stream-test.php
+++ b/tests/avatar-privacy/tools/images/class-image-stream-test.php
@@ -194,7 +194,7 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		// Check.
 		$this->assertSame( 'and', $this->sut->stream_read( $bytes_to_read ) );
-		$this->assertAttributeSame( $position + $bytes_to_read, 'position', $this->sut );
+		$this->assert_attribute_same( $position + $bytes_to_read, 'position', $this->sut );
 	}
 
 	/**
@@ -220,7 +220,7 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		// Check.
 		$this->assertFalse( $this->sut->stream_read( $bytes_to_read ) );
-		$this->assertAttributeSame( $position, 'position', $this->sut );
+		$this->assert_attribute_same( $position, 'position', $this->sut );
 	}
 
 	/**
@@ -249,8 +249,8 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		// Check.
 		$this->assertSame( $length, $this->sut->stream_write( $new_data ) );
-		$this->assertAttributeSame( $position + $length, 'position', $this->sut );
-		$this->assertAttributeSame( 'a long xxx tedious string that is our stream', 'data', $this->sut );
+		$this->assert_attribute_same( $position + $length, 'position', $this->sut );
+		$this->assert_attribute_same( 'a long xxx tedious string that is our stream', 'data', $this->sut );
 	}
 
 	/**
@@ -279,8 +279,8 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		// Check.
 		$this->assertSame( 0, $this->sut->stream_write( $new_data ) );
-		$this->assertAttributeSame( $position, 'position', $this->sut );
-		$this->assertAttributeSame( $data, 'data', $this->sut );
+		$this->assert_attribute_same( $position, 'position', $this->sut );
+		$this->assert_attribute_same( $data, 'data', $this->sut );
 	}
 
 	/**
@@ -399,7 +399,7 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 		}
 
 		$this->assertSame( $result, $this->sut->stream_seek( $offset, $whence ) );
-		$this->assertAttributeSame( $new_position, 'position', $this->sut );
+		$this->assert_attribute_same( $new_position, 'position', $this->sut );
 	}
 
 	/**
@@ -466,7 +466,7 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->set_value( $this->sut, 'data', $data );
 
 		$this->assertTrue( $this->sut->stream_truncate( $length ) );
-		$this->assertAttributeSame( $result, 'data', $this->sut );
+		$this->assert_attribute_same( $result, 'data', $this->sut );
 	}
 
 	/**

--- a/tests/avatar-privacy/tools/images/class-image-stream-test.php
+++ b/tests/avatar-privacy/tools/images/class-image-stream-test.php
@@ -55,9 +55,11 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'folder' => [

--- a/tests/avatar-privacy/tools/images/class-image-stream-test.php
+++ b/tests/avatar-privacy/tools/images/class-image-stream-test.php
@@ -187,10 +187,10 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 		$bytes_to_read = 3;
 
 		// Set up stream object.
-		$this->setValue( $this->sut, 'read', $readable, Image_Stream::class );
-		$this->setValue( $this->sut, 'write', $writable, Image_Stream::class );
-		$this->setValue( $this->sut, 'data', $data, Image_Stream::class );
-		$this->setValue( $this->sut, 'position', $position, Image_Stream::class );
+		$this->set_value( $this->sut, 'read', $readable );
+		$this->set_value( $this->sut, 'write', $writable );
+		$this->set_value( $this->sut, 'data', $data );
+		$this->set_value( $this->sut, 'position', $position );
 
 		// Check.
 		$this->assertSame( 'and', $this->sut->stream_read( $bytes_to_read ) );
@@ -213,10 +213,10 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 		$bytes_to_read = 3;
 
 		// Set up stream object.
-		$this->setValue( $this->sut, 'read', $readable, Image_Stream::class );
-		$this->setValue( $this->sut, 'write', $writable, Image_Stream::class );
-		$this->setValue( $this->sut, 'data', $data, Image_Stream::class );
-		$this->setValue( $this->sut, 'position', $position, Image_Stream::class );
+		$this->set_value( $this->sut, 'read', $readable );
+		$this->set_value( $this->sut, 'write', $writable );
+		$this->set_value( $this->sut, 'data', $data );
+		$this->set_value( $this->sut, 'position', $position );
 
 		// Check.
 		$this->assertFalse( $this->sut->stream_read( $bytes_to_read ) );
@@ -239,10 +239,10 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 		$new_data = 'xxx';
 
 		// Set up stream object.
-		$this->setValue( $this->sut, 'read', $readable, Image_Stream::class );
-		$this->setValue( $this->sut, 'write', $writable, Image_Stream::class );
-		$this->setValue( $this->sut, 'data', $data, Image_Stream::class );
-		$this->setValue( $this->sut, 'position', $position, Image_Stream::class );
+		$this->set_value( $this->sut, 'read', $readable );
+		$this->set_value( $this->sut, 'write', $writable );
+		$this->set_value( $this->sut, 'data', $data );
+		$this->set_value( $this->sut, 'position', $position );
 
 		// Results.
 		$length = \strlen( $new_data );
@@ -269,10 +269,10 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 		$new_data = 'xxx';
 
 		// Set up stream object.
-		$this->setValue( $this->sut, 'read', $readable, Image_Stream::class );
-		$this->setValue( $this->sut, 'write', $writable, Image_Stream::class );
-		$this->setValue( $this->sut, 'data', $data, Image_Stream::class );
-		$this->setValue( $this->sut, 'position', $position, Image_Stream::class );
+		$this->set_value( $this->sut, 'read', $readable );
+		$this->set_value( $this->sut, 'write', $writable );
+		$this->set_value( $this->sut, 'data', $data );
+		$this->set_value( $this->sut, 'position', $position );
 
 		// Results.
 		$length = \strlen( $new_data );
@@ -296,10 +296,10 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 		$position = 7;
 
 		// Set up stream object.
-		$this->setValue( $this->sut, 'read', $readable, Image_Stream::class );
-		$this->setValue( $this->sut, 'write', $writable, Image_Stream::class );
-		$this->setValue( $this->sut, 'data', $data, Image_Stream::class );
-		$this->setValue( $this->sut, 'position', $position, Image_Stream::class );
+		$this->set_value( $this->sut, 'read', $readable );
+		$this->set_value( $this->sut, 'write', $writable );
+		$this->set_value( $this->sut, 'data', $data );
+		$this->set_value( $this->sut, 'position', $position );
 
 		// Check.
 		$this->assertSame( $position, $this->sut->stream_tell() );
@@ -318,10 +318,10 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 		$position = \strlen( $data );
 
 		// Set up stream object.
-		$this->setValue( $this->sut, 'read', $readable, Image_Stream::class );
-		$this->setValue( $this->sut, 'write', $writable, Image_Stream::class );
-		$this->setValue( $this->sut, 'data', $data, Image_Stream::class );
-		$this->setValue( $this->sut, 'position', $position, Image_Stream::class );
+		$this->set_value( $this->sut, 'read', $readable );
+		$this->set_value( $this->sut, 'write', $writable );
+		$this->set_value( $this->sut, 'data', $data );
+		$this->set_value( $this->sut, 'position', $position );
 
 		// Check.
 		$this->assertTrue( $this->sut->stream_eof() );
@@ -340,10 +340,10 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 		$position = \strlen( $data ) - 1;
 
 		// Set up stream object.
-		$this->setValue( $this->sut, 'read', $readable, Image_Stream::class );
-		$this->setValue( $this->sut, 'write', $writable, Image_Stream::class );
-		$this->setValue( $this->sut, 'data', $data, Image_Stream::class );
-		$this->setValue( $this->sut, 'position', $position, Image_Stream::class );
+		$this->set_value( $this->sut, 'read', $readable );
+		$this->set_value( $this->sut, 'write', $writable );
+		$this->set_value( $this->sut, 'data', $data );
+		$this->set_value( $this->sut, 'position', $position );
 
 		// Check.
 		$this->assertFalse( $this->sut->stream_eof() );
@@ -391,8 +391,8 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 		}
 
 		// Set up stream object.
-		$this->setValue( $this->sut, 'data', $data, Image_Stream::class );
-		$this->setValue( $this->sut, 'position', $position, Image_Stream::class );
+		$this->set_value( $this->sut, 'data', $data );
+		$this->set_value( $this->sut, 'position', $position );
 
 		if ( $truncate ) {
 			$this->sut->shouldReceive( 'truncate_after_seek' )->once();
@@ -427,8 +427,8 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 	 */
 	public function test_truncate_after_seek( $position, $data, $truncate ) {
 		// Set up stream object.
-		$this->setValue( $this->sut, 'data', $data, Image_Stream::class );
-		$this->setValue( $this->sut, 'position', $position, Image_Stream::class );
+		$this->set_value( $this->sut, 'data', $data );
+		$this->set_value( $this->sut, 'position', $position );
 
 		if ( $truncate ) {
 			$this->sut->shouldReceive( 'stream_truncate' )->once()->with( $position );
@@ -463,7 +463,7 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 	 */
 	public function test_stream_truncate( $data, $length, $result ) {
 		// Set up stream object.
-		$this->setValue( $this->sut, 'data', $data, Image_Stream::class );
+		$this->set_value( $this->sut, 'data', $data );
 
 		$this->assertTrue( $this->sut->stream_truncate( $length ) );
 		$this->assertAttributeSame( $result, 'data', $this->sut );
@@ -479,7 +479,7 @@ class Image_Stream_Test extends \Avatar_Privacy\Tests\TestCase {
 		$data = 'a long and tedious string that is our stream';
 
 		// Set up stream object.
-		$this->setValue( $this->sut, 'data', $data, Image_Stream::class );
+		$this->set_value( $this->sut, 'data', $data );
 
 		// Expected result.
 		$result = [

--- a/tests/avatar-privacy/tools/images/class-png-test.php
+++ b/tests/avatar-privacy/tools/images/class-png-test.php
@@ -107,7 +107,7 @@ class PNG_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$image = $this->sut->create( 'white', $width, $height );
 
-		$this->assertInternalType( 'resource', $image );
+		$this->assert_is_resource( $image );
 		$this->assertSame( $width, \imageSX( $image ) );
 		$this->assertSame( $height, \imageSY( $image ) );
 		$this->assertSame(
@@ -136,7 +136,7 @@ class PNG_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$image = $this->sut->create( 'black', $width, $height );
 
-		$this->assertInternalType( 'resource', $image );
+		$this->assert_is_resource( $image );
 		$this->assertSame( $width, \imageSX( $image ) );
 		$this->assertSame( $height, \imageSY( $image ) );
 		$this->assertSame(
@@ -165,7 +165,7 @@ class PNG_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$image = $this->sut->create( 'transparent', $width, $height );
 
-		$this->assertInternalType( 'resource', $image );
+		$this->assert_is_resource( $image );
 		$this->assertSame( $width, \imageSX( $image ) );
 		$this->assertSame( $height, \imageSY( $image ) );
 		$this->assertSame(
@@ -213,7 +213,7 @@ class PNG_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$image = $this->sut->create_from_file( vfsStream::url( 'root/plugin/my_parts_dir/somefile.png' ) );
 
-		$this->assertInternalType( 'resource', $image );
+		$this->assert_is_resource( $image );
 		$this->assertSame( $width, \imageSX( $image ) );
 		$this->assertSame( $height, \imageSY( $image ) );
 

--- a/tests/avatar-privacy/tools/images/class-png-test.php
+++ b/tests/avatar-privacy/tools/images/class-png-test.php
@@ -55,9 +55,11 @@ class PNG_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$png_data = \base64_decode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions
 			'iVBORw0KGgoAAAANSUhEUgAAABwAAAASCAMAAAB/2U7WAAAABl' .

--- a/tests/avatar-privacy/tools/network/class-gravatar-service-test.php
+++ b/tests/avatar-privacy/tools/network/class-gravatar-service-test.php
@@ -104,9 +104,9 @@ class Gravatar_Service_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $this->transients, $this->site_transients, $this->editor );
 
-		$this->assertAttributeSame( $this->transients, 'transients', $mock );
-		$this->assertAttributeSame( $this->site_transients, 'site_transients', $mock );
-		$this->assertAttributeSame( $this->editor, 'editor', $mock );
+		$this->assert_attribute_same( $this->transients, 'transients', $mock );
+		$this->assert_attribute_same( $this->site_transients, 'site_transients', $mock );
+		$this->assert_attribute_same( $this->editor, 'editor', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/tools/network/class-gravatar-service-test.php
+++ b/tests/avatar-privacy/tools/network/class-gravatar-service-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -80,9 +80,11 @@ class Gravatar_Service_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Mock required helpers.
 		$this->transients      = m::mock( Transients::class );

--- a/tests/avatar-privacy/upload-handlers/class-custom-default-icon-upload-handler-test.php
+++ b/tests/avatar-privacy/upload-handlers/class-custom-default-icon-upload-handler-test.php
@@ -83,9 +83,11 @@ class Custom_Default_Icon_Upload_Handler_Test extends \Avatar_Privacy\Tests\Test
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'plugin'    => [

--- a/tests/avatar-privacy/upload-handlers/class-custom-default-icon-upload-handler-test.php
+++ b/tests/avatar-privacy/upload-handlers/class-custom-default-icon-upload-handler-test.php
@@ -134,7 +134,7 @@ class Custom_Default_Icon_Upload_Handler_Test extends \Avatar_Privacy\Tests\Test
 
 		$mock->__construct( $this->core, $this->file_cache, $this->options );
 
-		$this->assertAttributeSame( $this->options, 'options', $mock );
+		$this->assert_attribute_same( $this->options, 'options', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/upload-handlers/class-upload-handler-test.php
+++ b/tests/avatar-privacy/upload-handlers/class-upload-handler-test.php
@@ -119,8 +119,8 @@ class Upload_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( 'uploads', $this->core, $this->file_cache );
 
-		$this->assertAttributeSame( $this->core, 'core', $mock );
-		$this->assertAttributeSame( $this->file_cache, 'file_cache', $mock );
+		$this->assert_attribute_same( $this->core, 'core', $mock );
+		$this->assert_attribute_same( $this->file_cache, 'file_cache', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/upload-handlers/class-upload-handler-test.php
+++ b/tests/avatar-privacy/upload-handlers/class-upload-handler-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -74,9 +74,11 @@ class Upload_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'plugin'    => [

--- a/tests/avatar-privacy/upload-handlers/class-user-avatar-upload-handler-test.php
+++ b/tests/avatar-privacy/upload-handlers/class-user-avatar-upload-handler-test.php
@@ -126,7 +126,7 @@ class User_Avatar_Upload_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$mock->__construct( $this->core, $this->file_cache );
 
-		$this->assertAttributeSame( User_Avatar_Upload_Handler::UPLOAD_DIR, 'upload_dir', $mock );
+		$this->assert_attribute_same( User_Avatar_Upload_Handler::UPLOAD_DIR, 'upload_dir', $mock );
 	}
 
 	/**

--- a/tests/avatar-privacy/upload-handlers/class-user-avatar-upload-handler-test.php
+++ b/tests/avatar-privacy/upload-handlers/class-user-avatar-upload-handler-test.php
@@ -469,7 +469,7 @@ class User_Avatar_Upload_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 	public function test_get_unique_filename( $filename, $extension, $result, $user ) {
 		// Set up dummy user ID.
 		$user_id = 666;
-		$this->setValue( $this->sut, 'user_id_being_edited', $user_id, User_Avatar_Upload_Handler::class );
+		$this->set_value( $this->sut, 'user_id_being_edited', $user_id );
 
 		Functions\expect( 'get_user_by' )->once()->with( 'id', $user_id )->andReturn( $user );
 		Functions\expect( 'sanitize_file_name' )->once()->with( m::type( 'string' ) )->andReturnUsing(

--- a/tests/avatar-privacy/upload-handlers/class-user-avatar-upload-handler-test.php
+++ b/tests/avatar-privacy/upload-handlers/class-user-avatar-upload-handler-test.php
@@ -76,9 +76,11 @@ class User_Avatar_Upload_Handler_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'plugin'    => [

--- a/tests/avatar-privacy/upload-handlers/ui/class-file-upload-input-test.php
+++ b/tests/avatar-privacy/upload-handlers/ui/class-file-upload-input-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -68,9 +68,11 @@ class File_Upload_Input_Test extends \Avatar_Privacy\Tests\TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		Functions\when( 'wp_parse_args' )->alias(
 			function( $args, $defaults ) {

--- a/tests/avatar-privacy/upload-handlers/ui/class-file-upload-input-test.php
+++ b/tests/avatar-privacy/upload-handlers/ui/class-file-upload-input-test.php
@@ -110,10 +110,10 @@ class File_Upload_Input_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->options = m::mock( Options::class );
 
 		// Set necessary values manually.
-		$this->setValue( $this->sut, 'options', $this->options );
-		$this->setValue( $this->sut, 'erase_checkbox_id', 'erase-checkbox-id', File_Upload_Input::class );
-		$this->setValue( $this->sut, 'action', 'action-name', File_Upload_Input::class );
-		$this->setValue( $this->sut, 'nonce', 'nonce-name', File_Upload_Input::class );
+		$this->set_value( $this->sut, 'options', $this->options );
+		$this->set_value( $this->sut, 'erase_checkbox_id', 'erase-checkbox-id' );
+		$this->set_value( $this->sut, 'action', 'action-name' );
+		$this->set_value( $this->sut, 'nonce', 'nonce-name' );
 	}
 
 	/**

--- a/tests/avatar-privacy/upload-handlers/ui/class-file-upload-input-test.php
+++ b/tests/avatar-privacy/upload-handlers/ui/class-file-upload-input-test.php
@@ -155,11 +155,11 @@ class File_Upload_Input_Test extends \Avatar_Privacy\Tests\TestCase {
 		// Let's go!
 		$mock->__construct( $options, 'my_options_key', 'my_control_id', $args );
 
-		$this->assertAttributeSame( $options, 'options', $mock );
-		$this->assertAttributeSame( 'my_help_text', 'help_text', $mock );
-		$this->assertAttributeSame( 'my_erase_checkbox_id', 'erase_checkbox_id', $mock );
-		$this->assertAttributeSame( 'my_upload_action', 'action', $mock );
-		$this->assertAttributeSame( 'my_upload_nonce', 'nonce', $mock );
+		$this->assert_attribute_same( $options, 'options', $mock );
+		$this->assert_attribute_same( 'my_help_text', 'help_text', $mock );
+		$this->assert_attribute_same( 'my_erase_checkbox_id', 'erase_checkbox_id', $mock );
+		$this->assert_attribute_same( 'my_upload_action', 'action', $mock );
+		$this->assert_attribute_same( 'my_upload_nonce', 'nonce', $mock );
 	}
 
 	/**
@@ -202,11 +202,11 @@ class File_Upload_Input_Test extends \Avatar_Privacy\Tests\TestCase {
 		// Let's go!
 		$mock->__construct( $options, 'my_options_key', 'my_control_id', $args );
 
-		$this->assertAttributeSame( $options, 'options', $mock );
-		$this->assertAttributeSame( 'help-text-no-file', 'help_text', $mock );
-		$this->assertAttributeSame( 'my_erase_checkbox_id', 'erase_checkbox_id', $mock );
-		$this->assertAttributeSame( 'my_upload_action', 'action', $mock );
-		$this->assertAttributeSame( 'my_upload_nonce', 'nonce', $mock );
+		$this->assert_attribute_same( $options, 'options', $mock );
+		$this->assert_attribute_same( 'help-text-no-file', 'help_text', $mock );
+		$this->assert_attribute_same( 'my_erase_checkbox_id', 'erase_checkbox_id', $mock );
+		$this->assert_attribute_same( 'my_upload_action', 'action', $mock );
+		$this->assert_attribute_same( 'my_upload_nonce', 'nonce', $mock );
 	}
 
 	/**
@@ -248,11 +248,11 @@ class File_Upload_Input_Test extends \Avatar_Privacy\Tests\TestCase {
 		// Let's go!
 		$mock->__construct( $options, 'my_options_key', 'my_control_id', $args );
 
-		$this->assertAttributeSame( $options, 'options', $mock );
-		$this->assertAttributeSame( 'help-text-not-enough-capabilities', 'help_text', $mock );
-		$this->assertAttributeSame( 'my_erase_checkbox_id', 'erase_checkbox_id', $mock );
-		$this->assertAttributeSame( 'my_upload_action', 'action', $mock );
-		$this->assertAttributeSame( 'my_upload_nonce', 'nonce', $mock );
+		$this->assert_attribute_same( $options, 'options', $mock );
+		$this->assert_attribute_same( 'help-text-not-enough-capabilities', 'help_text', $mock );
+		$this->assert_attribute_same( 'my_erase_checkbox_id', 'erase_checkbox_id', $mock );
+		$this->assert_attribute_same( 'my_upload_action', 'action', $mock );
+		$this->assert_attribute_same( 'my_upload_nonce', 'nonce', $mock );
 	}
 
 	/**

--- a/tests/class-avatar-privacy-functions-test.php
+++ b/tests/class-avatar-privacy-functions-test.php
@@ -37,6 +37,8 @@ use org\bovigo\vfs\vfsStreamDirectory;
 
 use Mockery as m;
 
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+
 /**
  * Unit tests for Avatar Privacy functions.
  */
@@ -45,9 +47,11 @@ class Avatar_Privacy_Functions_Test extends TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$filesystem = [
 			'plugin' => [

--- a/tests/class-avatar-privacy-requirements-test.php
+++ b/tests/class-avatar-privacy-requirements-test.php
@@ -77,8 +77,8 @@ class Avatar_Privacy_Requirements_Test extends TestCase {
 		$req = m::mock( \Avatar_Privacy_Requirements::class )->makePartial();
 		$req->__construct( 'some_file' );
 
-		$this->assertSame( 'Avatar Privacy', $this->getValue( $req, 'plugin_name', \Mundschenk_WP_Requirements::class ) );
-		$this->assertSame( 'avatar-privacy', $this->getValue( $req, 'textdomain', \Mundschenk_WP_Requirements::class ) );
+		$this->assertSame( 'Avatar Privacy', $this->get_value( $req, 'plugin_name' ) );
+		$this->assertSame( 'avatar-privacy', $this->get_value( $req, 'textdomain' ) );
 		$this->assertSame(
 			[
 				'php'              => '5.6.0',
@@ -87,7 +87,7 @@ class Avatar_Privacy_Requirements_Test extends TestCase {
 				'gd'               => true,
 				'uploads_writable' => true,
 			],
-			$this->getValue( $req, 'install_requirements', \Mundschenk_WP_Requirements::class )
+			$this->get_value( $req, 'install_requirements' )
 		);
 	}
 

--- a/tests/class-avatar-privacy-requirements-test.php
+++ b/tests/class-avatar-privacy-requirements-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -53,9 +53,11 @@ class Avatar_Privacy_Requirements_Test extends TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->sut = m::mock( \Avatar_Privacy_Requirements::class )->makePartial()->shouldAllowMockingProtectedMethods();
 	}

--- a/tests/class-avatar-privacy-uninstallation-requirements-test.php
+++ b/tests/class-avatar-privacy-uninstallation-requirements-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018 Peter Putzer.
+ * Copyright 2018-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -53,9 +53,11 @@ class Avatar_Privacy_Uninstallation_Requirements_Test extends TestCase {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->sut = m::mock( \Avatar_Privacy_Uninstallation_Requirements::class )->makePartial()->shouldAllowMockingProtectedMethods();
 	}

--- a/tests/class-avatar-privacy-uninstallation-requirements-test.php
+++ b/tests/class-avatar-privacy-uninstallation-requirements-test.php
@@ -77,15 +77,15 @@ class Avatar_Privacy_Uninstallation_Requirements_Test extends TestCase {
 		$req = m::mock( \Avatar_Privacy_Uninstallation_Requirements::class )->makePartial();
 		$req->__construct( 'some_file' );
 
-		$this->assertSame( 'Avatar Privacy', $this->getValue( $req, 'plugin_name', \Mundschenk_WP_Requirements::class ) );
-		$this->assertSame( 'avatar-privacy', $this->getValue( $req, 'textdomain', \Mundschenk_WP_Requirements::class ) );
+		$this->assertSame( 'Avatar Privacy', $this->get_value( $req, 'plugin_name' ) );
+		$this->assertSame( 'avatar-privacy', $this->get_value( $req, 'textdomain' ) );
 		$this->assertSame(
 			[
 				'php'       => '5.6.0',
 				'multibyte' => false,
 				'utf-8'     => false,
 			],
-			$this->getValue( $req, 'install_requirements', \Mundschenk_WP_Requirements::class )
+			$this->get_value( $req, 'install_requirements' )
 		);
 	}
 }

--- a/tests/class-testcase.php
+++ b/tests/class-testcase.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2017-2018 Peter Putzer.
+ * Copyright 2017-2019 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -27,24 +27,57 @@
 namespace Avatar_Privacy\Tests;
 
 use Brain\Monkey;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * Abstract base class for \PHP_Typography\* unit tests.
  */
 abstract class TestCase extends \PHPUnit\Framework\TestCase {
+	/**
+	 * The SetUpTearDownTrait from symfony/phpunit-bridge is used to allow
+	 * test cases to be compatible with PHPUnit 8 and earlier versions at the
+	 * same time (needed for PHP 7.4 support).
+	 */
+	use SetUpTearDownTrait;
 
 	/**
-	 * Set up Brain Monkey.
+	 * Redirects ::setUp to polymorphic ::set_up.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @return void
 	 */
-	protected function setUp() {
+	private function doSetUp() {
+		$this->set_up();
+	}
+
+	/**
+	 * Redirects ::tearDown to polymorphic ::tear_down.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @return void
+	 */
+	private function doTearDown() {
+		$this->tear_down();
+	}
+
+	/**
+	 * Sets up Brain Monkey.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
+	 */
+	protected function set_up() {
 		parent::setUp();
 		Monkey\setUp();
 	}
 
 	/**
-	 * Tear down Brain Monkey.
+	 * Tears down Brain Monkey.
+	 *
+	 * @since 2.3.3 Renamed to `tear_down`.
 	 */
-	protected function tearDown() {
+	protected function tear_down() {
 		Monkey\tearDown();
 		parent::tearDown();
 	}

--- a/tests/class-testcase.php
+++ b/tests/class-testcase.php
@@ -234,6 +234,20 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	}
 
 	/**
+	 * Reports an error identified by $message if $attribute in $object is not the same as $value.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param mixed  $value     The comparison value.
+	 * @param string $attribute The attribute name.
+	 * @param object $object    The object.
+	 * @param string $message   Optional. Default ''.
+	 */
+	protected function assert_attribute_same( $value, $attribute, $object, $message = '' ) {
+		return $this->assertSame( $value, $this->get_value( $object, $attribute ), $message );
+	}
+
+	/**
 	 * Reports an error identified by $message if $attribute in $object does not have the $key.
 	 *
 	 * @since 2.3.3 Renamed to `assert_attribute_array_has_key`.

--- a/tests/class-testcase.php
+++ b/tests/class-testcase.php
@@ -262,6 +262,34 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	}
 
 	/**
+	 * Reports an error identified by $message if $attribute in $object does not contain $value.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param mixed  $value     The comparison value.
+	 * @param string $attribute The attribute name.
+	 * @param object $object    The object.
+	 * @param string $message   Optional. Default ''.
+	 */
+	protected function assert_attribute_contains( $value, $attribute, $object, $message = '' ) {
+		return $this->assertContains( $value, $this->get_value( $object, $attribute ), $message );
+	}
+
+	/**
+	 * Reports an error identified by $message if $attribute in $object contains $value.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param mixed  $value     The comparison value.
+	 * @param string $attribute The attribute name.
+	 * @param object $object    The object.
+	 * @param string $message   Optional. Default ''.
+	 */
+	protected function assert_attribute_not_contains( $value, $attribute, $object, $message = '' ) {
+		return $this->assertNotContains( $value, $this->get_value( $object, $attribute ), $message );
+	}
+
+	/**
 	 * Reports an error identified by $message if $attribute in $object does not have the $key.
 	 *
 	 * @since 2.3.3 Renamed to `assert_attribute_array_has_key`.

--- a/tests/class-testcase.php
+++ b/tests/class-testcase.php
@@ -213,32 +213,28 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	/**
 	 * Reports an error identified by $message if $attribute in $object does not have the $key.
 	 *
-	 * @param string $key       The array key.
-	 * @param string $attribute The attribute name.
-	 * @param object $object    The object.
-	 * @param string $message   Optional. Default ''.
-	 */
-	protected function assertAttributeArrayHasKey( $key, $attribute, $object, $message = '' ) {
-		$ref  = new \ReflectionClass( get_class( $object ) );
-		$prop = $ref->getProperty( $attribute );
-		$prop->setAccessible( true );
-
-		return $this->assertArrayHasKey( $key, $prop->getValue( $object ), $message );
-	}
-
-	/**
-	 * Reports an error identified by $message if $attribute in $object does have the $key.
+	 * @since 2.3.3 Renamed to `assert_attribute_array_has_key`.
 	 *
 	 * @param string $key       The array key.
 	 * @param string $attribute The attribute name.
 	 * @param object $object    The object.
 	 * @param string $message   Optional. Default ''.
 	 */
-	protected function assertAttributeArrayNotHasKey( $key, $attribute, $object, $message = '' ) {
-		$ref  = new \ReflectionClass( get_class( $object ) );
-		$prop = $ref->getProperty( $attribute );
-		$prop->setAccessible( true );
+	protected function assert_attribute_array_has_key( $key, $attribute, $object, $message = '' ) {
+		return $this->assertArrayHasKey( $key, $this->get_value( $object, $attribute ), $message );
+	}
 
-		return $this->assertArrayNotHasKey( $key, $prop->getValue( $object ), $message );
+	/**
+	 * Reports an error identified by $message if $attribute in $object does have the $key.
+	 *
+	 * @since 2.3.3 Renamed to `assert_attribute_array_not_has_key`.
+	 *
+	 * @param string $key       The array key.
+	 * @param string $attribute The attribute name.
+	 * @param object $object    The object.
+	 * @param string $message   Optional. Default ''.
+	 */
+	protected function assert_attribute_array_not_has_key( $key, $attribute, $object, $message = '' ) {
+		return $this->assertArrayNotHasKey( $key, $this->get_value( $object, $attribute ), $message );
 	}
 }

--- a/tests/class-testcase.php
+++ b/tests/class-testcase.php
@@ -134,13 +134,15 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	/**
 	 * Call protected/private method of a class.
 	 *
+	 * @since 2.3.3 Renamed to `invoke_static_method`.
+	 *
 	 * @param string $classname   A class that we will run the method on.
 	 * @param string $method_name Method name to call.
 	 * @param array  $parameters  Array of parameters to pass into method.
 	 *
 	 * @return mixed Method return.
 	 */
-	protected function invokeStaticMethod( $classname, $method_name, array $parameters = [] ) {
+	protected function invoke_static_method( $classname, $method_name, array $parameters = [] ) {
 		$reflection = new \ReflectionClass( $classname );
 		$method     = $reflection->getMethod( $method_name );
 		$method->setAccessible( true );
@@ -151,11 +153,13 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	/**
 	 * Sets the value of a private/protected property of a class.
 	 *
+	 * @since 2.3.3 Renamed to `set_static_value`.
+	 *
 	 * @param string     $classname     A class whose property we will access.
 	 * @param string     $property_name Property to set.
 	 * @param mixed|null $value         The new value.
 	 */
-	protected function setStaticValue( $classname, $property_name, $value ) {
+	protected function set_static_value( $classname, $property_name, $value ) {
 		$reflection = new \ReflectionClass( $classname );
 		$property   = $reflection->getProperty( $property_name );
 		$property->setAccessible( true );
@@ -194,12 +198,14 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	/**
 	 * Retrieves the value of a private/protected property of a class.
 	 *
+	 * @since 2.3.3 Renamed to `get_static_value`.
+	 *
 	 * @param string $classname     A class whose property we will access.
 	 * @param string $property_name Property to set.
 	 *
 	 * @return mixed
 	 */
-	protected function getStaticValue( $classname, $property_name ) {
+	protected function get_static_value( $classname, $property_name ) {
 		$reflection = new \ReflectionClass( $classname );
 		$property   = $reflection->getProperty( $property_name );
 		$property->setAccessible( true );

--- a/tests/class-testcase.php
+++ b/tests/class-testcase.php
@@ -288,4 +288,213 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	protected function assert_attribute_array_not_has_key( $key, $attribute, $object, $message = '' ) {
 		return $this->assertArrayNotHasKey( $key, $this->get_value( $object, $attribute ), $message );
 	}
+
+	/**
+	 * Reports an error identified by $message if $actual is not an array.
+	 *
+	 * A custom method is used to future-proof the testcases as assertInternalType()
+	 * has been deprecated in PHPUnit 8.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  mixed  $actual  The value to test.
+	 * @param  string $message Optional. Default ''.
+	 */
+	protected function assert_is_array( $actual, $message = '' ) {
+		if ( \method_exists( $this, 'assertIsArray' ) ) {
+			return $this->assertIsArray( $actual, $message );
+		} else {
+			return $this->assertInternalType( 'array', $actual, $message );
+		}
+	}
+
+	/**
+	 * Reports an error identified by $message if $actual is not a boolean value.
+	 *
+	 * A custom method is used to future-proof the testcases as assertInternalType()
+	 * has been deprecated in PHPUnit 8.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  mixed  $actual  The value to test.
+	 * @param  string $message Optional. Default ''.
+	 */
+	protected function assert_is_bool( $actual, $message = '' ) {
+		if ( \method_exists( $this, 'assertIsBool' ) ) {
+			return $this->assertIsBool( $actual, $message );
+		} else {
+			return $this->assertInternalType( 'bool', $actual, $message );
+		}
+	}
+
+	/**
+	 * Reports an error identified by $message if $actual is not a float value.
+	 *
+	 * A custom method is used to future-proof the testcases as assertInternalType()
+	 * has been deprecated in PHPUnit 8.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  mixed  $actual  The value to test.
+	 * @param  string $message Optional. Default ''.
+	 */
+	protected function assert_is_float( $actual, $message = '' ) {
+		if ( \method_exists( $this, 'assertIsFloat' ) ) {
+			return $this->assertIsFloat( $actual, $message );
+		} else {
+			return $this->assertInternalType( 'float', $actual, $message );
+		}
+	}
+
+	/**
+	 * Reports an error identified by $message if $actual is not an integer value.
+	 *
+	 * A custom method is used to future-proof the testcases as assertInternalType()
+	 * has been deprecated in PHPUnit 8.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  mixed  $actual  The value to test.
+	 * @param  string $message Optional. Default ''.
+	 */
+	protected function assert_is_int( $actual, $message = '' ) {
+		if ( \method_exists( $this, 'assertIsInt' ) ) {
+			return $this->assertIsInt( $actual, $message );
+		} else {
+			return $this->assertInternalType( 'int', $actual, $message );
+		}
+	}
+
+	/**
+	 * Reports an error identified by $message if $actual is not a numeric value.
+	 *
+	 * A custom method is used to future-proof the testcases as assertInternalType()
+	 * has been deprecated in PHPUnit 8.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  mixed  $actual  The value to test.
+	 * @param  string $message Optional. Default ''.
+	 */
+	protected function assert_is_numeric( $actual, $message = '' ) {
+		if ( \method_exists( $this, 'assertIsNumeric' ) ) {
+			return $this->assertIsNumeric( $actual, $message );
+		} else {
+			return $this->assertInternalType( 'numeric', $actual, $message );
+		}
+	}
+
+	/**
+	 * Reports an error identified by $message if $actual is not an object.
+	 *
+	 * A custom method is used to future-proof the testcases as assertInternalType()
+	 * has been deprecated in PHPUnit 8.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  mixed  $actual  The value to test.
+	 * @param  string $message Optional. Default ''.
+	 */
+	protected function assert_is_object( $actual, $message = '' ) {
+		if ( \method_exists( $this, 'assertIsObject' ) ) {
+			return $this->assertIsObject( $actual, $message );
+		} else {
+			return $this->assertInternalType( 'object', $actual, $message );
+		}
+	}
+
+	/**
+	 * Reports an error identified by $message if $actual is not a resource.
+	 *
+	 * A custom method is used to future-proof the testcases as assertInternalType()
+	 * has been deprecated in PHPUnit 8.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  mixed  $actual  The value to test.
+	 * @param  string $message Optional. Default ''.
+	 */
+	protected function assert_is_resource( $actual, $message = '' ) {
+		if ( \method_exists( $this, 'assertIsResource' ) ) {
+			return $this->assertIsResource( $actual, $message );
+		} else {
+			return $this->assertInternalType( 'resource', $actual, $message );
+		}
+	}
+
+	/**
+	 * Reports an error identified by $message if $actual is not a string.
+	 *
+	 * A custom method is used to future-proof the testcases as assertInternalType()
+	 * has been deprecated in PHPUnit 8.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  mixed  $actual  The value to test.
+	 * @param  string $message Optional. Default ''.
+	 */
+	protected function assert_is_string( $actual, $message = '' ) {
+		if ( \method_exists( $this, 'assertIsString' ) ) {
+			return $this->assertIsString( $actual, $message );
+		} else {
+			return $this->assertInternalType( 'string', $actual, $message );
+		}
+	}
+
+	/**
+	 * Reports an error identified by $message if $actual is not a scalar value.
+	 *
+	 * A custom method is used to future-proof the testcases as assertInternalType()
+	 * has been deprecated in PHPUnit 8.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  mixed  $actual  The value to test.
+	 * @param  string $message Optional. Default ''.
+	 */
+	protected function assert_is_scalar( $actual, $message = '' ) {
+		if ( \method_exists( $this, 'assertIsScalar' ) ) {
+			return $this->assertIsScalar( $actual, $message );
+		} else {
+			return $this->assertInternalType( 'scalar', $actual, $message );
+		}
+	}
+
+	/**
+	 * Reports an error identified by $message if $actual is not a callable.
+	 *
+	 * A custom method is used to future-proof the testcases as assertInternalType()
+	 * has been deprecated in PHPUnit 8.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  mixed  $actual  The value to test.
+	 * @param  string $message Optional. Default ''.
+	 */
+	protected function assert_is_callable( $actual, $message = '' ) {
+		if ( \method_exists( $this, 'assertIsCallable' ) ) {
+			return $this->assertIsCallable( $actual, $message );
+		} else {
+			return $this->assertInternalType( 'callable', $actual, $message );
+		}
+	}
+
+	/**
+	 * Reports an error identified by $message if $actual is not an iterable value.
+	 *
+	 * A custom method is used to future-proof the testcases as assertInternalType()
+	 * has been deprecated in PHPUnit 8.
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param  mixed  $actual  The value to test.
+	 * @param  string $message Optional. Default ''.
+	 */
+	protected function assert_is_iterable( $actual, $message = '' ) {
+		if ( \method_exists( $this, 'assertIsIterable' ) ) {
+			return $this->assertIsIterable( $actual, $message );
+		} else {
+			return $this->assertInternalType( 'iterable', $actual, $message );
+		}
+	}
 }


### PR DESCRIPTION
- Runs Travis tests on PHP 7.3 and 7.4.
- Runs Scrutinizer analysis on PHP 7.4.
- Re-allows short array syntax (`[]`) and short ternary operators (`?:`) after recent WordPress Coding Standard changes.
- Makes test cases compatible with both PHPUnit 8 and earlier versions.
- Uses `gmdate()` instead of `date()` for printing cron job schedules using WP-CLI.