### PR TITLE
Don't use wpdb::prepare for querying server variables

### DIFF
--- a/includes/avatar-privacy/data-storage/database/class-hashes-table.php
+++ b/includes/avatar-privacy/data-storage/database/class-hashes-table.php
@@ -129,7 +129,7 @@ class Hashes_Table extends Table {
 	protected function database_supports_large_index(): bool {
 		global $wpdb;
 
-		$innodb_version = $wpdb->get_var( $wpdb->prepare( 'SHOW VARIABLES LIKE "innodb_version"' ), 1 ) ?? '';  // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQuery -- No caching necessary, no actual wildcards used.
+		$innodb_version = $wpdb->get_var( 'SHOW VARIABLES LIKE "innodb_version"', 1 ) ?? '';  // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- No caching necessary, no actual wildcards used.
 
 		return \version_compare( $innodb_version, '5.7', '>=' );
 	}

--- a/tests/avatar-privacy/data-storage/database/class-hashes-table-test.php
+++ b/tests/avatar-privacy/data-storage/database/class-hashes-table-test.php
@@ -143,8 +143,7 @@ class Hashes_Table_Test extends \Avatar_Privacy\Tests\TestCase {
 		global $wpdb;
 		$wpdb = m::mock( \wpdb::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
-		$wpdb->shouldReceive( 'prepare' )->once()->with( 'SHOW VARIABLES LIKE "innodb_version"',  )->andReturn( 'PREPARED_SQL' );
-		$wpdb->shouldReceive( 'get_var' )->once()->with( 'PREPARED_SQL', 1 )->andReturn( $innodb_version );
+		$wpdb->shouldReceive( 'get_var' )->once()->with( 'SHOW VARIABLES LIKE "innodb_version"', 1 )->andReturn( $innodb_version );
 
 		$this->assertSame( $result, $this->sut->database_supports_large_index() );
 	}


### PR DESCRIPTION
- Drops the use of `wpdb::prepare` for querying server variables when no placeholder is needed (bug introduced in #276).