### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           echo "AVATAR_PRIVACY_VERSION=$(sed -n 's/^.*Version: \(.*\)$/\1/p' avatar-privacy.php)" >> $GITHUB_ENV
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v1.7
+        uses: SonarSource/sonarcloud-github-action@v1.9
         with:
           args: >
             -Dsonar.projectVersion=${{ env.AVATAR_PRIVACY_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,14 @@ jobs:
         run: |
           sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' phpunit.coverage.xml
           sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' phpunit.test-report.xml
+      - name: Extract version number
+        run: |
+          echo "AVATAR_PRIVACY_VERSION=$(sed -n 's/^.*Version: \(.*\)$/\1/p' avatar-privacy.php)" >> $GITHUB_ENV
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v1.7
+        with:
+          args: >
+            -Dsonar.projectVersion=${{ env.AVATAR_PRIVACY_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -29,7 +29,7 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at
- * Version: 2.7.0-alpha.1
+ * Version: 2.7.0-alpha.2
  * Requires at least: 5.6
  * Requires PHP: 7.4
  * License: GNU General Public License v2 or later


### PR DESCRIPTION
- Bumps version to `2.7.0-alpha.2`
- Uses never version of `SonarSource/sonarcloud-github-action` action again after upstream fixes.
- Extracts plugin version for CI.