### PR TITLE
Fix PHPStan warnings due to GD image change in PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "sirbrillig/phpcs-variable-analysis": "^2.8",
         "sirbrillig/phpcs-import-detection": "^1.2",
         "php-stubs/wp-cli-stubs": "^2.4",
+        "php-stubs/wordpress-stubs": "5.5",
         "szepeviktor/phpstan-wordpress": "^0.7.1"
     },
 

--- a/includes/avatar-privacy-functions.php
+++ b/includes/avatar-privacy-functions.php
@@ -59,7 +59,7 @@ if ( ! \function_exists( 'is_gd_image' ) ) {
 	 *
 	 * @since 2.5.0
 	 *
-	 * @param  resource/GdImage/false $image A value to check the type for.
+	 * @param  resource|GdImage|false $image A value to check the type for.
 	 *
 	 * @return bool                          True if $image is either a GD image
 	 *                                       resource or GdImage instance, false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -32,4 +32,7 @@ parameters:
         # Uses func_get_args()
         - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
         - '#^Parameter \#[1-9] \$[a-z_]+ of function [a-z_]+ expects GdImage, GdImage\|resource given\.$#'
+        - '#^Parameter \#[1-9] \$[a-z_]+ of function [a-z_]+ expects resource, GdImage\|resource given\.$#'
+        - '#^Parameter \#[1-9] \$[a-z_]+ of function [a-z_]+ expects resource, resource\|false given\.$#'
+        - '#^Method Avatar_Privacy(\\[a-zA-Z_]+)+::[a-z_]+\(\) should return GdImage\|resource but returns resource\|false\.$#'
         - '#^Call to function is_resource\(\) with GdImage\|false will always evaluate to false\.$#'

--- a/tests/phpstan/external-classes.php
+++ b/tests/phpstan/external-classes.php
@@ -26,8 +26,14 @@
 
 // phpcs:disable WordPress.NamingConventions, Squiz.Commenting.ClassComment.Missing, Generic.Files.OneObjectStructurePerFile.MultipleFound, Squiz.Commenting.FunctionComment.InvalidNoReturn
 
-// WP User Manager stubs.
+// PHP 8.0 internal classes.
+namespace {
+	if ( \version_compare( \PHP_VERSION, '8.0.0', '<' ) ) {
+		class GdImage {}
+	}
+}
 
+// WP User Manager stubs.
 namespace Carbon_Fields\Field {
 	class Field {
 		/**
@@ -108,6 +114,7 @@ namespace wpdFormAttr\Field {
 
 // Simple Author Box.
 namespace {
+
 	class Simple_Author_Box {
 		/**
 		 * Stub for Simple Author Box.


### PR DESCRIPTION
- Adds `GdImage` stub class on PHP < 8.
- Locks WordPress stubs to prevent conflict with `is_gd_image` polyfill.
- Fixes typo in `is_gd_image` PHPDoc.
- Ignore several warning messages produced by the GD function signature changes between PHP versions.