### PR TITLE
Add support for PHP 8.0

### DIFF
--- a/includes/avatar-privacy-functions.php
+++ b/includes/avatar-privacy-functions.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018-2020 Peter Putzer.
+ * Copyright 2018-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -43,6 +43,37 @@ if ( ! \function_exists( 'avapr_get_avatar_checkbox' ) ) {
 		\_deprecated_function( __FUNCTION__, '2.3.0', 'Avatar_Privacy\get_gravatar_checkbox' );
 
 		return get_gravatar_checkbox();
+	}
+}
+
+if ( ! \function_exists( 'is_gd_image' ) ) {
+
+	/**
+	 * Determines whether the value is an acceptable type for GD image functions.
+	 *
+	 * In PHP 8.0, the GD extension uses GdImage objects for its data structures.
+	 * This function checks if the passed value is either a resource of type `gd`
+	 * or a `GdImage` object instance. Any other type will return `false`.
+	 *
+	 * This function is a fallback for WordPress versions < 5.6.
+	 *
+	 * @since 2.5.0
+	 *
+	 * @param  resource/GdImage/false $image A value to check the type for.
+	 *
+	 * @return bool                          True if $image is either a GD image
+	 *                                       resource or GdImage instance, false
+	 *                                       otherwise.
+	 */
+	function is_gd_image( $image ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- shim for compatibility with WordPress < 5.6.
+		if (
+			\is_resource( $image ) && 'gd' === \get_resource_type( $image ) ||
+			\is_object( $image ) && $image instanceof GdImage
+		) {
+			return true;
+		}
+
+		return false;
 	}
 }
 

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-bird-avatar.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-bird-avatar.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2019-2020 Peter Putzer.
+ * Copyright 2019-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -30,6 +30,8 @@ use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\PNG_Parts_Generator;
 use Avatar_Privacy\Data_Storage\Site_Transients;
 use Avatar_Privacy\Tools\Images;
 use Avatar_Privacy\Tools\Number_Generator;
+
+use GdImage; // phpcs:ignore ImportDetection.Imports -- PHP 8.0 compatibility.
 
 /**
  * A bird avatar generator for the images created by David Revoy.
@@ -70,10 +72,12 @@ class Bird_Avatar extends PNG_Parts_Generator {
 	/**
 	 * Renders the avatar from its parts, using any of the given additional arguments.
 	 *
+	 * @since  2.5.0 Returns a resource or GdImage instance, depending on the PHP version.
+	 *
 	 * @param  array $parts The (randomized) avatar parts.
 	 * @param  array $args  Any additional arguments defined by the subclass.
 	 *
-	 * @return resource
+	 * @return resource|GdImage
 	 */
 	protected function render_avatar( array $parts, array $args ) {
 		// Create background.

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-cat-avatar.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-cat-avatar.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2019-2020 Peter Putzer.
+ * Copyright 2019-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -30,6 +30,8 @@ use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\PNG_Parts_Generator;
 use Avatar_Privacy\Data_Storage\Site_Transients;
 use Avatar_Privacy\Tools\Images;
 use Avatar_Privacy\Tools\Number_Generator;
+
+use GdImage; // phpcs:ignore ImportDetection.Imports -- PHP 8.0 compatibility.
 
 /**
  * A cat avatar generator for the images created by David Revoy.
@@ -70,10 +72,12 @@ class Cat_Avatar extends PNG_Parts_Generator {
 	/**
 	 * Renders the avatar from its parts, using any of the given additional arguments.
 	 *
+	 * @since  2.5.0 Returns a resource or GdImage instance, depending on the PHP version.
+	 *
 	 * @param  array $parts The (randomized) avatar parts.
 	 * @param  array $args  Any additional arguments defined by the subclass.
 	 *
-	 * @return resource
+	 * @return resource|GdImage
 	 */
 	protected function render_avatar( array $parts, array $args ) {
 		// Create background.

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id.php
@@ -32,6 +32,8 @@ use Avatar_Privacy\Data_Storage\Site_Transients;
 use Avatar_Privacy\Tools\Images;
 use Avatar_Privacy\Tools\Number_Generator;
 
+use GdImage; // phpcs:ignore ImportDetection.Imports -- PHP 8.0 compatibility.
+
 /**
  * A monster generator based on the WordPress implementation by Scott Sherrill-Mix
  * and the original algorithm designed by Andreas Gohr, based on an idea by Don Park.
@@ -256,10 +258,12 @@ class Monster_ID extends PNG_Parts_Generator {
 	/**
 	 * Renders the avatar from its parts, using any of the given additional arguments.
 	 *
+	 * @since  2.5.0 Returns a resource or GdImage instance, depending on the PHP version.
+	 *
 	 * @param  array $parts The (randomized) avatar parts.
 	 * @param  array $args  Any additional arguments defined by the subclass.
 	 *
-	 * @return resource
+	 * @return resource|GdImage
 	 */
 	protected function render_avatar( array $parts, array $args ) {
 		// Create background.
@@ -301,15 +305,17 @@ class Monster_ID extends PNG_Parts_Generator {
 	/**
 	 * Adds color to the given image.
 	 *
-	 * @since 2.1.0 Visibility changed to protected.
-	 * @since 2.3.0 Name changed to colorize_image() for consistency.
+	 * @since  2.1.0 Visibility changed to protected.
+	 * @since  2.3.0 Name changed to colorize_image() for consistency.
+	 * @since  2.5.0 Parameter $image can now also be a GdImage. Returns a resource
+	 *               or GdImage instance, depending on the PHP version.
 	 *
-	 * @param  resource $image      The image.
-	 * @param  int      $hue        The hue (0-360).
-	 * @param  int      $saturation The saturation (0-100).
-	 * @param  string   $part       The part name.
+	 * @param  resource|GdImage $image      The image.
+	 * @param  int              $hue        The hue (0-360).
+	 * @param  int              $saturation The saturation (0-100).
+	 * @param  string           $part       The part name.
 	 *
-	 * @return resource             The image, for chaining.
+	 * @return resource|GdImage             The image, for chaining.
 	 */
 	protected function colorize_image( $image, $hue = 360, $saturation = 100, $part = '' ) {
 		// Ensure non-negative hue.

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-png-parts-generator.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-png-parts-generator.php
@@ -32,6 +32,8 @@ use Avatar_Privacy\Data_Storage\Site_Transients;
 use Avatar_Privacy\Tools\Images;
 use Avatar_Privacy\Tools\Number_Generator;
 
+use GdImage; // phpcs:ignore ImportDetection.Imports -- PHP 8.0 compatibility.
+
 /**
  * A base class for parts-based PNG icon generators.
  *
@@ -128,8 +130,10 @@ abstract class PNG_Parts_Generator extends Parts_Generator {
 	/**
 	 * Resizes the image and returns the raw data.
 	 *
-	 * @param  resource $image The image resource.
-	 * @param  int      $size  The size in pixels.
+	 * @since  2.5.0 Parameter $image can now also be a GdImage.
+	 *
+	 * @param  resource|GdImage $image The image resource.
+	 * @param  int              $size  The size in pixels.
 	 *
 	 * @return string          The image data (or the empty string on error).
 	 */
@@ -185,14 +189,15 @@ abstract class PNG_Parts_Generator extends Parts_Generator {
 	}
 
 	/**
-	 * Creates an image resource of the chosen type with the set avatar size for
-	 * width and height.
+	 * Creates a GD image of the chosen type with the set avatar size for width
+	 * and height.
 	 *
-	 * @since 2.3.0
+	 * @since  2.3.0
+	 * @since  2.5.0 Returns a resource or GdImage instance, depending on the PHP version.
 	 *
 	 * @param  string $type The type of background to create. Valid: 'white', 'black', 'transparent'.
 	 *
-	 * @return resource
+	 * @return resource|GdImage
 	 *
 	 * @throws \RuntimeException The image could not be copied.
 	 */
@@ -205,13 +210,15 @@ abstract class PNG_Parts_Generator extends Parts_Generator {
 	 * the parts directory if a filename is given, assuming the avatar size for
 	 * width and height.
 	 *
-	 * The image resource is freed after copying.
+	 * The GD image (resource) is freed after copying.
 	 *
-	 * @param  resource        $base   The avatar image resource.
-	 * @param  string|resource $image  The image to be copied onto the base. Can
-	 *                                 be either the name of the image file
-	 *                                 relative to the parts directory, or an
-	 *                                 existing image resource.
+	 * @since  2.5.0 Parameters $base and $image can now also be GdImage instances.
+	 *
+	 * @param  resource|GdImage        $base  The avatar image resource.
+	 * @param  string|resource|GdImage $image The image to be copied onto the base. Can
+	 *                                        be either the name of the image file
+	 *                                        relative to the parts directory, or an
+	 *                                        existing image resource.
 	 *
 	 * @return void
 	 *
@@ -273,11 +280,12 @@ abstract class PNG_Parts_Generator extends Parts_Generator {
 	 * transparent pixels).
 	 *
 	 * @since  2.4.0 Extracted from ::get_parts_dimensions.
+	 * @since  2.5.0 Parameter $im can now also be a GdImage.
 	 *
 	 * @author Peter Putzer
 	 * @author Scott Sherrill-Mix
 	 *
-	 * @param  resource $im The image resource.
+	 * @param  resource|GdImage $im The image resource.
 	 *
 	 * @return array {
 	 *     The boundary coordinates for the image.

--- a/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar.php
+++ b/includes/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018-2020 Peter Putzer.
+ * Copyright 2018-2021 Peter Putzer.
  * Copyright 2007-2008 Shamus Young.
  *
  * This program is free software; you can redistribute it and/or
@@ -31,6 +31,8 @@ use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generators\PNG_Parts_Generator;
 use Avatar_Privacy\Data_Storage\Site_Transients;
 use Avatar_Privacy\Tools\Images;
 use Avatar_Privacy\Tools\Number_Generator;
+
+use GdImage; // phpcs:ignore ImportDetection.Imports -- PHP 8.0 compatibility.
 
 /**
  * A Wavatar generator, based on the original WordPress plugin by Shamus Young.
@@ -128,10 +130,12 @@ class Wavatar extends PNG_Parts_Generator {
 	/**
 	 * Renders the avatar from its parts, using any of the given additional arguments.
 	 *
+	 * @since  2.5.0 Returns a resource or GdImage instance, depending on the PHP version.
+	 *
 	 * @param  array $parts The (randomized) avatar parts.
 	 * @param  array $args  Any additional arguments defined by the subclass.
 	 *
-	 * @return resource
+	 * @return resource|GdImage
 	 */
 	protected function render_avatar( array $parts, array $args ) {
 		// Create background.

--- a/includes/avatar-privacy/tools/images/class-editor.php
+++ b/includes/avatar-privacy/tools/images/class-editor.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018-2020 Peter Putzer.
+ * Copyright 2018-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,6 +28,8 @@ namespace Avatar_Privacy\Tools\Images;
 
 use Avatar_Privacy\Tools\Images\Image_File;
 use Avatar_Privacy\Tools\Images\Image_Stream;
+
+use GdImage; // phpcs:ignore ImportDetection.Imports -- PHP 8.0 compatibility.
 
 /**
  * A utility class providing in-memory \WP_Image_Editor support.
@@ -140,15 +142,16 @@ class Editor {
 	}
 
 	/**
-	 * Creates a \WP_Image_Editor from a PHP image resource. The resource is
-	 * destroyed on success.
+	 * Creates a \WP_Image_Editor from a GD image. The image is destroyed on success.
 	 *
-	 * @param  resource $image Image data.
+	 * @since  2.5.0 Parameter $image can now also be a GdImage.
+	 *
+	 * @param  resource|GdImage $image Image data.
 	 *
 	 * @return \WP_Image_Editor|\WP_Error
 	 */
 	public function create_from_image_resource( $image ) {
-		if ( \is_resource( $image ) && \imagePNG( $image, $this->stream_url ) ) {
+		if ( \is_gd_image( $image ) && \imagePNG( $image, $this->stream_url ) ) {
 			// Clean up resource.
 			\imageDestroy( $image );
 

--- a/includes/avatar-privacy/tools/images/class-png.php
+++ b/includes/avatar-privacy/tools/images/class-png.php
@@ -28,6 +28,8 @@ namespace Avatar_Privacy\Tools\Images;
 
 use Avatar_Privacy\Exceptions\PNG_Image_Exception;
 
+use GdImage; // phpcs:ignore ImportDetection.Imports -- PHP 8.0 compatibility.
+
 /**
  * A utility class providing some methods for dealing with PNG images.
  *
@@ -40,11 +42,13 @@ class PNG {
 	/**
 	 * Creates an image resource of the chosen type.
 	 *
+	 * @since  2.5.0 Returns a resource or GdImage instance, depending on the PHP version.
+	 *
 	 * @param  string $type   The type of background to create. Valid: 'white', 'black', 'transparent'.
 	 * @param  int    $width  Image width in pixels.
 	 * @param  int    $height Image height in pixels.
 	 *
-	 * @return resource
+	 * @return resource|GdImage
 	 *
 	 * @throws \InvalidArgumentException Called with an incorrect type.
 	 * @throws PNG_Image_Exception       The image could not be created.
@@ -53,7 +57,7 @@ class PNG {
 		$image = \imageCreateTrueColor( $width, $height );
 
 		// Something went wrong, badly.
-		if ( ! \is_resource( $image ) ) {
+		if ( ! \is_gd_image( $image ) ) {
 			throw new PNG_Image_Exception( "The image of type {$type} ($width x $height) could not be created." );  // @codeCoverageIgnore
 		}
 
@@ -98,9 +102,11 @@ class PNG {
 	/**
 	 * Creates an image resource from the given file.
 	 *
+	 * @since  2.5.0 Returns a resource or GdImage instance, depending on the PHP version.
+	 *
 	 * @param  string $file The absolute path to a PNG image file.
 	 *
-	 * @return resource
+	 * @return resource|GdImage
 	 *
 	 * @throws PNG_Image_Exception The image could not be read.
 	 */
@@ -108,7 +114,7 @@ class PNG {
 		$image = @\imageCreateFromPNG( $file );
 
 		// Something went wrong, badly.
-		if ( ! \is_resource( $image ) ) {
+		if ( ! \is_gd_image( $image ) ) {
 			throw new PNG_Image_Exception( "The PNG image {$file} could not be read." );
 		}
 
@@ -123,10 +129,12 @@ class PNG {
 	 * Copies an image onto an existing base image. The image resource is freed
 	 * after copying.
 	 *
-	 * @param  resource $base   The avatar image resource.
-	 * @param  resource $image  The image to be copied onto the base.
-	 * @param  int      $width  Image width in pixels.
-	 * @param  int      $height Image height in pixels.
+	 * @since  2.5.0 Parameters $base and $image can now also be instances of GdImage.
+	 *
+	 * @param  resource|GdImage $base   The avatar image resource.
+	 * @param  resource|GdImage $image  The image to be copied onto the base.
+	 * @param  int              $width  Image width in pixels.
+	 * @param  int              $height Image height in pixels.
 	 *
 	 * @return void
 	 *
@@ -136,7 +144,7 @@ class PNG {
 	public function combine( $base, $image, $width, $height ) {
 
 		// Abort if $image is not a valid resource.
-		if ( ! \is_resource( $base ) || ! \is_resource( $image ) ) {
+		if ( ! \is_gd_image( $base ) || ! \is_gd_image( $image ) ) {
 			throw new \InvalidArgumentException( 'Invalid image resource.' );
 		}
 
@@ -155,12 +163,14 @@ class PNG {
 	/**
 	 * Fills the given image with a HSL color.
 	 *
-	 * @param  resource $image      The image.
-	 * @param  int      $hue        The hue (0-360).
-	 * @param  int      $saturation The saturation (0-100).
-	 * @param  int      $lightness  The lightness/Luminosity (0-100).
-	 * @param  int      $x          The horizontal coordinate.
-	 * @param  int      $y          The vertical coordinate.
+	 * @since  2.5.0 Parameter $image can now also be a GdImage.
+	 *
+	 * @param  resource|GdImage $image      The image.
+	 * @param  int              $hue        The hue (0-360).
+	 * @param  int              $saturation The saturation (0-100).
+	 * @param  int              $lightness  The lightness/Luminosity (0-100).
+	 * @param  int              $x          The horizontal coordinate.
+	 * @param  int              $y          The vertical coordinate.
 	 *
 	 * @return void
 	 *
@@ -169,7 +179,7 @@ class PNG {
 	 */
 	public function fill_hsl( $image, $hue, $saturation, $lightness, $x, $y ) {
 		// Abort if $image is not a valid resource.
-		if ( ! \is_resource( $image ) ) {
+		if ( ! \is_gd_image( $image ) ) {
 			throw new \InvalidArgumentException( 'Invalid image resource.' );
 		}
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -31,3 +31,5 @@ parameters:
     ignoreErrors:
         # Uses func_get_args()
         - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
+        - '#^Parameter \#[1-9] \$[a-z_]+ of function [a-z_]+ expects GdImage, GdImage\|resource given\.$#'
+        - '#^Call to function is_resource\(\) with GdImage\|false will always evaluate to false\.$#'

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-bird-avatar-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-bird-avatar-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2019 Peter Putzer.
+ * Copyright 2019-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -92,6 +92,8 @@ class Bird_Avatar_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * Tests ::render_avatar.
 	 *
 	 * @covers ::render_avatar
+	 *
+	 * @uses is_gd_image
 	 */
 	public function test_render_avatar() {
 		// Input.
@@ -106,7 +108,7 @@ class Bird_Avatar_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->sut->shouldReceive( 'create_image' )->once()->with( 'transparent' )->andReturn( $background );
 
-		$this->sut->shouldReceive( 'combine_images' )->times( $parts_number )->with( m::type( 'resource' ), m::type( 'string' ) );
+		$this->sut->shouldReceive( 'combine_images' )->times( $parts_number )->with( m::on( 'is_gd_image' ), m::type( 'string' ) );
 
 		$this->assertSame( $background, $this->sut->render_avatar( $parts, [] ) );
 	}

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-cat-avatar-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-cat-avatar-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2019 Peter Putzer.
+ * Copyright 2019-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -92,6 +92,8 @@ class Cat_Avatar_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * Tests ::render_avatar.
 	 *
 	 * @covers ::render_avatar
+	 *
+	 * @uses is_gd_image
 	 */
 	public function test_render_avatar() {
 		// Input.
@@ -106,7 +108,7 @@ class Cat_Avatar_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->sut->shouldReceive( 'create_image' )->once()->with( 'transparent' )->andReturn( $background );
 
-		$this->sut->shouldReceive( 'combine_images' )->times( $parts_number )->with( m::type( 'resource' ), m::type( 'string' ) );
+		$this->sut->shouldReceive( 'combine_images' )->times( $parts_number )->with( m::on( 'is_gd_image' ), m::type( 'string' ) );
 
 		$this->assertSame( $background, $this->sut->render_avatar( $parts, [] ) );
 	}

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-monster-id-test.php
@@ -183,6 +183,8 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * Tests ::render_avatar.
 	 *
 	 * @covers ::render_avatar
+	 *
+	 * @uses is_gd_image
 	 */
 	public function test_render_avatar() {
 		// Input.
@@ -205,8 +207,8 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->png->shouldReceive( 'create_from_file' )->once()->with( m::pattern( '/\bback\.png$/' ) )->andReturn( $background );
 		$this->png->shouldReceive( 'create_from_file' )->times( $parts_number )->with( m::type( 'string' ) )->andReturn( $fake_image );
 
-		$this->sut->shouldReceive( 'colorize_image' )->times( $parts_number )->with( m::type( 'resource' ), m::type( 'numeric' ), m::type( 'numeric' ), m::type( 'string' ) );
-		$this->sut->shouldReceive( 'combine_images' )->times( $parts_number )->with( m::type( 'resource' ), m::type( 'resource' ) );
+		$this->sut->shouldReceive( 'colorize_image' )->times( $parts_number )->with( m::on( 'is_gd_image' ), m::type( 'numeric' ), m::type( 'numeric' ), m::type( 'string' ) );
+		$this->sut->shouldReceive( 'combine_images' )->times( $parts_number )->with( m::on( 'is_gd_image' ), m::on( 'is_gd_image' ) );
 
 		$this->assertSame( $background, $this->sut->render_avatar( $parts, $args ) );
 	}
@@ -216,6 +218,7 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 	 *
 	 * @covers ::colorize_image
 	 *
+	 * @uses is_gd_image
 	 * @uses Avatar_Privacy\Tools\Images\PNG::hsl_to_rgb
 	 */
 	public function test_colorize_image() {
@@ -229,7 +232,7 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = $this->sut->colorize_image( $resource, $hue, $saturation, $part );
 
-		$this->assert_is_resource( $result );
+		$this->assert_is_gd_image( $result );
 
 		// Clean up.
 		\imageDestroy( $resource );
@@ -240,6 +243,7 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 	 *
 	 * @covers ::colorize_image
 	 *
+	 * @uses is_gd_image
 	 * @uses Avatar_Privacy\Tools\Images\PNG::hsl_to_rgb
 	 */
 	public function test_colorize_image_no_optimization() {
@@ -254,7 +258,7 @@ class Monster_ID_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = $this->sut->colorize_image( $resource, $hue, $saturation, $part );
 
-		$this->assert_is_resource( $result );
+		$this->assert_is_gd_image( $result );
 
 		// Clean up.
 		\imageDestroy( $resource );

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-parts-generator-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-parts-generator-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2019 Peter Putzer.
+ * Copyright 2019-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -326,7 +326,7 @@ class Parts_Generator_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$result = 666;
 
-		$this->number_generator->shouldReceive( 'get' )->once()->with( $type, $count - 1 )->andReturn( $result );
+		$this->number_generator->shouldReceive( 'get' )->once()->with( 0, $count - 1 )->andReturn( $result );
 
 		$this->assertSame( $result, $this->sut->get_random_part_index( $type, $count ) );
 	}

--- a/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar-test.php
+++ b/tests/avatar-privacy/avatar-handlers/default-icons/generators/class-wavatar-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2019-2020 Peter Putzer.
+ * Copyright 2019-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -167,6 +167,8 @@ class Wavatar_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * Tests ::render_avatar.
 	 *
 	 * @covers ::render_avatar
+	 *
+	 * @uses is_gd_image
 	 */
 	public function test_render_avatar() {
 		// Input.
@@ -186,7 +188,7 @@ class Wavatar_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->sut->shouldReceive( 'create_image' )->once()->with( 'white' )->andReturn( $background );
 		$this->png->shouldReceive( 'fill_hsl' )->once()->with( $background, $args['background_hue'], m::type( 'int' ), m::type( 'int' ), 1, 1 );
 
-		$this->sut->shouldReceive( 'combine_images' )->times( $parts_number )->with( m::type( 'resource' ), m::type( 'string' ) );
+		$this->sut->shouldReceive( 'combine_images' )->times( $parts_number )->with( m::on( 'is_gd_image' ), m::type( 'string' ) );
 		$this->png->shouldReceive( 'fill_hsl' )->once()->with( $background, $args['wavatar_hue'], m::type( 'int' ), m::type( 'int' ), m::type( 'int' ), m::type( 'int' ) );
 
 		$this->assertSame( $background, $this->sut->render_avatar( $parts, $args ) );

--- a/tests/avatar-privacy/tools/images/class-editor-test.php
+++ b/tests/avatar-privacy/tools/images/class-editor-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2019-2020 Peter Putzer.
+ * Copyright 2019-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -176,6 +176,8 @@ class Editor_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * Tests ::create_from_image_resource.
 	 *
 	 * @covers ::create_from_image_resource
+	 *
+	 * @uses is_gd_image
 	 */
 	public function test_create_from_image_resource() {
 		$resource = \imageCreateTrueColor( 20, 20 );
@@ -189,6 +191,8 @@ class Editor_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * Tests ::create_from_image_resource.
 	 *
 	 * @covers ::create_from_image_resource
+	 *
+	 * @uses is_gd_image
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled

--- a/tests/avatar-privacy/tools/images/class-png-test.php
+++ b/tests/avatar-privacy/tools/images/class-png-test.php
@@ -43,6 +43,8 @@ use Avatar_Privacy\Exceptions\PNG_Image_Exception;
  *
  * @coversDefaultClass \Avatar_Privacy\Tools\Images\PNG
  * @usesDefaultClass \Avatar_Privacy\Tools\Images\PNG
+ *
+ * @uses is_gd_image
  */
 class PNG_Test extends \Avatar_Privacy\Tests\TestCase {
 
@@ -108,7 +110,7 @@ class PNG_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$image = $this->sut->create( 'white', $width, $height );
 
-		$this->assert_is_resource( $image );
+		$this->assert_is_gd_image( $image );
 		$this->assertSame( $width, \imageSX( $image ) );
 		$this->assertSame( $height, \imageSY( $image ) );
 		$this->assertSame(
@@ -137,7 +139,7 @@ class PNG_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$image = $this->sut->create( 'black', $width, $height );
 
-		$this->assert_is_resource( $image );
+		$this->assert_is_gd_image( $image );
 		$this->assertSame( $width, \imageSX( $image ) );
 		$this->assertSame( $height, \imageSY( $image ) );
 		$this->assertSame(
@@ -166,7 +168,7 @@ class PNG_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$image = $this->sut->create( 'transparent', $width, $height );
 
-		$this->assert_is_resource( $image );
+		$this->assert_is_gd_image( $image );
 		$this->assertSame( $width, \imageSX( $image ) );
 		$this->assertSame( $height, \imageSY( $image ) );
 		$this->assertSame(
@@ -214,7 +216,7 @@ class PNG_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$image = $this->sut->create_from_file( vfsStream::url( 'root/plugin/my_parts_dir/somefile.png' ) );
 
-		$this->assert_is_resource( $image );
+		$this->assert_is_gd_image( $image );
 		$this->assertSame( $width, \imageSX( $image ) );
 		$this->assertSame( $height, \imageSY( $image ) );
 

--- a/tests/class-avatar-privacy-functions-test.php
+++ b/tests/class-avatar-privacy-functions-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018-2020 Peter Putzer.
+ * Copyright 2018-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -44,9 +44,9 @@ use Avatar_Privacy\Components\Comments;
 class Avatar_Privacy_Functions_Test extends TestCase {
 
 	/**
-	 * Tests run method.
+	 * Tests avapr_get_avatar_checkbox function.
 	 *
-	 * @covers ::avapr_get_avatar_checkbox
+	 * @covers avapr_get_avatar_checkbox
 	 *
 	 * @uses Avatar_Privacy\get_gravatar_checkbox
 	 * @uses Avatar_Privacy\Factory::get
@@ -68,9 +68,9 @@ class Avatar_Privacy_Functions_Test extends TestCase {
 	}
 
 	/**
-	 * Tests run method.
+	 * Tests avapr_get_avatar_checkbox function.
 	 *
-	 * @covers ::avapr_get_avatar_checkbox
+	 * @covers avapr_get_avatar_checkbox
 	 *
 	 * @uses Avatar_Privacy\get_gravatar_checkbox
 	 */
@@ -79,5 +79,27 @@ class Avatar_Privacy_Functions_Test extends TestCase {
 		Functions\expect( 'is_user_logged_in' )->once()->andReturn( true );
 
 		$this->assertSame( '', \avapr_get_avatar_checkbox() );
+	}
+
+	/**
+	 * Tests is_gd_image function.
+	 *
+	 * @covers is_gd_image
+	 */
+	public function test_is_gd_image_ok() {
+		$resource = \imageCreate( 10, 10 );
+
+		$this->assertTrue( \is_gd_image( $resource ) );
+
+		\imageDestroy( $resource );
+	}
+
+	/**
+	 * Tests is_gd_image function.
+	 *
+	 * @covers is_gd_image
+	 */
+	public function test_is_gd_image_not_ok() {
+		$this->assertFalse( \is_gd_image( false ) );
 	}
 }

--- a/tests/class-testcase.php
+++ b/tests/class-testcase.php
@@ -31,4 +31,18 @@ namespace Avatar_Privacy\Tests;
  *
  * @since 2.4.0 Refactored to use \Mundschenk\PHPUnit_Cross_Version\TestCase.
  */
-abstract class TestCase extends \Mundschenk\PHPUnit_Cross_Version\TestCase {}
+abstract class TestCase extends \Mundschenk\PHPUnit_Cross_Version\TestCase {
+
+	/**
+	 * Asserts the the argument is a valid GD image.
+	 *
+	 * @since  2.5.0
+	 *
+	 * @param  mixed $image The variable to assert.
+	 *
+	 * @return bool
+	 */
+	public function assert_is_gd_image( $image ) {
+		return $this->assertTrue( \is_gd_image( $image ) );
+	}
+}

--- a/tests/class-testcase.php
+++ b/tests/class-testcase.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2017-2020 Peter Putzer.
+ * Copyright 2017-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -27,8 +27,8 @@
 namespace Avatar_Privacy\Tests;
 
 /**
- * Abstract base class for \PHP_Typography\* unit tests.
+ * Abstract base class for Avatar Privacy unit tests.
  *
- * @since 3.0.0 Refactored to use \Mundschenk\PHPUnit_Cross_Version\TestCase.
+ * @since 2.4.0 Refactored to use \Mundschenk\PHPUnit_Cross_Version\TestCase.
  */
 abstract class TestCase extends \Mundschenk\PHPUnit_Cross_Version\TestCase {}


### PR DESCRIPTION
Fixes #197:

- Adds support for new `GdImage` return type from GD functions.
- Fixes an incorrect test in `Parts_Generator` (that accidentally "worked" in PHP < 8).