### PR TITLE
Release 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Changelog
 
-## 2.6.0 (unreleased)
+## 2.6.0 (2022-04-18)
+*   _Feature_: The size of uploaded images is now checked to make sure processing
+    does not overload the server. By default, all uploaded images have to be smaller
+    than 2000×2000 pixels. The constraints can be adjusted with these new filter
+    hooks:
+    -   `avatar_privacy_upload_min_width`
+    -   `avatar_privacy_upload_min_height`
+    -   `avatar_privacy_upload_max_width`
+    -   `avatar_privacy_upload_max_height`
+*   _Feature_: Improved caching to reduce the number of database queries.
 *   _Change_: Requires at least WordPress 5.6 and PHP 7.2.
 *   _Change_: Support for Internet Explorer (all extant versions, i.e. 9, 10, and 11)
     has been dropped.
-*   _Change_: Improved caching to reduce the number of database queries.
+*   _Change_: A fabulous new plugin icon designed by [Johanna Amann](https://www.instagram.com/_jo_am/).
 
 ## 2.5.2 (2021-04-30)
 *   _Bugfix_: When a user is deleted, their local avatar image is removed as well.

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of Avatar Privacy.
  *
- * Copyright 2018-2021 Peter Putzer.
+ * Copyright 2018-2022 Peter Putzer.
  * Copyright 2012-2013 Johannes Freudendahl.
  *
  * This program is free software; you can redistribute it and/or
@@ -29,7 +29,7 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at
- * Version: 2.6.0-alpha.1
+ * Version: 2.6.0
  * Requires at least: 5.6
  * Requires PHP: 7.2
  * License: GNU General Public License v2 or later

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,8 @@
         "vendor-dir": "vendor",
         "platform-check": false,
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "dangoodman/composer-for-wordpress": true
         }
     },
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: pputzer, Ammaletu
 Tags: gravatar, avatar, privacy, caching, bbpress, buddypress
 Tested up to: 5.9
-Stable tag: 2.5.2
+Stable tag: 2.6.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Avatar Privacy ===
 Contributors: pputzer, Ammaletu
 Tags: gravatar, avatar, privacy, caching, bbpress, buddypress
-Tested up to: 5.8
+Tested up to: 5.9
 Stable tag: 2.5.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -165,6 +165,17 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 
 == Changelog ==
+
+= 2.6.0 (2022-04-18) =
+* _Feature_: The size of uploaded images is now checked to make sure processing does not overload the server. By default, all uploaded images have to be smaller than 2000×2000 pixels. The constraints can be adjusted with these new filter hooks:
+  - `avatar_privacy_upload_min_width`
+  - `avatar_privacy_upload_min_height`
+  - `avatar_privacy_upload_max_width`
+  - `avatar_privacy_upload_max_height`
+* _Feature_: Improved caching to reduce the number of database queries.
+* _Change_: Requires at least WordPress 5.6 and PHP 7.2.
+* _Change_: Support for Internet Explorer (all extant versions, i.e. 9, 10, and 11) has been dropped.
+* _Change_: A fabulous new plugin icon designed by [Johanna Amann](https://www.instagram.com/_jo_am/).
 
 = 2.5.2 (2021-04-30) =
 * _Bugfix_: When a user is deleted, their local avatar image is removed as well.


### PR DESCRIPTION
- Bumps version to `2.6.0`.
- Bumps `Tested up to` to `5.9`. 
- Updates CHANGELOG.
- Fixes classloader naming.