### PR TITLE
Additional housekeeping tasks

### DIFF
--- a/admin/partials/network/settings-page.php
+++ b/admin/partials/network/settings-page.php
@@ -24,14 +24,14 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.html
  */
 
-use Avatar_Privacy\Data_Storage\Network_Options;
+use Avatar_Privacy\Components\Network_Settings_Page;
 
 ?><div class='wrap'>
 	<h1><?php \esc_html_e( 'Avatar Privacy Network Settings', 'avatar-privacy' ); ?></h1>
 
-	<form method="post" action="<?php echo \esc_url( 'edit.php?action=' . self::ACTION ); ?>">
-		<?php \settings_fields( self::OPTION_GROUP ); ?>
-		<?php \do_settings_sections( self::OPTION_GROUP ); ?>
+	<form method="post" action="<?php echo \esc_url( 'edit.php?action=' . Network_Settings_Page::ACTION ); ?>">
+		<?php \settings_fields( Network_Settings_Page::OPTION_GROUP ); ?>
+		<?php \do_settings_sections( Network_Settings_Page::OPTION_GROUP ); ?>
 
 		<p class="submit">
 			<?php \submit_button( \__( 'Save Changes', 'avatar-privacy' ), 'primary', 'save_changes', false, [ 'tabindex' => 1 ] ); ?>

--- a/includes/avatar-privacy/class-factory.php
+++ b/includes/avatar-privacy/class-factory.php
@@ -234,99 +234,19 @@ class Factory extends Dice {
 			User_Form::class                                        => self::SHARED,
 			self::USERFORM_PROFILE_INSTANCE                         => [
 				'instanceOf'      => User_Form::class,
-				'constructParams' => [
-					[
-						'nonce'   => 'avatar_privacy_use_gravatar_nonce_',
-						'action'  => 'avatar_privacy_edit_use_gravatar',
-						'field'   => 'avatar-privacy-use-gravatar',
-						'partial' => 'admin/partials/profile/use-gravatar.php',
-					],
-					[
-						'nonce'   => 'avatar_privacy_allow_anonymous_nonce_',
-						'action'  => 'avatar_privacy_edit_allow_anonymous',
-						'field'   => 'avatar-privacy-allow-anonymous',
-						'partial' => 'admin/partials/profile/allow-anonymous.php',
-					],
-					[
-						'nonce'   => 'avatar_privacy_upload_avatar_nonce_',
-						'action'  => 'avatar_privacy_upload_avatar',
-						'field'   => 'avatar-privacy-user-avatar-upload',
-						'erase'   => 'avatar-privacy-user-avatar-erase',
-						'partial' => 'admin/partials/profile/user-avatar-upload.php',
-					],
-				],
+				'constructParams' => $this->get_user_form_parameters( self::USERFORM_PROFILE_INSTANCE ),
 			],
 			self::USERFORM_BBPRESS_PROFILE_INSTANCE                 => [
 				'instanceOf'      => User_Form::class,
-				'constructParams' => [
-					[
-						'nonce'   => 'avatar_privacy_bbpress_use_gravatar_nonce_',
-						'action'  => 'avatar_privacy_bbpress_edit_use_gravatar',
-						'field'   => 'avatar-privacy-bbpress-use-gravatar',
-						'partial' => 'public/partials/bbpress/profile/use-gravatar.php',
-					],
-					[
-						'nonce'   => 'avatar_privacy_bbpress_allow_anonymous_nonce_',
-						'action'  => 'avatar_privacy_bbpress_edit_allow_anonymous',
-						'field'   => 'avatar-privacy-bbpress-allow-anonymous',
-						'partial' => 'public/partials/bbpress/profile/allow-anonymous.php',
-					],
-					[
-						'nonce'   => 'avatar_privacy_bbpress_upload_avatar_nonce_',
-						'action'  => 'avatar_privacy_bbpress_upload_avatar',
-						'field'   => 'avatar-privacy-bbpress-user-avatar-upload',
-						'erase'   => 'avatar-privacy-bbpress-user-avatar-erase',
-						'partial' => 'public/partials/bbpress/profile/user-avatar-upload.php',
-					],
-				],
+				'constructParams' => $this->get_user_form_parameters( self::USERFORM_BBPRESS_PROFILE_INSTANCE ),
 			],
 			self::USERFORM_FRONTEND_INSTANCE                        => [
 				'instanceOf'      => User_Form::class,
-				'constructParams' => [
-					[
-						'nonce'   => 'avatar_privacy_frontend_use_gravatar_nonce_',
-						'action'  => 'avatar_privacy_frontend_edit_use_gravatar',
-						'field'   => 'avatar-privacy-frontend-use-gravatar',
-						'partial' => 'public/partials/profile/use-gravatar.php',
-					],
-					[
-						'nonce'   => 'avatar_privacy_frontend_allow_anonymous_nonce_',
-						'action'  => 'avatar_privacy_frontend_edit_allow_anonymous',
-						'field'   => 'avatar_privacy-frontend-allow_anonymous',
-						'partial' => 'public/partials/profile/allow-anonymous.php',
-					],
-					[
-						'nonce'   => 'avatar_privacy_frontend_upload_avatar_nonce_',
-						'action'  => 'avatar_privacy_frontend_upload_avatar',
-						'field'   => 'avatar-privacy-frontend-user-avatar-upload',
-						'erase'   => 'avatar-privacy-frontend-user-avatar-erase',
-						'partial' => 'public/partials/profile/user-avatar-upload.php',
-					],
-				],
+				'constructParams' => $this->get_user_form_parameters( self::USERFORM_FRONTEND_INSTANCE ),
 			],
 			self::USERFORM_THEME_MY_LOGIN_PROFILES_INSTANCE         => [
 				'instanceOf'      => User_Form::class,
-				'constructParams' => [
-					[
-						'nonce'   => 'avatar_privacy_tml_profiles_use_gravatar_nonce_',
-						'action'  => 'avatar_privacy_tml_profiles_edit_use_gravatar',
-						'field'   => 'avatar-privacy-tml-profiles-use-gravatar',
-						'partial' => 'public/partials/tml-profiles/use-gravatar.php',
-					],
-					[
-						'nonce'   => 'avatar_privacy_tml_profiles_allow_anonymous_nonce_',
-						'action'  => 'avatar_privacy_tml_profiles_edit_allow_anonymous',
-						'field'   => 'avatar_privacy-tml-profiles-allow_anonymous',
-						'partial' => 'public/partials/tml-profiles/allow-anonymous.php',
-					],
-					[
-						'nonce'   => 'avatar_privacy_tml_profiles_upload_avatar_nonce_',
-						'action'  => 'avatar_privacy_tml_profiles_upload_avatar',
-						'field'   => 'avatar-privacy-tml-profiles-user-avatar-upload',
-						'erase'   => 'avatar-privacy-tml-profiles-user-avatar-erase',
-						'partial' => 'public/partials/tml-profiles/user-avatar-upload.php',
-					],
-				],
+				'constructParams' => $this->get_user_form_parameters( self::USERFORM_THEME_MY_LOGIN_PROFILES_INSTANCE ),
 			],
 
 			// Plugin integrations.
@@ -527,5 +447,114 @@ class Factory extends Dice {
 			'avatar_privacy_default_icon_url'     => [ 'instance' => Default_Icons_Handler::class ],
 			'avatar_privacy_legacy_icon_url'      => [ 'instance' => Legacy_Icon_Handler::class ],
 		];
+	}
+
+	/**
+	 * Retrieves the constructor parameters for configuring named user form instances.
+	 *
+	 * @since  2.4.0
+	 *
+	 * @param  string $instance The named instance.
+	 *
+	 * @return array            The constructor parameter array for the named instance.
+	 *
+	 * @throws \InvalidArgumentException An exception is raised when $instance is
+	 *                                   not one of the expected constants.
+	 */
+	protected function get_user_form_parameters( $instance ) {
+		switch ( $instance ) {
+			case self::USERFORM_PROFILE_INSTANCE:
+				$use_gravatar    = [
+					'nonce'   => 'avatar_privacy_use_gravatar_nonce_',
+					'action'  => 'avatar_privacy_edit_use_gravatar',
+					'field'   => 'avatar-privacy-use-gravatar',
+					'partial' => 'admin/partials/profile/use-gravatar.php',
+				];
+				$allow_anonymous = [
+					'nonce'   => 'avatar_privacy_allow_anonymous_nonce_',
+					'action'  => 'avatar_privacy_edit_allow_anonymous',
+					'field'   => 'avatar-privacy-allow-anonymous',
+					'partial' => 'admin/partials/profile/allow-anonymous.php',
+				];
+				$user_avatar     = [
+					'nonce'   => 'avatar_privacy_upload_avatar_nonce_',
+					'action'  => 'avatar_privacy_upload_avatar',
+					'field'   => 'avatar-privacy-user-avatar-upload',
+					'erase'   => 'avatar-privacy-user-avatar-erase',
+					'partial' => 'admin/partials/profile/user-avatar-upload.php',
+				];
+				break;
+
+			case self::USERFORM_BBPRESS_PROFILE_INSTANCE:
+				$use_gravatar    = [
+					'nonce'   => 'avatar_privacy_bbpress_use_gravatar_nonce_',
+					'action'  => 'avatar_privacy_bbpress_edit_use_gravatar',
+					'field'   => 'avatar-privacy-bbpress-use-gravatar',
+					'partial' => 'public/partials/bbpress/profile/use-gravatar.php',
+				];
+				$allow_anonymous = [
+					'nonce'   => 'avatar_privacy_bbpress_allow_anonymous_nonce_',
+					'action'  => 'avatar_privacy_bbpress_edit_allow_anonymous',
+					'field'   => 'avatar-privacy-bbpress-allow-anonymous',
+					'partial' => 'public/partials/bbpress/profile/allow-anonymous.php',
+				];
+				$user_avatar     = [
+					'nonce'   => 'avatar_privacy_bbpress_upload_avatar_nonce_',
+					'action'  => 'avatar_privacy_bbpress_upload_avatar',
+					'field'   => 'avatar-privacy-bbpress-user-avatar-upload',
+					'erase'   => 'avatar-privacy-bbpress-user-avatar-erase',
+					'partial' => 'public/partials/bbpress/profile/user-avatar-upload.php',
+				];
+				break;
+
+			case self::USERFORM_FRONTEND_INSTANCE:
+				$use_gravatar    = [
+					'nonce'   => 'avatar_privacy_frontend_use_gravatar_nonce_',
+					'action'  => 'avatar_privacy_frontend_edit_use_gravatar',
+					'field'   => 'avatar-privacy-frontend-use-gravatar',
+					'partial' => 'public/partials/profile/use-gravatar.php',
+				];
+				$allow_anonymous = [
+					'nonce'   => 'avatar_privacy_frontend_allow_anonymous_nonce_',
+					'action'  => 'avatar_privacy_frontend_edit_allow_anonymous',
+					'field'   => 'avatar_privacy-frontend-allow_anonymous',
+					'partial' => 'public/partials/profile/allow-anonymous.php',
+				];
+				$user_avatar     = [
+					'nonce'   => 'avatar_privacy_frontend_upload_avatar_nonce_',
+					'action'  => 'avatar_privacy_frontend_upload_avatar',
+					'field'   => 'avatar-privacy-frontend-user-avatar-upload',
+					'erase'   => 'avatar-privacy-frontend-user-avatar-erase',
+					'partial' => 'public/partials/profile/user-avatar-upload.php',
+				];
+				break;
+
+			case self::USERFORM_THEME_MY_LOGIN_PROFILES_INSTANCE:
+				$use_gravatar    = [
+					'nonce'   => 'avatar_privacy_tml_profiles_use_gravatar_nonce_',
+					'action'  => 'avatar_privacy_tml_profiles_edit_use_gravatar',
+					'field'   => 'avatar-privacy-tml-profiles-use-gravatar',
+					'partial' => 'public/partials/tml-profiles/use-gravatar.php',
+				];
+				$allow_anonymous = [
+					'nonce'   => 'avatar_privacy_tml_profiles_allow_anonymous_nonce_',
+					'action'  => 'avatar_privacy_tml_profiles_edit_allow_anonymous',
+					'field'   => 'avatar_privacy-tml-profiles-allow_anonymous',
+					'partial' => 'public/partials/tml-profiles/allow-anonymous.php',
+				];
+				$user_avatar     = [
+					'nonce'   => 'avatar_privacy_tml_profiles_upload_avatar_nonce_',
+					'action'  => 'avatar_privacy_tml_profiles_upload_avatar',
+					'field'   => 'avatar-privacy-tml-profiles-user-avatar-upload',
+					'erase'   => 'avatar-privacy-tml-profiles-user-avatar-erase',
+					'partial' => 'public/partials/tml-profiles/user-avatar-upload.php',
+				];
+				break;
+
+			default:
+				throw new \InvalidArgumentException( "Invalid named instance {$instance}." );
+		}
+
+		return [ $use_gravatar, $allow_anonymous, $user_avatar ];
 	}
 }

--- a/includes/avatar-privacy/class-factory.php
+++ b/includes/avatar-privacy/class-factory.php
@@ -139,7 +139,6 @@ class Factory extends Dice {
 			API::class                                              => self::SHARED,
 			Core::class                                             => self::SHARED,
 			Settings::class                                         => [
-				'shared'          => true,
 				'constructParams' => [ $this->get_plugin_version( \AVATAR_PRIVACY_PLUGIN_FILE ) ],
 			],
 

--- a/includes/avatar-privacy/class-factory.php
+++ b/includes/avatar-privacy/class-factory.php
@@ -150,6 +150,11 @@ class Factory extends Dice {
 
 			// Components.
 			Component::class                                        => self::SHARED,
+			Components\Block_Editor::class                          => [
+				'substitutions' => [
+					User_Form::class => [ 'instance' => self::USERFORM_FRONTEND_INSTANCE ],
+				],
+			],
 			Components\Command_Line_Interface::class                => [
 				'constructParams' => [ $this->get_cli_commands() ],
 			],
@@ -161,6 +166,16 @@ class Factory extends Dice {
 			],
 			Components\Setup::class                                 => [
 				'constructParams' => [ $this->get_database_tables() ],
+			],
+			Components\Shortcodes::class                            => [
+				'substitutions' => [
+					User_Form::class => [ 'instance' => self::USERFORM_FRONTEND_INSTANCE ],
+				],
+			],
+			Components\User_Profile::class                          => [
+				'substitutions' => [
+					User_Form::class => [ 'instance' => self::USERFORM_PROFILE_INSTANCE ],
+				],
 			],
 
 			// Default icon providers.
@@ -312,22 +327,6 @@ class Factory extends Dice {
 						'erase'   => 'avatar-privacy-tml-profiles-user-avatar-erase',
 						'partial' => 'public/partials/tml-profiles/user-avatar-upload.php',
 					],
-				],
-			],
-
-			Components\Block_Editor::class                          => [
-				'substitutions' => [
-					User_Form::class => [ 'instance' => self::USERFORM_FRONTEND_INSTANCE ],
-				],
-			],
-			Components\Shortcodes::class                            => [
-				'substitutions' => [
-					User_Form::class => [ 'instance' => self::USERFORM_FRONTEND_INSTANCE ],
-				],
-			],
-			Components\User_Profile::class                          => [
-				'substitutions' => [
-					User_Form::class => [ 'instance' => self::USERFORM_PROFILE_INSTANCE ],
 				],
 			],
 

--- a/includes/avatar-privacy/cli/class-cron-command.php
+++ b/includes/avatar-privacy/cli/class-cron-command.php
@@ -63,12 +63,9 @@ class Cron_Command extends Abstract_Command {
 	 *
 	 * @subcommand list
 	 *
-	 * @param  array $args       The positional arguments.
-	 * @param  array $assoc_args The associative arguments.
-	 *
 	 * @return void
 	 */
-	public function list_( /* @scrutinizer ignore-unused */ array $args, /* @scrutinizer ignore-unused */ array $assoc_args ) {
+	public function list_() {
 		$job  = Image_Proxy::CRON_JOB_ACTION;
 		$next = \wp_next_scheduled( $job );
 
@@ -91,12 +88,9 @@ class Cron_Command extends Abstract_Command {
 	 *    $ wp avatar-privacy cron delete
 	 *    Success: Cron job avatar_privacy_daily was unscheduled on this site (1 event).
 	 *
-	 * @param  array $args       The positional arguments.
-	 * @param  array $assoc_args The associative arguments.
-	 *
 	 * @return void
 	 */
-	public function delete( /* @scrutinizer ignore-unused */ array $args, /* @scrutinizer ignore-unused */ array $assoc_args ) {
+	public function delete() {
 		$job    = Image_Proxy::CRON_JOB_ACTION;
 		$events = \wp_unschedule_hook( $job );
 

--- a/includes/avatar-privacy/cli/class-database-command.php
+++ b/includes/avatar-privacy/cli/class-database-command.php
@@ -102,12 +102,9 @@ class Database_Command extends Abstract_Command {
 	 *
 	 * @global \wpdb $wpdb       The WordPress database.
 	 *
-	 * @param  array $args       The positional arguments.
-	 * @param  array $assoc_args The associative arguments.
-	 *
 	 * @return void
 	 */
-	public function show( /* @scrutinizer ignore-unused */ array $args, /* @scrutinizer ignore-unused */ array $assoc_args ) {
+	public function show() {
 		global $wpdb;
 
 		// Query data.

--- a/includes/avatar-privacy/components/class-setup.php
+++ b/includes/avatar-privacy/components/class-setup.php
@@ -330,8 +330,6 @@ class Setup implements Component {
 					\wp_unschedule_hook( Image_Proxy::CRON_JOB_ACTION );
 				}
 			);
-
-			return;
 		}
 	}
 

--- a/includes/avatar-privacy/data-storage/class-filesystem-cache.php
+++ b/includes/avatar-privacy/data-storage/class-filesystem-cache.php
@@ -138,11 +138,14 @@ class Filesystem_Cache {
 			return true;
 		}
 
-		if ( 0 === \strlen( $data ) || ! \wp_mkdir_p( \dirname( $file ) ) || false === \file_put_contents( $file, $data, \LOCK_EX ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
-			return false;
-		} else {
-			return true;
-		}
+		return ! (
+			// Don't create empty files.
+			0 === \strlen( $data ) ||
+			// Make sure that the file path is valid.
+			! \wp_mkdir_p( \dirname( $file ) ) ||
+			// Check if the file has been stored successfully.
+			false === \file_put_contents( $file, $data, \LOCK_EX )  // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
+		);
 	}
 
 	/**

--- a/includes/avatar-privacy/data-storage/class-filesystem-cache.php
+++ b/includes/avatar-privacy/data-storage/class-filesystem-cache.php
@@ -26,6 +26,8 @@
 
 namespace Avatar_Privacy\Data_Storage;
 
+use Avatar_Privacy\Exceptions\Filesystem_Exception;
+
 /**
  * A filesystem caching handler.
  *
@@ -68,7 +70,10 @@ class Filesystem_Cache {
 	/**
 	 * Retrieves the base directory for caching files.
 	 *
-	 * @throws \RuntimeException A RuntimeException is thrown if the cache directory does not exist and can't be created.
+	 * @since  2.4.0 A Filesystem_Exception is thrown instead of a generic \RuntimeException.
+	 *
+	 * @throws Filesystem_Exception An exception is thrown if the cache directory
+	 *                              does not exist and can't be created.
 	 *
 	 * @return string
 	 */
@@ -77,7 +82,7 @@ class Filesystem_Cache {
 			$this->base_dir = "{$this->get_upload_dir()['basedir']}/" . self::CACHE_DIR;
 
 			if ( ! \wp_mkdir_p( $this->base_dir ) ) {
-				throw new \RuntimeException( "The cache directory {$this->base_dir} could not be created." );
+				throw new Filesystem_Exception( "The cache directory {$this->base_dir} could not be created." );
 			}
 		}
 

--- a/includes/avatar-privacy/data-storage/database/class-table.php
+++ b/includes/avatar-privacy/data-storage/database/class-table.php
@@ -26,6 +26,8 @@
 
 namespace Avatar_Privacy\Data_Storage\Database;
 
+use Avatar_Privacy\Exceptions\Database_Exception;
+
 /**
  * A plugin-specific database handler.
  *
@@ -311,7 +313,7 @@ abstract class Table {
 	 *
 	 * @return string[]
 	 *
-	 * @throws \RuntimeException A \RuntimeException is raised when invalid column names are used.
+	 * @throws Database_Exception An exception is raised when invalid column names are used.
 	 */
 	protected function get_format( array $columns ) {
 		$format_strings = [];
@@ -320,7 +322,7 @@ abstract class Table {
 			if ( ! empty( $this->column_formats[ $key ] ) ) {
 				$format_strings[] = null === $value ? 'NULL' : $this->column_formats[ $key ];
 			} else {
-				throw new \RuntimeException( "Invalid column name '{$key}'." );
+				throw new Database_Exception( "Invalid column name '{$key}'." );
 			}
 		}
 

--- a/includes/avatar-privacy/data-storage/database/class-table.php
+++ b/includes/avatar-privacy/data-storage/database/class-table.php
@@ -180,7 +180,7 @@ abstract class Table {
 		// Force DB update?
 		$db_needs_update = \version_compare( $previous_version, $this->update_threshold, '<' );
 
-		// Check if the table exists.
+		// Check if the table has already been registered.
 		if ( ! $db_needs_update && \property_exists( $wpdb, $this->table_basename ) ) {
 			return false;
 		}
@@ -188,21 +188,19 @@ abstract class Table {
 		// Set up table name.
 		$table_name = $this->get_table_name();
 
-		// Fix $wpdb object if table already exists, unless we need an update.
+		// Just fix $wpdb object if table already exists, unless we need an update.
 		if ( ! $db_needs_update && $this->table_exists( $table_name ) ) {
 			$this->register_table( $wpdb, $table_name );
-			return false;
+		} else {
+			// Create/update the table.
+			$this->db_delta( $this->get_table_definition( $table_name ) . " {$wpdb->get_charset_collate()};" );
+
+			if ( $this->table_exists( $table_name ) ) {
+				$this->register_table( $wpdb, $table_name );
+				return true;
+			}
 		}
 
-		// Create the table.
-		$this->db_delta( $this->get_table_definition( $table_name ) . " {$wpdb->get_charset_collate()};" );
-
-		if ( $this->table_exists( $table_name ) ) {
-			$this->register_table( $wpdb, $table_name );
-			return true;
-		}
-
-		// Should not ever happen.
 		return false;
 	}
 

--- a/includes/avatar-privacy/exceptions/class-database-exception.php
+++ b/includes/avatar-privacy/exceptions/class-database-exception.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2020 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Exceptions;
+
+/**
+ * An exception indicating that an error occured during a database operation.
+ *
+ * @since 2.4.0
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ */
+class Database_Exception extends \RuntimeException {
+}

--- a/includes/avatar-privacy/exceptions/class-filesystem-exception.php
+++ b/includes/avatar-privacy/exceptions/class-filesystem-exception.php
@@ -26,14 +26,12 @@
 
 namespace Avatar_Privacy\Exceptions;
 
-use Avatar_Privacy\Exceptions\Filesystem_Exception;
-
 /**
- * An exception indicating that a file could not be deleted.
+ * An exception indicating that a filesystem operation failed.
  *
  * @since 2.4.0
  *
  * @author Peter Putzer <github@mundschenk.at>
  */
-class File_Deletion_Exception extends Filesystem_Exception {
+class Filesystem_Exception extends \RuntimeException {
 }

--- a/includes/avatar-privacy/exceptions/class-png-image-exception.php
+++ b/includes/avatar-privacy/exceptions/class-png-image-exception.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2020 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Exceptions;
+
+/**
+ * An exception indicating that an error occured during image handling.
+ *
+ * @since 2.4.0
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ */
+class PNG_Image_Exception extends \RuntimeException {
+}

--- a/includes/avatar-privacy/tools/images/class-png.php
+++ b/includes/avatar-privacy/tools/images/class-png.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2019 Peter Putzer.
+ * Copyright 2019-2020 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,12 +26,15 @@
 
 namespace Avatar_Privacy\Tools\Images;
 
+use Avatar_Privacy\Exceptions\PNG_Image_Exception;
+
 use function Scriptura\Color\Helpers\HSLtoRGB;
 
 /**
  * A utility class providing some methods for dealing with PNG images.
  *
  * @since 2.3.0
+ * @since 2.4.0 The class now uses `PNG_Image_Exception` instead of plain `RuntimeException`.
  *
  * @author Peter Putzer <github@mundschenk.at>
  */
@@ -46,14 +49,14 @@ class PNG {
 	 * @return resource
 	 *
 	 * @throws \InvalidArgumentException Called with an incorrect type.
-	 * @throws \RuntimeException         The image could not be created.
+	 * @throws PNG_Image_Exception       The image could not be created.
 	 */
 	public function create( $type, $width, $height ) {
 		$image = \imageCreateTrueColor( $width, $height );
 
 		// Something went wrong, badly.
 		if ( ! \is_resource( $image ) ) {
-			throw new \RuntimeException( "The image of type {$type} ($width x $height) could not be created." );  // @codeCoverageIgnore
+			throw new PNG_Image_Exception( "The image of type {$type} ($width x $height) could not be created." );  // @codeCoverageIgnore
 		}
 
 		// Don't do alpha blending for the initial fill operation.
@@ -80,9 +83,9 @@ class PNG {
 			}
 
 			if ( false === $color || ! \imageFilledRectangle( $image, 0, 0, $width, $height, $color ) ) {
-				throw new \RuntimeException( "Error filling image of type $type." ); // @codeCoverageIgnore
+				throw new PNG_Image_Exception( "Error filling image of type $type." ); // @codeCoverageIgnore
 			}
-		} catch ( \RuntimeException $e ) {
+		} catch ( PNG_Image_Exception $e ) {
 			// Clean up and re-throw exception.
 			\imageDestroy( $image ); // @codeCoverageIgnoreStart
 			throw $e;                // @codeCoverageIgnoreEnd
@@ -101,14 +104,14 @@ class PNG {
 	 *
 	 * @return resource
 	 *
-	 * @throws \RuntimeException The image could not be read.
+	 * @throws PNG_Image_Exception The image could not be read.
 	 */
 	public function create_from_file( $file ) {
 		$image = @\imageCreateFromPNG( $file );
 
 		// Something went wrong, badly.
 		if ( ! \is_resource( $image ) ) {
-			throw new \RuntimeException( "The PNG image {$file} could not be read." );
+			throw new PNG_Image_Exception( "The PNG image {$file} could not be read." );
 		}
 
 		// Fix transparent background.
@@ -130,7 +133,7 @@ class PNG {
 	 * @return void
 	 *
 	 * @throws \InvalidArgumentException One of the first two parameters was not a valid image resource.
-	 * @throws \RuntimeException         The image could not be copied.
+	 * @throws PNG_Image_Exception       The image could not be copied.
 	 */
 	public function combine( $base, $image, $width, $height ) {
 
@@ -147,7 +150,7 @@ class PNG {
 
 		// Return copy success status.
 		if ( ! $result ) {
-			throw new \RuntimeException( 'Error while copying image.' ); // @codeCoverageIgnore
+			throw new PNG_Image_Exception( 'Error while copying image.' ); // @codeCoverageIgnore
 		}
 	}
 
@@ -164,7 +167,7 @@ class PNG {
 	 * @return void
 	 *
 	 * @throws \InvalidArgumentException Not a valid image resource.
-	 * @throws \RuntimeException         The image could not be filled.
+	 * @throws PNG_Image_Exception       The image could not be filled.
 	 */
 	public function fill_hsl( $image, $hue, $saturation, $lightness, $x, $y ) {
 		// Abort if $image is not a valid resource.
@@ -176,7 +179,7 @@ class PNG {
 		$color                      = \imageColorAllocate( $image, $red, $green, $blue );
 
 		if ( false === $color || ! \imageFill( $image, $x, $y, $color ) ) {
-			throw new \RuntimeException( "Error filling image with HSL ({$hue}, {$saturation}, {$lightness})." ); // @codeCoverageIgnore
+			throw new PNG_Image_Exception( "Error filling image with HSL ({$hue}, {$saturation}, {$lightness})." ); // @codeCoverageIgnore
 		}
 	}
 }

--- a/includes/avatar-privacy/tools/images/class-svg.php
+++ b/includes/avatar-privacy/tools/images/class-svg.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2019 Peter Putzer.
+ * Copyright 2019-2020 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -30,6 +30,7 @@ namespace Avatar_Privacy\Tools\Images;
  * A utility class providing some methods for dealing with SVG images.
  *
  * @since 2.3.0
+ * @since 2.4.0 Attributes changed to use constants.
  *
  * @author Peter Putzer <github@mundschenk.at>
  */
@@ -193,11 +194,21 @@ abstract class SVG {
 			self::ATTR_CLIPPATHUNITS => true,
 			self::ATTR_ID            => true,
 		],
-		'defs'           => true,
+		'defs'           => [
+			// Global attributes.
+			self::ATTR_CLASS         => true,
+			self::ATTR_ID            => true,
+			self::ATTR_STYLE         => true,
+		],
 		'style'          => [
 			self::ATTR_TYPE => true,
 		],
-		'desc'           => true,
+		'desc'           => [
+			// Global attributes.
+			self::ATTR_CLASS         => true,
+			self::ATTR_ID            => true,
+			self::ATTR_STYLE         => true,
+		],
 		'ellipse'        => [
 			self::ATTR_CLASS             => true,
 			self::ATTR_CLIP_PATH         => true,
@@ -633,7 +644,12 @@ abstract class SVG {
 			self::ATTR_TRANSFORM        => true,
 			self::ATTR_XLINK_HREF       => true,
 		],
-		'title'          => true,
+		'title'          => [
+			// Global attributes.
+			self::ATTR_CLASS         => true,
+			self::ATTR_ID            => true,
+			self::ATTR_STYLE         => true,
+		],
 		'tspan'          => [
 			self::ATTR_CLASS             => true,
 			self::ATTR_CLIP_PATH         => true,

--- a/includes/avatar-privacy/tools/network/class-gravatar-service.php
+++ b/includes/avatar-privacy/tools/network/class-gravatar-service.php
@@ -169,8 +169,8 @@ class Gravatar_Service {
 
 		// Try to find it via transient cache. On multisite, we use site transients.
 		$transient_key = "check_{$hash}";
-		$transients    = \is_multisite() ? $this->site_transients : $this->transients;
-		$result        = $transients->get( $transient_key );
+		$_transients   = \is_multisite() ? $this->site_transients : $this->transients;
+		$result        = $_transients->get( $transient_key );
 		if ( false !== $result ) {
 			// Warm 1st level cache.
 			$this->validation_cache[ $hash ] = $result;
@@ -181,7 +181,7 @@ class Gravatar_Service {
 		$result = $this->ping_gravatar( $email );
 		if ( false !== $result ) {
 			// Cache result.
-			$transients->set( $transient_key, $result, $this->calculate_caching_duration( $result, $age ) );
+			$_transients->set( $transient_key, $result, $this->calculate_caching_duration( $result, $age ) );
 			$this->validation_cache[ $hash ] = $result;
 		}
 

--- a/includes/avatar-privacy/tools/network/class-gravatar-service.php
+++ b/includes/avatar-privacy/tools/network/class-gravatar-service.php
@@ -42,7 +42,7 @@ class Gravatar_Service {
 	/**
 	 * A cache for the results of the validate method.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	private $validation_cache = [];
 
@@ -164,7 +164,7 @@ class Gravatar_Service {
 
 		// Try to find something in the cache.
 		if ( isset( $this->validation_cache[ $hash ] ) ) {
-			return $this->validation_cache[ $hash ] ?: '';
+			return $this->validation_cache[ $hash ];
 		}
 
 		// Try to find it via transient cache. On multisite, we use site transients.
@@ -174,18 +174,16 @@ class Gravatar_Service {
 		if ( false !== $result ) {
 			// Warm 1st level cache.
 			$this->validation_cache[ $hash ] = $result;
-			return $result ?: '';
+			return $result;
 		}
 
 		// Ask gravatar.com.
 		$result = $this->ping_gravatar( $email );
-		if ( false === $result ) {
-			return ''; // Do not cache this result.
+		if ( false !== $result ) {
+			// Cache result.
+			$transients->set( $transient_key, $result, $this->calculate_caching_duration( $result, $age ) );
+			$this->validation_cache[ $hash ] = $result;
 		}
-
-		// Cache result.
-		$transients->set( $transient_key, $result, $this->calculate_caching_duration( $result, $age ) );
-		$this->validation_cache[ $hash ] = $result;
 
 		return $result ?: '';
 	}

--- a/includes/avatar-privacy/upload-handlers/ui/class-file-upload-input.php
+++ b/includes/avatar-privacy/upload-handlers/ui/class-file-upload-input.php
@@ -122,16 +122,16 @@ class File_Upload_Input extends Controls\Input {
 	 * @var string
 	 */
 	protected function get_element_markup() {
-		$value    = $this->get_value();
-		$checkbox = '';
-		$nonce    = \wp_nonce_field( $this->action, $this->nonce . \get_current_blog_id(), true, false );
+		$value           = $this->get_value();
+		$checkbox_markup = '';
+		$nonce_markup    = \wp_nonce_field( $this->action, $this->nonce . \get_current_blog_id(), true, false );
 
 		if ( ! empty( $value ) ) {
-			$checkbox =
+			$checkbox_markup =
 				"<input id=\"{$this->erase_checkbox_id}\" name=\"{$this->erase_checkbox_id}\" value=\"true\" type=\"checkbox\">
 				 <label for=\"{$this->erase_checkbox_id}\">" . \__( 'Delete custom default avatar.', 'avatar-privacy' ) . '</label>';
 		}
 
-		return $nonce . parent::get_element_markup() . $checkbox;
+		return $nonce_markup . parent::get_element_markup() . $checkbox_markup;
 	}
 }

--- a/public/partials/block/frontend-form.php
+++ b/public/partials/block/frontend-form.php
@@ -43,6 +43,7 @@ use Avatar_Privacy\Tools\HTML\User_Form;
 <form class="<?php echo \esc_attr( \trim( "avatar-privacy-frontend avatar-privacy-block {$attributes['className']}" ) ); ?>" method="post" enctype="multipart/form-data">
 <?php if ( ! empty( $attributes['preview'] ) ) : ?>
 	<fieldset disabled="disabled">
+		<legend class="screen-reader-text"><?php \esc_html_e( 'Avatar Privacy Form Preview', 'avatar-privacy' ); ?></legend>
 <?php endif; ?>
 	<?php $form->avatar_uploader( $user_id, $attributes ); ?>
 	<?php $form->use_gravatar_checkbox( $user_id, $attributes ); ?>

--- a/public/partials/wpdiscuz/use-gravatar.php
+++ b/public/partials/wpdiscuz/use-gravatar.php
@@ -39,7 +39,6 @@ if ( isset( $_POST[ Comments::CHECKBOX_FIELD_NAME ] ) ) { // phpcs:ignore WordPr
 	$is_checked = \filter_input( \INPUT_COOKIE, $cookie_name, \FILTER_VALIDATE_BOOLEAN );
 }
 ?>
-<!-- div class="comment-form-use-gravatar wpdiscuz-item wpd-field-group wpd-field-checkbox wpd-field-single wpd-has-desc" -->
 <div class="comment-form-use-gravatar wpdiscuz-item wpd-field-group wpd-field-checkbox wpd-field-single wpd-has-desc">
 	<div class="wpd-field-group-title">
 		<div class="wpd-item">

--- a/tests/avatar-privacy/cli/class-cron-command-test.php
+++ b/tests/avatar-privacy/cli/class-cron-command-test.php
@@ -87,15 +87,12 @@ class Cron_Command_Test extends TestCase {
 	 * @covers ::list_
 	 */
 	public function test_list_() {
-		$args       = [];
-		$assoc_args = [];
-
 		Functions\expect( 'wp_next_scheduled' )->once()->with( Image_Proxy::CRON_JOB_ACTION )->andReturn( \time() );
 
 		$this->wp_cli->shouldReceive( 'colorize' )->zeroOrMoreTimes();
 		$this->expect_wp_cli_success();
 
-		$this->assertNull( $this->sut->list_( $args, $assoc_args ) );
+		$this->assertNull( $this->sut->list_() );
 	}
 
 	/**
@@ -104,15 +101,12 @@ class Cron_Command_Test extends TestCase {
 	 * @covers ::list_
 	 */
 	public function test_list_not_scheduled() {
-		$args       = [];
-		$assoc_args = [];
-
 		Functions\expect( 'wp_next_scheduled' )->once()->with( Image_Proxy::CRON_JOB_ACTION )->andReturn( false );
 
 		$this->wp_cli->shouldReceive( 'colorize' )->zeroOrMoreTimes();
 		$this->expect_wp_cli_success();
 
-		$this->assertNull( $this->sut->list_( $args, $assoc_args ) );
+		$this->assertNull( $this->sut->list_() );
 	}
 
 	/**
@@ -121,15 +115,12 @@ class Cron_Command_Test extends TestCase {
 	 * @covers ::delete
 	 */
 	public function test_delete() {
-		$args       = [];
-		$assoc_args = [];
-
 		Functions\expect( 'wp_unschedule_hook' )->once()->with( Image_Proxy::CRON_JOB_ACTION )->andReturn( 1 );
 
 		$this->wp_cli->shouldReceive( 'colorize' )->zeroOrMoreTimes();
 		$this->expect_wp_cli_success();
 
-		$this->assertNull( $this->sut->delete( $args, $assoc_args ) );
+		$this->assertNull( $this->sut->delete() );
 	}
 
 	/**
@@ -138,14 +129,11 @@ class Cron_Command_Test extends TestCase {
 	 * @covers ::delete
 	 */
 	public function test_delete_no_events() {
-		$args       = [];
-		$assoc_args = [];
-
 		Functions\expect( 'wp_unschedule_hook' )->once()->with( Image_Proxy::CRON_JOB_ACTION )->andReturn( false );
 
 		$this->wp_cli->shouldReceive( 'colorize' )->zeroOrMoreTimes();
 		$this->expect_wp_cli_error();
 
-		$this->assertNull( $this->sut->delete( $args, $assoc_args ) );
+		$this->assertNull( $this->sut->delete() );
 	}
 }

--- a/tests/avatar-privacy/cli/class-database-command-test.php
+++ b/tests/avatar-privacy/cli/class-database-command-test.php
@@ -133,9 +133,6 @@ class Database_Command_Test extends TestCase {
 	 * @covers ::show
 	 */
 	public function test_show() {
-		$args       = [];
-		$assoc_args = [];
-
 		// Intermediary data.
 		$table   = 'fake_table';
 		$version = '6.6.6';
@@ -160,7 +157,7 @@ class Database_Command_Test extends TestCase {
 
 		$this->wp_cli->shouldReceive( 'line' )->atLeast()->once()->with( m::type( 'string' ) );
 
-		$this->assertNull( $this->sut->show( $args, $assoc_args ) );
+		$this->assertNull( $this->sut->show() );
 	}
 
 	/**
@@ -169,9 +166,6 @@ class Database_Command_Test extends TestCase {
 	 * @covers ::show
 	 */
 	public function test_show_multisite() {
-		$args       = [];
-		$assoc_args = [];
-
 		// Intermediary data.
 		$table   = 'fake_table';
 		$version = '6.6.6';
@@ -198,7 +192,7 @@ class Database_Command_Test extends TestCase {
 
 		$this->wp_cli->shouldReceive( 'line' )->atLeast()->once()->with( m::type( 'string' ) );
 
-		$this->assertNull( $this->sut->show( $args, $assoc_args ) );
+		$this->assertNull( $this->sut->show() );
 	}
 
 	/**
@@ -207,9 +201,6 @@ class Database_Command_Test extends TestCase {
 	 * @covers ::show
 	 */
 	public function test_show_multisite_global_table() {
-		$args       = [];
-		$assoc_args = [];
-
 		// Intermediary data.
 		$table   = 'fake_table';
 		$version = '6.6.6';
@@ -236,7 +227,7 @@ class Database_Command_Test extends TestCase {
 
 		$this->wp_cli->shouldReceive( 'line' )->atLeast()->once()->with( m::type( 'string' ) );
 
-		$this->assertNull( $this->sut->show( $args, $assoc_args ) );
+		$this->assertNull( $this->sut->show() );
 	}
 
 	/**

--- a/tests/avatar-privacy/data-storage/class-filesystem-cache-test.php
+++ b/tests/avatar-privacy/data-storage/class-filesystem-cache-test.php
@@ -35,6 +35,7 @@ use Mockery as m;
 use org\bovigo\vfs\vfsStream;
 
 use Avatar_Privacy\Data_Storage\Filesystem_Cache;
+use Avatar_Privacy\Exceptions\Filesystem_Exception;
 
 /**
  * Avatar_Privacy\Data_Storage\Filesystem_Cache unit test.
@@ -122,7 +123,7 @@ class Filesystem_Cache_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->sut->shouldReceive( 'get_upload_dir' )->once()->andReturn( [ 'basedir' => $basedir ] );
 		Functions\expect( 'wp_mkdir_p' )->once()->with( m::type( 'string' ) )->andReturn( false );
 
-		$this->expectException( \RuntimeException::class );
+		$this->expectException( Filesystem_Exception::class );
 
 		$this->assertSame( $cachedir, $this->sut->get_base_dir() );
 	}

--- a/tests/avatar-privacy/data-storage/database/class-table-test.php
+++ b/tests/avatar-privacy/data-storage/database/class-table-test.php
@@ -36,6 +36,8 @@ use org\bovigo\vfs\vfsStream;
 
 use Avatar_Privacy\Data_Storage\Database\Table;
 
+use Avatar_Privacy\Exceptions\Database_Exception;
+
 /**
  * Avatar_Privacy\Data_Storage\Database\Table unit test.
  *
@@ -466,7 +468,7 @@ class Table_Test extends \Avatar_Privacy\Tests\TestCase {
 		];
 		$expected = [ '%s', '%d', '%s' ];
 
-		$this->expectException( \RuntimeException::class );
+		$this->expectException( Database_Exception::class );
 
 		$this->assertSame( $expected, $this->sut->get_format( $columns ) );
 	}
@@ -516,7 +518,7 @@ class Table_Test extends \Avatar_Privacy\Tests\TestCase {
 		$wpdb = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		$this->sut->shouldReceive( 'get_table_name' )->once()->with( $site_id )->andReturn( $table_name );
-		$this->sut->shouldReceive( 'get_format' )->once()->with( $data )->andThrow( \RuntimeException::class );
+		$this->sut->shouldReceive( 'get_format' )->once()->with( $data )->andThrow( Database_Exception::class );
 		$wpdb->shouldReceive( 'insert' )->never();
 
 		$this->assertFalse( $this->sut->insert( $data, $site_id ) );
@@ -567,7 +569,7 @@ class Table_Test extends \Avatar_Privacy\Tests\TestCase {
 		$wpdb = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		$this->sut->shouldReceive( 'get_table_name' )->once()->with( $site_id )->andReturn( $table_name );
-		$this->sut->shouldReceive( 'get_format' )->once()->with( $data )->andThrow( \RuntimeException::class );
+		$this->sut->shouldReceive( 'get_format' )->once()->with( $data )->andThrow( Database_Exception::class );
 		$wpdb->shouldReceive( 'replace' )->never();
 
 		$this->assertFalse( $this->sut->replace( $data, $site_id ) );
@@ -627,7 +629,7 @@ class Table_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->sut->shouldReceive( 'get_table_name' )->once()->with( $site_id )->andReturn( $table_name );
 		$this->sut->shouldReceive( 'get_format' )->once()->with( $data )->andReturn( $formats );
-		$this->sut->shouldReceive( 'get_format' )->once()->with( $where )->andThrow( \RuntimeException::class );
+		$this->sut->shouldReceive( 'get_format' )->once()->with( $where )->andThrow( Database_Exception::class );
 		$wpdb->shouldReceive( 'update' )->never();
 
 		$this->assertFalse( $this->sut->update( $data, $where, $site_id ) );
@@ -673,7 +675,7 @@ class Table_Test extends \Avatar_Privacy\Tests\TestCase {
 		$wpdb = m::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		$this->sut->shouldReceive( 'get_table_name' )->once()->with( $site_id )->andReturn( $table_name );
-		$this->sut->shouldReceive( 'get_format' )->once()->with( $where )->andThrow( \RuntimeException::class );
+		$this->sut->shouldReceive( 'get_format' )->once()->with( $where )->andThrow( Database_Exception::class );
 		$wpdb->shouldReceive( 'delete' )->never();
 
 		$this->assertFalse( $this->sut->delete( $where, $site_id ) );
@@ -888,7 +890,7 @@ class Table_Test extends \Avatar_Privacy\Tests\TestCase {
 			],
 		];
 
-		$this->sut->shouldReceive( 'get_format' )->once()->andThrow( \RuntimeException::class );
+		$this->sut->shouldReceive( 'get_format' )->once()->andThrow( Database_Exception::class );
 		$this->sut->shouldReceive( 'get_table_name' )->never();
 
 		$wpdb->shouldReceive( 'prepare' )->never();

--- a/tests/avatar-privacy/tools/images/class-png-test.php
+++ b/tests/avatar-privacy/tools/images/class-png-test.php
@@ -36,6 +36,8 @@ use org\bovigo\vfs\vfsStream;
 
 use Avatar_Privacy\Tools\Images\PNG;
 
+use Avatar_Privacy\Exceptions\PNG_Image_Exception;
+
 /**
  * Avatar_Privacy\Tools\Images\PNG unit test.
  *
@@ -227,7 +229,7 @@ class PNG_Test extends \Avatar_Privacy\Tests\TestCase {
 	 */
 	public function test_create_from_file_invalid() {
 
-		$this->expectException( \RuntimeException::class );
+		$this->expectException( PNG_Image_Exception::class );
 
 		$this->assertNull( $this->sut->create_from_file( '/not/a/valid/PNG' ) );
 	}
@@ -379,7 +381,7 @@ class PNG_Test extends \Avatar_Privacy\Tests\TestCase {
 		}
 
 		// Expect failure.
-		$this->expectException( \RuntimeException::class );
+		$this->expectException( PNG_Image_Exception::class );
 
 		$this->sut->fill_hsl( $resource, $hue, $saturation, $lightness, $x, $y );
 


### PR DESCRIPTION
Various non-functional code clean-ups like:
- Simplify (return) logic in various places.
- Rename local variables that can be mistaken for class properties.
- Use custom exceptions instead of generic ones like `\RuntimeException`.
- Remove unused method arguments from WP-CLI commands where possible.
- Extract parts of `Factory::get_rules()`.