### PR TITLE
Upgrade collations to prevent "Illegal mix of collations" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.4 (unreleased)
+*   _Bugfix_: Gracefully handle changes to WordPress' default DB collation (no
+    more `Illegal mix of collations` errors). 
+
 ## 2.4.3 (2021-01-15)
 *   _Bugfix_: Don't break stuff (another build process fix, for real this time).
 

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -29,7 +29,7 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at
- * Version: 2.4.3
+ * Version: 2.4.4-beta.1
  * Requires at least: 5.2
  * Requires PHP: 7.0
  * License: GNU General Public License v2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -168,6 +168,9 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 == Changelog ==
 
+= 2.4.4 (unreleased) =
+* _Bugfix_: Gracefully handle changes to WordPress' default DB collation (no more `Illegal mix of collations` errors).
+
 = 2.4.3 (2021-01-15) =
 * _Bugfix_: Don't break stuff (another build process fix, for real this time).
 


### PR DESCRIPTION
- Adds `Table::maybe_upgrade_charset_and_collation()` to work around [Trac #45697](https://core.trac.wordpress.org/ticket/45697). Fixes #230.
- Bumps version to `2.4.4-beta.1`.