### PR TITLE
Allow legacy icons from gravatar.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 *   _Feature_: Avatar Privacy is now compatible with PHP 8.2.
 *   _Feature_: The plugin now honors the `wp_delete_file` filter when deleting files.
 *   _Change_: Requires at least PHP 7.4.
+*   _Bugfix_: Icons from Webmentions using Gravatar will get cached now.
 
 ## 2.6.0 (2022-04-18)
 *   _Feature_: The size of uploaded images is now checked to make sure processing

--- a/includes/avatar-privacy/components/class-avatar-handling.php
+++ b/includes/avatar-privacy/components/class-avatar-handling.php
@@ -223,7 +223,7 @@ class Avatar_Handling implements Component {
 				// Maybe display a gravatar.
 				if ( $this->should_show_gravatar( $user_id, $email, $id_or_email, $age, $mimetype ) ) {
 					$url = $this->get_gravatar_url( $user_id, $email, $hash, $args['size'], $args['rating'], $mimetype );
-				} elseif ( ! empty( $args['url'] ) && $this->is_valid_image_url( $args['url'] ) ) {
+				} elseif ( ! empty( $args['url'] ) && $this->remote_images->validate_image_url( $args['url'], 'avatar' ) ) {
 					// Fall back to avatars set by other plugins.
 					$url = $this->get_legacy_icon_url( $args['url'], $args['size'] );
 				}
@@ -638,11 +638,15 @@ class Avatar_Handling implements Component {
 	 *
 	 * @since 2.4.0
 	 *
+	 * @deprecated 2.7.0
+	 *
 	 * @param  string $url The image URL.
 	 *
 	 * @return bool
 	 */
 	protected function is_valid_image_url( $url ) {
+		\_deprecated_function( __METHOD__, '2.7.0', 'Avatar_Privacy\Tools\Network\Remote_Image_Service::validate_image_url' );
+
 		return ( ! \strpos( $url, 'gravatar.com' ) && $this->remote_images->validate_image_url( $url, 'avatar' ) );
 	}
 

--- a/tests/avatar-privacy/components/class-avatar-handling-test.php
+++ b/tests/avatar-privacy/components/class-avatar-handling-test.php
@@ -295,7 +295,7 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 				$this->sut->shouldReceive( 'get_gravatar_url' )->never();
 
 				if ( ! empty( $legacy_url ) ) {
-					$this->sut->shouldReceive( 'is_valid_image_url' )->once()->with( $legacy_url )->andReturn( true );
+					$this->remote_images->shouldReceive( 'validate_image_url' )->once()->with( $legacy_url, 'avatar' )->andReturn( true );
 					$this->sut->shouldReceive( 'get_legacy_icon_url' )->once()->with( $legacy_url, $size )->andReturn( $legacy_url );
 				}
 			}
@@ -353,7 +353,7 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 
 		$this->sut->shouldReceive( 'get_default_icon_url' )->never();
 		$this->sut->shouldReceive( 'get_gravatar_url' )->never();
-		$this->sut->shouldReceive( 'is_valid_image_url' )->never();
+		$this->remote_images->shouldReceive( 'validate_image_url' )->never();
 		$this->sut->shouldReceive( 'get_legacy_icon_url' )->never();
 
 		$avatar_response = $this->sut->get_avatar_data( $args, $id_or_email );
@@ -392,7 +392,7 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->comment_author->shouldReceive( 'get_hash' )->once()->with( $email )->andReturn( $hash );
 
 		$this->sut->shouldReceive( 'should_show_gravatar' )->once()->with( $user_id, $email, $id_or_email, $age, m::type( 'string' ) )->andReturn( false );
-		$this->sut->shouldReceive( 'is_valid_image_url' )->once()->with( $remote_url )->andReturn( true );
+		$this->remote_images->shouldReceive( 'validate_image_url' )->once()->with( $remote_url, 'avatar' )->andReturn( true );
 		$this->sut->shouldReceive( 'get_legacy_icon_url' )->once()->with( $remote_url, $size )->andReturn( $remote_url );
 		$this->sut->shouldReceive( 'get_default_icon_url' )->never();
 
@@ -935,6 +935,8 @@ class Avatar_Handling_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @param  bool   $result The expected result.
 	 */
 	public function test_is_valid_image_url( $url, $result ) {
+		Functions\expect( '_deprecated_function' )->once()->with( m::type( 'string' ), '2.7.0', m::type( 'string' ) );
+
 		$this->remote_images->shouldReceive( 'validate_image_url' )->atMost()->once()->with( $url, 'avatar' )->andReturn( $result );
 
 		$this->assertSame( $result, $this->sut->is_valid_image_url( $url ) );


### PR DESCRIPTION
Disables the obsolete check for ”legacy icons” (e.g. coming from webmentions) not containing `gravatar.com`. Fixes #270.