### PR TITLE
Simplify PHPStan config and clean up remaining issues

### DIFF
--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id.php
@@ -344,7 +344,9 @@ class Monster_ID extends PNG_Parts_Generator {
 
 					// Change color of pixel.
 					$color = \imageColorAllocateAlpha( $image, $r, $g, $b, $alpha );
-					\imageSetPixel( $image, $i, $j, $color );
+					if ( false !== $color ) {
+						\imageSetPixel( $image, $i, $j, $color );
+					}
 				}
 			}
 		}

--- a/includes/avatar-privacy/tools/images/class-png.php
+++ b/includes/avatar-privacy/tools/images/class-png.php
@@ -79,7 +79,7 @@ class PNG {
 					throw new \InvalidArgumentException( "Invalid image type $type." );
 			}
 
-			if ( false === $color || ! \imageFilledRectangle( $image, 0, 0, $width, $height, $color ) ) { // @phpstan-ignore-line -- https://github.com/phpstan/phpstan-src/pull/386
+			if ( false === $color || ! \imageFilledRectangle( $image, 0, 0, $width, $height, $color ) ) {
 				throw new \RuntimeException( "Error filling image of type $type." ); // @codeCoverageIgnore
 			}
 		} catch ( \RuntimeException $e ) {
@@ -175,7 +175,7 @@ class PNG {
 		list( $red, $green, $blue ) = HSLtoRGB( $hue, $saturation, $lightness );
 		$color                      = \imageColorAllocate( $image, $red, $green, $blue );
 
-		if ( false === $color || ! \imageFill( $image, $x, $y, $color ) ) { // @phpstan-ignore-line -- https://github.com/phpstan/phpstan-src/pull/386
+		if ( false === $color || ! \imageFill( $image, $x, $y, $color ) ) {
 			throw new \RuntimeException( "Error filling image with HSL ({$hue}, {$saturation}, {$lightness})." ); // @codeCoverageIgnore
 		}
 	}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,7 +12,7 @@ parameters:
     inferPrivatePropertyTypeFromConstructor: true
     treatPhpDocTypesAsCertain: false
     checkMissingIterableValueType: false
-    reportUnmatchedIgnoredErrors: false
+    reportUnmatchedIgnoredErrors: true
     bootstrapFiles:
         # Missing constants, function and class stubs
         - tests/phpstan/constants.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,34 +19,10 @@ parameters:
         - tests/phpstan/external-classes.php
         - tests/phpstan/external-functions.php
     scanFiles:
-        # - ../../php-stubs/wordpress-stubs/wordpress-stubs.php
         - vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php
-        - vendor/php-stubs/wp-cli-stubs/wp-cli-commands-stubs.php
-        - vendor/php-stubs/wp-cli-stubs/wp-cli-i18n-stubs.php
-#
-#        # Plugin stubs
-#        - tests/phpstan/PLUGIN-stubs.php
-#        # Procedural code
-#        - myplugin-functions.php
-#    autoload_directories:
-#        - inc/
     paths:
         - includes/
-    excludes_analyse:
-        - tests/
     ignoreErrors:
         # Uses func_get_args()
         - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
         - '#^Method Mundschenk_WP_Requirements::display_error_notice\(\) invoked with [234567] parameters, 1 required\.$#'
-        # Fixed in WordPress 5.3
-        #- '#^Function do_action(_ref_array)? invoked with [3456] parameters, 1-2 required\.$#'
-        #- '#^Function current_user_can invoked with 2 parameters, 1 required\.$#'
-        #- '#^Function add_query_arg invoked with [123] parameters?, 0 required\.$#'
-        #- '#^Function wp_sprintf invoked with [23456] parameters, 1 required\.$#'
-        #- '#^Function add_post_type_support invoked with [345] parameters, 2 required\.$#'
-        #- '#^Function ((get|add)_theme_support|current_theme_supports) invoked with [2345] parameters, 1 required\.$#'
-        # https://core.trac.wordpress.org/ticket/43304
-        #- '/^Parameter #2 \$deprecated of function load_plugin_textdomain expects string, false given\.$/'
-        # WP-CLI accepts a class as callable
-        #- '/^Parameter #2 \$callable of static method WP_CLI::add_command\(\) expects callable\(\): mixed, \S+ given\.$/'
-        # Please consider commenting ignores: issue URL or reason for ignoring


### PR DESCRIPTION
- Simplifies the PHPStan configuration file (`phpstan.neon`).
- Cleans up the remaining issues.