### PR TITLE
Fix CI workflow after renaming main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
Fixes the CI workflow for `main`.