### PR TITLE
Add ETag header for proxied images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 *   _Change_: Some unused files have been removed from the `vendor-scoped` directory.
 *   _Change_: A new per-site database table for fast hash lookup has been introduced
               (base name `avatar_privacy_hashes`).
+*   _Change_: An ETag header is added to proxied images for better browser caching
+              in the Profile screen.
 *   _Bugfix_: Gravatars will be properly regenerated for comment authors that have
               not set a policy (when the site-admin has switched the default to
               "opt-out").

--- a/includes/avatar-privacy/components/class-image-proxy.php
+++ b/includes/avatar-privacy/components/class-image-proxy.php
@@ -226,6 +226,7 @@ class Image_Proxy implements Component {
 			\header( "Content-Length: {$length}" );
 			\header( 'Last-Modified: ' . \gmdate( 'D, d M Y H:i:s \G\M\T', $last_modified ) );
 			\header( 'Expires: ' . \gmdate( 'D, d M Y H:i:s \G\M\T', \time() + $cache_time ) );
+			\header( 'ETag: ' . \md5( $image ) );
 
 			// Here comes the content.
 			echo $image; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/tests/avatar-privacy/components/class-image-proxy-test.php
+++ b/tests/avatar-privacy/components/class-image-proxy-test.php
@@ -408,6 +408,7 @@ class Image_Proxy_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->assert_matches_regular_expression( "|Content-Length: {$length}|", $headers[1] );
 		$this->assert_matches_regular_expression( '|Last-Modified: |', $headers[2] );
 		$this->assert_matches_regular_expression( '|Expires: |', $headers[3] );
+		$this->assert_matches_regular_expression( '|ETag: |', $headers[4] );
 	}
 
 	/**


### PR DESCRIPTION
Add an `ETag` header to try to fix #154 (could not reproduce issue anymore, so efficacy of fix is unknown).