### PR TITLE
Fix warnings created by DI container on PHP 8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.1 (2021-03-13)
+*   _Bugfix_: Fixes PHP 8.0 deprecation warning in the `level-2/dice` package.
+
 ## 2.5.0 (2021-03-11)
 *   _Feature_: Avatar Privacy is now compatible with PHP 8.0.
 *   _Feature_: Integration for the following plugins had been added:

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -29,7 +29,7 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at
- * Version: 2.5.0
+ * Version: 2.5.1
  * Requires at least: 5.2
  * Requires PHP: 7.0
  * License: GNU General Public License v2 or later

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=7.0.0",
         "ext-gd": "*",
-        "level-2/dice": "^3.0",
+        "level-2/dice": "^4.0",
         "mundschenk-at/check-wp-requirements": "^2.0",
         "mundschenk-at/wp-data-storage": "^1.0",
         "mundschenk-at/wp-settings-ui": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,17 @@
         }
     ],
 
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/mundschenk-at/Dice/"
+        }
+    ],
+
     "require": {
         "php": ">=7.0.0",
         "ext-gd": "*",
-        "level-2/dice": "^4.0",
+        "level-2/dice": "dev-php8 as 4.0.2",
         "mundschenk-at/check-wp-requirements": "^2.0",
         "mundschenk-at/wp-data-storage": "^1.0",
         "mundschenk-at/wp-settings-ui": "^1.0",

--- a/includes/avatar-privacy/class-factory.php
+++ b/includes/avatar-privacy/class-factory.php
@@ -46,6 +46,9 @@ use Avatar_Privacy\Avatar_Handlers\Gravatar_Cache_Handler;
 use Avatar_Privacy\Avatar_Handlers\Legacy_Icon_Handler;
 use Avatar_Privacy\Avatar_Handlers\User_Avatar_Handler;
 
+use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generated_Icons;
+use Avatar_Privacy\Avatar_Handlers\Default_Icons\Static_Icons;
+
 use Avatar_Privacy\Data_Storage\Cache;
 use Avatar_Privacy\Data_Storage\Database;
 use Avatar_Privacy\Data_Storage\Filesystem_Cache;
@@ -54,13 +57,13 @@ use Avatar_Privacy\Data_Storage\Network_Options;
 use Avatar_Privacy\Data_Storage\Transients;
 use Avatar_Privacy\Data_Storage\Site_Transients;
 
-use Avatar_Privacy\Avatar_Handlers\Default_Icons\Generated_Icons;
-use Avatar_Privacy\Avatar_Handlers\Default_Icons\Static_Icons;
+use Avatar_Privacy\Exceptions\Object_Factory_Exception;
 
 use Avatar_Privacy\Integrations;
 
 use Avatar_Privacy\Tools;
 use Avatar_Privacy\Tools\HTML\User_Form;
+
 
 /**
  * A factory for creating Avatar_Privacy instances via dependency injection.
@@ -94,21 +97,31 @@ class Factory extends Dice {
 	 * Creates a new instance.
 	 */
 	final protected function __construct() {
-		$this->addRules( $this->get_rules() );
 	}
 
 	/**
 	 * Retrieves a factory set up for creating Avatar_Privacy instances.
 	 *
 	 * @since 2.1.0 Parameter $full_plugin_path replaced with AVATAR_PRIVACY_PLUGIN_FILE constant.
+	 * @since 2.5.1 Now throws an Object_Factory_Exception in case of error.
 	 *
 	 * @return Factory
+	 *
+	 * @throws Object_Factory_Exception An exception is thrown if the factory cannot
+	 *                                  be created.
 	 */
 	public static function get() {
 		if ( ! isset( self::$factory ) ) {
 
 			// Create factory.
-			self::$factory = new static();
+			$factory = new static();
+			$factory = $factory->addRules( $factory->get_rules() );
+
+			if ( $factory instanceof Factory ) {
+				self::$factory = $factory;
+			} else {
+				throw new Object_Factory_Exception( 'Could not create object factory.' ); // @codeCoverageIgnore
+			}
 		}
 
 		return self::$factory;

--- a/includes/avatar-privacy/exceptions/class-object-factory-exception.php
+++ b/includes/avatar-privacy/exceptions/class-object-factory-exception.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is part of Avatar Privacy.
+ *
+ * Copyright 2021 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/avatar-privacy
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Avatar_Privacy\Exceptions;
+
+/**
+ * An exception indicating that an error occured while setting up the object factory.
+ *
+ * @since 2.5.1
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ */
+class Object_Factory_Exception extends \RuntimeException {
+}

--- a/readme.txt
+++ b/readme.txt
@@ -169,6 +169,9 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 == Changelog ==
 
+= 2.5.1 (2021-03-13) =
+* _Bugfix_: Fixes PHP 8.0 deprecation warning in the `level-2/dice` package.
+
 = 2.5.0 (2021-03-11) =
 * _Feature_: Avatar Privacy is now compatible with PHP 8.0.
 * _Feature_: Integration for the following plugins had been added:

--- a/tests/avatar-privacy/class-factory-test.php
+++ b/tests/avatar-privacy/class-factory-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018-2020 Peter Putzer.
+ * Copyright 2018-2021 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -86,24 +86,14 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$rules = [
-			'Fake_Class_A' => [
-				'shared'          => true,
-				'constructParams' => [ 'A', 'B' ],
-			],
-			'Fake_Class_B' => [
-				'constructParams' => [ 'C' ],
-			],
-		];
-
-		$this->sut->shouldReceive( 'get_rules' )->once()->andReturn( $rules );
+		$this->sut->shouldReceive( 'get_rules' )->never();
 
 		// Manually call constructor.
 		$this->sut->__construct();
 
 		$resulting_rules = $this->get_value( $this->sut, 'rules' );
 		$this->assert_is_array( $resulting_rules );
-		$this->assertCount( \count( $rules ), $resulting_rules );
+		$this->assertCount( 0, $resulting_rules );
 	}
 
 	/**

--- a/tests/avatar-privacy/class-factory-test.php
+++ b/tests/avatar-privacy/class-factory-test.php
@@ -188,7 +188,7 @@ class Factory_Test extends \Avatar_Privacy\Tests\TestCase {
 	}
 
 	/**
-	 * Test ::get. Should be run after tet_get_plugin_version.
+	 * Test ::get. Should be run after test_get_plugin_version.
 	 *
 	 * @covers ::get
 	 *


### PR DESCRIPTION
Fixes deprecation warnings created by `Dice` when running on PHP 8. Fixes #197.