### PR TITLE
Load avatar privacy later and exit if another plugin has returned a URL

### DIFF
--- a/includes/avatar-privacy/components/class-avatar-handling.php
+++ b/includes/avatar-privacy/components/class-avatar-handling.php
@@ -95,7 +95,7 @@ class Avatar_Handling implements \Avatar_Privacy\Component {
 	 */
 	public function init() {
 		// New default image display: filter the gravatar image upon display.
-		\add_filter( 'pre_get_avatar_data', [ $this, 'get_avatar_data' ], 10, 2 );
+		\add_filter( 'pre_get_avatar_data', [ $this, 'get_avatar_data' ], 99, 2 );
 
 		// Generate presets from saved settings.
 		$this->enable_presets();
@@ -126,6 +126,10 @@ class Avatar_Handling implements \Avatar_Privacy\Component {
 	 * @return array
 	 */
 	public function get_avatar_data( $args, $id_or_email ) {
+		// If another filter has already passed in a URL then exit.
+		if ( isset( $args['url'] ) ) {
+			return $args; // \apply_filters( 'get_avatar_data', $args, $id_or_email );
+		}
 		$force_default = ! empty( $args['force_default'] );
 		$mimetype      = '';
 

--- a/tests/avatar-privacy/components/class-avatar-handling-test.php
+++ b/tests/avatar-privacy/components/class-avatar-handling-test.php
@@ -148,7 +148,7 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::init
 	 */
 	public function test_init() {
-		Filters\expectAdded( 'pre_get_avatar_data' )->once()->with( [ $this->sut, 'get_avatar_data' ], 10, 2 );
+		Filters\expectAdded( 'pre_get_avatar_data' )->once()->with( [ $this->sut, 'get_avatar_data' ], 99, 2 );
 
 		$this->sut->shouldReceive( 'enable_presets' )->once();
 


### PR DESCRIPTION
This fixes the problem outlined in #152 

You were loading your filter of pre_get_avatar_data at priority 10. I moved it to load later and to return if another plugin has added a url.