### PR TITLE
Improve DB caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
 ## 2.6.0 (unreleased)
+*   _Change_: Requires at least WordPress 5.6 and PHP 7.2.
 *   _Change_: Support for Internet Explorer (all extant versions, i.e. 9, 10, and 11)
     has been dropped.
-*   _Change_: Requires at least WordPress 5.6 and PHP 7.2.
+*   _Change_: Improved caching to reduce the number of database queries.
 
 ## 2.5.2 (2021-04-30)
 *   _Bugfix_: When a user is deleted, their local avatar image is removed as well.

--- a/includes/avatar-privacy/components/class-avatar-handling.php
+++ b/includes/avatar-privacy/components/class-avatar-handling.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018-2021 Peter Putzer.
+ * Copyright 2018-2022 Peter Putzer.
  * Copyright 2012-2013 Johannes Freudendahl.
  *
  * This program is free software; you can redistribute it and/or
@@ -298,7 +298,7 @@ class Avatar_Handling implements Component {
 			}
 		} elseif ( empty( $user_id ) && ! empty( $email ) ) {
 			// Check if anonymous comments "as user" are allowed.
-			$user = \get_user_by( 'email', $email );
+			$user = $this->registered_user->get_user_by_email( $email );
 			if ( ! empty( $user ) && $this->registered_user->allows_anonymous_commenting( $user->ID ) ) {
 				$user_id = $user->ID;
 			}

--- a/includes/avatar-privacy/core/class-comment-author-fields.php
+++ b/includes/avatar-privacy/core/class-comment-author-fields.php
@@ -304,7 +304,7 @@ class Comment_Author_Fields implements API {
 		];
 
 		// Update database.
-		$result = $this->hashes_table->replace( $data );
+		$result = $this->hashes_table->insert_or_update_row( $data );
 
 		// Check whether we need to clear the cache.
 		if ( $clear_cache || ! empty( $result ) ) {

--- a/includes/avatar-privacy/core/class-user-fields.php
+++ b/includes/avatar-privacy/core/class-user-fields.php
@@ -93,6 +93,13 @@ class User_Fields implements API {
 	private $image_file;
 
 	/**
+	 * A request-level cache for user lookups.
+	 *
+	 * @var array<string,\WP_User|null>
+	 */
+	private $user_by_email = [];
+
+	/**
 	 * Creates a new instance.
 	 *
 	 * @param Hasher           $hasher     The hashing helper..
@@ -151,6 +158,34 @@ class User_Fields implements API {
 		}
 
 		return $users[0];
+	}
+
+	/**
+	 * Retrieves a user by email.
+	 *
+	 * This method differs from `get_user_by` in that it caches the result even
+	 * if no user is found for the duration of the request.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @param string $email The email to query.
+	 *
+	 * @return \WP_User|null
+	 */
+	public function get_user_by_email( $email ) {
+		if ( isset( $this->user_by_email[ $email ] ) || \array_key_exists( $email, $this->user_by_email ) ) {
+			return $this->user_by_email[ $email ];
+		}
+
+		$user = \get_user_by( 'email', $email );
+		if ( empty( $user ) ) {
+			$user = null;
+		}
+
+		// Cache lookup result.
+		$this->user_by_email[ $email ] = $user;
+
+		return $user;
 	}
 
 	/**

--- a/includes/avatar-privacy/data-storage/database/class-comment-author-table.php
+++ b/includes/avatar-privacy/data-storage/database/class-comment-author-table.php
@@ -68,6 +68,17 @@ class Comment_Author_Table extends Table {
 	];
 
 	/**
+	 * A list auto-update columns (e.g. date-/timestamps).
+	 *
+	 * @since 2.6.0
+	 *
+	 * @var string[]
+	 */
+	const AUTO_UPDATE_COLS = [
+		'last_updated',
+	];
+
+	/**
 	 * The options handler.
 	 *
 	 * @var Network_Options
@@ -83,7 +94,7 @@ class Comment_Author_Table extends Table {
 	 * @param Network_Options $network_options The network options handler.
 	 */
 	public function __construct( Network_Options $network_options ) {
-		parent::__construct( self::TABLE_BASENAME, self::LAST_UPDATED, self::COLUMN_FORMATS );
+		parent::__construct( self::TABLE_BASENAME, self::LAST_UPDATED, self::COLUMN_FORMATS, self::AUTO_UPDATE_COLS );
 
 		$this->network_options = $network_options;
 	}

--- a/includes/avatar-privacy/data-storage/database/class-hashes-table.php
+++ b/includes/avatar-privacy/data-storage/database/class-hashes-table.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2020-2021 Peter Putzer.
+ * Copyright 2020-2022 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -66,10 +66,21 @@ class Hashes_Table extends Table {
 	];
 
 	/**
+	 * A list auto-update columns (e.g. date-/timestamps).
+	 *
+	 * @since 2.6.0
+	 *
+	 * @var string[]
+	 */
+	const AUTO_UPDATE_COLS = [
+		'last_updated',
+	];
+
+	/**
 	 * Creates a new instance.
 	 */
 	public function __construct() {
-		parent::__construct( self::TABLE_BASENAME, self::LAST_UPDATED, self::COLUMN_FORMATS );
+		parent::__construct( self::TABLE_BASENAME, self::LAST_UPDATED, self::COLUMN_FORMATS, self::AUTO_UPDATE_COLS );
 	}
 
 	/**

--- a/includes/avatar-privacy/data-storage/database/class-table.php
+++ b/includes/avatar-privacy/data-storage/database/class-table.php
@@ -532,7 +532,8 @@ abstract class Table {
 	 * @param  int|null $site_id Optional. The site ID. Null means the current
 	 *                           $blog_id. Default null.
 	 *
-	 * @return int|false         The number of rows updated, or false on error.
+	 * @return int|false         The number of rows inserted or updated, or false
+	 *                           on error.
 	 */
 	public function insert_or_update( array $fields, array $rows, $site_id = null ) {
 		try {

--- a/includes/avatar-privacy/data-storage/database/class-table.php
+++ b/includes/avatar-privacy/data-storage/database/class-table.php
@@ -565,6 +565,27 @@ abstract class Table {
 	}
 
 	/**
+	 * Inserts or updates a single row, as required.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @param  array    $data    The data to insert (in column => value pairs).
+	 *                           Both $data columns and $data values should be
+	 *                           "raw" (neither should be SQL escaped). Sending
+	 *                           a null value will cause the column to be set to
+	 *                           NULL - the corresponding format is ignored in
+	 *                           this case.
+	 * @param  int|null $site_id Optional. The site ID. Null means the current
+	 *                           $blog_id. Default null.
+	 *
+	 * @return int|false         The number of rows inserted or updated, or false
+	 *                           on error.
+	 */
+	public function insert_or_update_row( array $data, $site_id = null ) {
+		return $this->insert_or_update( \array_keys( $data ), [ $data ], $site_id );
+	}
+
+	/**
 	 * Retrieves the update clause based on the updated fields.
 	 *
 	 * @since 2.3.0

--- a/includes/avatar-privacy/tools/network/class-remote-image-service.php
+++ b/includes/avatar-privacy/tools/network/class-remote-image-service.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2020-2021 Peter Putzer.
+ * Copyright 2020-2022 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -186,7 +186,7 @@ class Remote_Image_Service {
 				'hash'       => $hash,
 				'type'       => self::IDENTIFIER_TYPE,
 			];
-			$this->table->replace( $data );
+			$this->table->insert_or_update_row( $data );
 
 			// Also prime the URL cache, just in case.
 			$this->cache->set( $key, $url, self::URL_CACHE_DURATION );

--- a/tests/avatar-privacy/components/class-avatar-handling-test.php
+++ b/tests/avatar-privacy/components/class-avatar-handling-test.php
@@ -521,6 +521,9 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 				} else {
 					$user = false;
 				}
+
+				Functions\expect( 'get_user_by' )->once()->with( 'ID', $query )->andReturn( $user );
+
 			} elseif ( 'email' === $get_user_by ) {
 				$query = $email;
 
@@ -530,9 +533,9 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 				} else {
 					$user = false;
 				}
-			}
 
-			Functions\expect( 'get_user_by' )->once()->with( $get_user_by, $query )->andReturn( $user );
+				$this->registered_user->shouldReceive( 'get_user_by_email' )->once()->with( $query )->andReturn( $user );
+			}
 		}
 
 		// The filter should always run.

--- a/tests/avatar-privacy/core/class-comment-author-fields-test.php
+++ b/tests/avatar-privacy/core/class-comment-author-fields-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018-2021 Peter Putzer.
+ * Copyright 2018-2022 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -492,7 +492,7 @@ class Comment_Author_Fields_Test extends \Avatar_Privacy\Tests\TestCase {
 		$hash  = 'hashedemail123';
 
 		$this->sut->shouldReceive( 'get_hash' )->once()->with( $email )->andReturn( $hash );
-		$this->hashes_table->shouldReceive( 'replace' )->once()->with(
+		$this->hashes_table->shouldReceive( 'insert_or_update_row' )->once()->with(
 			[
 				'identifier' => $email,
 				'hash'       => $hash,

--- a/tests/avatar-privacy/core/class-user-fields-test.php
+++ b/tests/avatar-privacy/core/class-user-fields-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018-2021 Peter Putzer.
+ * Copyright 2018-2022 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -202,6 +202,41 @@ class User_Fields_Test extends \Avatar_Privacy\Tests\TestCase {
 		Functions\expect( 'get_users' )->once()->with( m::type( 'array' ) )->andReturn( $users );
 
 		$this->assertNull( $this->sut->get_user_by_hash( $hash ) );
+	}
+
+	/**
+	 * Tests ::get_user_by_email.
+	 *
+	 * @covers ::get_user_by_email
+	 */
+	public function test_get_user_by_email() {
+		$email = 'email@example.org';
+		$user  = m::mock( 'WP_User' );
+
+		Functions\expect( 'get_user_by' )->once()->with( 'email', $email )->andReturn( $user );
+
+		// The first time queries get_user_by.
+		$this->assertSame( $user, $this->sut->get_user_by_email( $email ) );
+
+		// The second time just returns the cached value.
+		$this->assertSame( $user, $this->sut->get_user_by_email( $email ) );
+	}
+
+	/**
+	 * Tests ::get_user_by_email.
+	 *
+	 * @covers ::get_user_by_email
+	 */
+	public function test_get_user_by_email_does_not_exist() {
+		$email = 'email@example.org';
+
+		Functions\expect( 'get_user_by' )->once()->with( 'email', $email )->andReturn( false );
+
+		// The first time queries get_user_by.
+		$this->assertNull( $this->sut->get_user_by_email( $email ) );
+
+		// The second time just returns the cached value.
+		$this->assertNull( $this->sut->get_user_by_email( $email ) );
 	}
 
 	/**

--- a/tests/avatar-privacy/data-storage/database/class-table-test.php
+++ b/tests/avatar-privacy/data-storage/database/class-table-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018-2021 Peter Putzer.
+ * Copyright 2018-2022 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -67,6 +67,9 @@ class Table_Test extends \Avatar_Privacy\Tests\TestCase {
 		'last_updated' => '%s',
 		'log_message'  => '%s',
 	];
+	const AUTO_UPDATE_COLS = [
+		'last_updated',
+	];
 
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
@@ -94,7 +97,7 @@ class Table_Test extends \Avatar_Privacy\Tests\TestCase {
 		set_include_path( 'vfs://root/' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_set_include_path
 
 		// Partially mock system under test.
-		$this->sut = m::mock( Table::class, [ self::TABLE_BASENAME, self::UPDATE_THRESHOLD, self::COLUMN_FORMATS ] )->makePartial()->shouldAllowMockingProtectedMethods();
+		$this->sut = m::mock( Table::class, [ self::TABLE_BASENAME, self::UPDATE_THRESHOLD, self::COLUMN_FORMATS, self::AUTO_UPDATE_COLS ] )->makePartial()->shouldAllowMockingProtectedMethods();
 	}
 
 	/**
@@ -109,13 +112,17 @@ class Table_Test extends \Avatar_Privacy\Tests\TestCase {
 			'foobar' => '%s',
 			'foobaz' => '%d',
 		];
+		$auto_update_cols = [
+			'foobaz',
+		];
 
 		$mock = m::mock( Table::class )->makePartial();
-		$mock->__construct( $table_basename, $update_threshold, $column_formats );
+		$mock->__construct( $table_basename, $update_threshold, $column_formats, $auto_update_cols );
 
 		$this->assert_attribute_same( $table_basename, 'table_basename', $mock );
 		$this->assert_attribute_same( $update_threshold, 'update_threshold', $mock );
 		$this->assert_attribute_same( $column_formats, 'column_formats', $mock );
+		$this->assert_attribute_same( \array_flip( $auto_update_cols ), 'auto_update_cols', $mock );
 	}
 
 	/**
@@ -1016,11 +1023,11 @@ class Table_Test extends \Avatar_Privacy\Tests\TestCase {
 		return [
 			[
 				[ 'email', 'hash', 'use_gravatar' ],
-				"id = id,\nemail = VALUES(email),\nhash = VALUES(hash),\nuse_gravatar = VALUES(use_gravatar),\nlast_updated = last_updated,\nlog_message = log_message",
+				"id = id,\nemail = VALUES(email),\nhash = VALUES(hash),\nuse_gravatar = VALUES(use_gravatar),\nlog_message = log_message",
 			],
 			[
 				[ 'log_message' ],
-				"id = id,\nemail = email,\nhash = hash,\nuse_gravatar = use_gravatar,\nlast_updated = last_updated,\nlog_message = VALUES(log_message)",
+				"id = id,\nemail = email,\nhash = hash,\nuse_gravatar = use_gravatar,\nlog_message = VALUES(log_message)",
 			],
 			[
 				[ 'email', 'hash', 'use_gravatar', 'last_updated', 'log_message' ],

--- a/tests/avatar-privacy/data-storage/database/class-table-test.php
+++ b/tests/avatar-privacy/data-storage/database/class-table-test.php
@@ -1015,6 +1015,26 @@ class Table_Test extends \Avatar_Privacy\Tests\TestCase {
 	}
 
 	/**
+	 * Tests ::insert_or_update_row.
+	 *
+	 * @covers ::insert_or_update_row
+	 */
+	public function test_insert_or_update_row() {
+		$site_id = 3;
+		$data    = [
+			'id'           => 1,
+			'email'        => 'foo@bar.org',
+			'hash'         => 'hash',
+			'use_gravatar' => 1,
+		];
+		$result  = 1;
+
+		$this->sut->shouldReceive( 'insert_or_update' )->once()->with( \array_keys( $data ), [ $data ], $site_id )->andReturn( $result );
+
+		$this->assertSame( $result, $this->sut->insert_or_update_row( $data, $site_id ) );
+	}
+
+	/**
 	 * Provides data for testing get_update_clause.
 	 *
 	 * @return array

--- a/tests/avatar-privacy/tools/network/class-remote-image-service-test.php
+++ b/tests/avatar-privacy/tools/network/class-remote-image-service-test.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2020 Peter Putzer.
+ * Copyright 2020-2022 Peter Putzer.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -310,7 +310,7 @@ class Remote_Image_Service_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->hasher->shouldReceive( 'get_hash' )->once()->with( $url )->andReturn( $hash );
 		$this->cache->shouldReceive( 'get' )->once()->with( $key )->andReturn( false );
 
-		$this->table->shouldReceive( 'replace' )->once()->with(
+		$this->table->shouldReceive( 'insert_or_update_row' )->once()->with(
 			[
 				'identifier' => $url,
 				'hash'       => $hash,
@@ -336,7 +336,7 @@ class Remote_Image_Service_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->hasher->shouldReceive( 'get_hash' )->once()->with( $url )->andReturn( $hash );
 		$this->cache->shouldReceive( 'get' )->once()->with( $key )->andReturn( $url );
 
-		$this->table->shouldReceive( 'replace' )->never();
+		$this->table->shouldReceive( 'insert_or_update_row' )->never();
 		$this->cache->shouldReceive( 'set' )->never();
 
 		$this->assertSame( $hash, $this->sut->get_hash( $url ) );


### PR DESCRIPTION
- Adds new method `Table::insert_or_update_row` for convenience.
- Adds new method `User_Fields::get_user_by_email` to enable caching for all results (i.e. even when there is no user).
- Fixes cache misses due to unnecessarily updated rows in the hashes table.
- Adds request-level caching for update queries.
