### PR TITLE
Release 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.4.1 (unreleased)
+## 2.4.1 (2021-01-10)
 *   _Bugfix_: Don't break the site when the options value in the DB has become corrupted.
 *   _Bugfix_: Workaround for maximum database key length when using MySQL < 5.7.7 or
               MariaDB < 10.2.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.4.1 (unreleased)
 *   _Bugfix_: Don't break the site when the options value in the DB has become corrupted.
+*   _Bugfix_: Workaround for maximum database key length when using MySQL < 5.7.7 or
+              MariaDB < 10.2.2.
 
 ## 2.4.0 (2021-01-10)
 *   _Feature_: Legacy (default) avatars are now properly cached and resized.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.1 (unreleased)
+*   _Bugfix_: Don't break the site when the options value in the DB has become corrupted.
+
 ## 2.4.0 (2021-01-10)
 *   _Feature_: Legacy (default) avatars are now properly cached and resized.
 *   _Feature_: There are now API methods to get and set a user's (local) avatar

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Avatar Privacy
 
-[![Build Status](https://travis-ci.org/mundschenk-at/avatar-privacy.svg?branch=master)](https://travis-ci.org/mundschenk-at/avatar-privacy)
 [![Latest Stable Version](https://poser.pugx.org/mundschenk-at/avatar-privacy/v/stable)](https://packagist.org/packages/mundschenk-at/avatar-privacy)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=mundschenk-at_avatar-privacy&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=mundschenk-at_avatar-privacy)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=mundschenk-at_avatar-privacy&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=mundschenk-at_avatar-privacy)

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -29,7 +29,7 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at
- * Version: 2.4.0
+ * Version: 2.4.1
  * Requires at least: 5.2
  * Requires PHP: 7.0
  * License: GNU General Public License v2 or later

--- a/includes/avatar-privacy/core/class-settings.php
+++ b/includes/avatar-privacy/core/class-settings.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018-2020 Peter Putzer.
+ * Copyright 2018-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -177,10 +177,41 @@ class Settings implements API {
 			$this->version !== $this->settings[ $site_id ][ Options::INSTALLED_VERSION ] ||
 			$force
 		) {
-			$this->settings[ $site_id ] = (array) $this->options->get( self::OPTION_NAME, $this->get_defaults() );
+			$this->settings[ $site_id ] = $this->load_settings();
 		}
 
 		return $this->settings[ $site_id ];
+	}
+
+	/**
+	 * Load settings from the database and set defaults if necessary.
+	 *
+	 * @since 2.4.1
+	 *
+	 * @return array
+	 */
+	protected function load_settings() {
+		$_settings = $this->options->get( self::OPTION_NAME );
+		$_defaults = $this->get_defaults();
+		$modified  = false;
+
+		if ( \is_array( $_settings ) ) {
+			foreach ( $_defaults as $name => $default_value ) {
+				if ( ! isset( $_settings[ $name ] ) ) {
+					$_settings[ $name ] = $default_value;
+					$modified           = true;
+				}
+			}
+		} else {
+			$_settings = $_defaults;
+			$modified  = true;
+		}
+
+		if ( $modified ) {
+			$this->options->set( self::OPTION_NAME, $_settings );
+		}
+
+		return $_settings;
 	}
 
 	/**

--- a/includes/avatar-privacy/data-storage/database/class-hashes-table.php
+++ b/includes/avatar-privacy/data-storage/database/class-hashes-table.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2020 Peter Putzer.
+ * Copyright 2020-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -98,10 +98,12 @@ class Hashes_Table extends Table {
 	 * @return string
 	 */
 	protected function get_table_definition( $table_name ) {
+		// TODO: The identifier length should be increased to at least 200 (or
+		// better 256 as in 2.4.0) in one of the next versions.
 		return "CREATE TABLE {$table_name} (
-				identifier varchar(256) NOT NULL,
-				hash char(64) NOT NULL,
-				type varchar(20) NOT NULL,
+				identifier varchar(175) NOT NULL,
+				hash char(64) CHARACTER SET ascii NOT NULL,
+				type varchar(20) CHARACTER SET ascii NOT NULL,
 				last_updated datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
 				PRIMARY KEY (hash, type),
 				UNIQUE KEY identifier (identifier, type)

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: gravatar, avatar, privacy, caching, bbpress, buddypress
 Requires at least: 5.2
 Requires PHP: 7.0
 Tested up to: 5.6
-Stable tag: 2.4.0
+Stable tag: 2.4.1
 License: GPLv2 or later
 
 Enhances the privacy of your users and visitors with gravatar opt-in and local avatars.
@@ -167,6 +167,10 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 
 == Changelog ==
+
+= 2.4.1 (2021-01-10) =
+*   _Bugfix_: Don't break the site when the options value in the DB has become corrupted.
+*   _Bugfix_: Workaround for maximum database key length when using MySQL < 5.7.7 or MariaDB < 10.2.2.
 
 = 2.4.0 (2021-01-10) =
 * _Feature_: Legacy (default) avatars are now properly cached and resized.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=mundschenk-at
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=avatar-privacy
-sonar.projectVersion=1.0
+#sonar.projectVersion=1.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=avatar-privacy.php,uninstall.php,includes,public,admin


### PR DESCRIPTION
- Bumps version.
- Updates README and CHANGELOG.
- Fixes crash when preferences don't contain `gravatar_use_default` setting.
- Works on MySQL 5.6 and MariaDB 10.1 again.