### PR TITLE
Update yzalis/identicon package to 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.0 (unreleased)
+*   _Change_: The `yzalis/identicon` package has been updated to version 2.0.
+*   _Change_: Some unused files have been removed from the `vendor-scoped` directory.
+
 ## 2.3.4 (2020-03-22)
 *   _Bugfix_: Allow plain URLs as default avatars. Use the filter hook
     `avatar_privacy_allow_remote_default_icon_url` to allow third-party domains

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,14 @@ module.exports = function(grunt) {
 			vendor: [
 				"build/vendor-scoped/{jdenticon,mistic100,scripturadesign,splitbrain}/*/*",
 				"!build/vendor-scoped/**/src",
-				"!build/vendor-scoped/**/partials"
+				"!build/vendor-scoped/**/partials",
+				// Prune Scriptura Color classes - we only need the helper functions.
+				"build/vendor-scoped/scripturadesign/color/src/**/*",
+				"!build/vendor-scoped/scripturadesign/color/src/functions.php",
+				// Prune PNG-based RingIcon.
+				"build/vendor-scoped/splitbrain/php-ringicon/src/RingIcon.php",
+				// Prune PNG-based Identicon generators.
+				"build/vendor-scoped/yzalis/identicon/src/Identicon/Generator/{GdGenerator,ImageMagickGenerator}.php"
 			],
 		},
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "scripturadesign/color": "^0.1.3",
         "mistic100/randomcolor": "^1.0",
         "jdenticon/jdenticon": "<1.1",
-        "yzalis/identicon": "^1.2",
+        "yzalis/identicon": "^2.0",
         "splitbrain/php-ringicon": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
- Updates `yzalis/identicon` to version 2.0.
- Removes some unused `*.php` files from `vendor-scoped` while building.