### PR TITLE
Fix build process for real

### DIFF
--- a/.scoper.inc.php
+++ b/.scoper.inc.php
@@ -42,6 +42,7 @@ const AVATAR_PRIVACY_WORDPRESS_FUNCTIONS = [
 
     // Multisite.
     'get_current_network_id',
+    'get_bloginfo',
 
     // Escaping and sanitization.
     'esc_attr',
@@ -51,6 +52,11 @@ const AVATAR_PRIVACY_WORDPRESS_FUNCTIONS = [
     'wp_kses',
     'wp_kses_allowed_html',
 
+    // Translation,
+    '__',
+    '_e',
+    'load_plugin_textdomain',
+
     // Settings API.
     'add_settings_field',
 
@@ -58,9 +64,20 @@ const AVATAR_PRIVACY_WORDPRESS_FUNCTIONS = [
     'checked',
     'selected',
 
+    // Hooks.
+    'add_action',
+    'add_filter',
+    'remove_action',
+    'remove_filter',
+
+    // Plugins.
+    'plugin_basename',
+    'deactivate_plugins',
+
     // Utility functions.
     'wp_list_pluck',
     'wp_parse_args',
+    'is_admin',
 ];
 
 return [
@@ -131,9 +148,7 @@ return [
     // Whitelists a list of files. Unlike the other whitelist related features, this one is about completely leaving
     // a file untouched.
     // Paths are relative to the configuration file unless if they are already absolute
-    'files-whitelist' => [
-        'vendor/mundschenk-at/check-wp-requirements/class-wp-requirements.php',
-    ],
+    'files-whitelist' => [],
 
     // When scoping PHP files, there will be scenarios where some of the code being scoped indirectly references the
     // original namespace. These will include, for example, strings or string manipulations. PHP-Scoper has limited

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.3 (2021-01-15)
+*   _Bugfix_: Don't break stuff (another build process fix, for real this time).
+
 ## 2.4.2 (2021-01-15)
 *   _Bugfix_: An unfortunate oversight in the build process led to crashes instead
               of the intended graceful failure when the installation requirements

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -29,7 +29,7 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at
- * Version: 2.4.2
+ * Version: 2.4.3
  * Requires at least: 5.2
  * Requires PHP: 7.0
  * License: GNU General Public License v2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: gravatar, avatar, privacy, caching, bbpress, buddypress
 Requires at least: 5.2
 Requires PHP: 7.0
 Tested up to: 5.6
-Stable tag: 2.4.2
+Stable tag: 2.4.3
 License: GPLv2 or later
 
 Enhances the privacy of your users and visitors with gravatar opt-in and local avatars.

--- a/readme.txt
+++ b/readme.txt
@@ -168,6 +168,9 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 == Changelog ==
 
+= 2.4.3 (2021-01-15) =
+* _Bugfix_: Don't break stuff (another build process fix, for real this time).
+
 = 2.4.2 (2021-01-15) =
 * _Bugfix_: An unfortunate oversight in the build process led to crashes instead of the intended graceful failure when the installation requirements were not met.
 


### PR DESCRIPTION
Unfortunately, 2.4.2 broke Avatar Privacy on all sites instead of just on those failing to meet requirements.