### PR TITLE
Release 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 *   _Change_: Upgrades `identifier` column of `avatar_privacy_hashes` table to
     256 characters on supported MySQL/MariaDB versions (as it was in 2.4.0).
 *   _Change_: The library `yzalis/identicon` has been removed as a dependency.
+*   _Change_: Avatar Privacy now honors the `wp_delete_file` filter hook.
 *   _Bugfix_: Icons from Webmentions using Gravatar will get cached now.
 *   _Bugfix_: Uploading avatars for users with no role on the primary site
     of a Multsite network now works as expected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.7.0 (unreleased)
+## 2.7.0 (2023-05-01)
 *   _Feature_: Avatar Privacy is now compatible with PHP 8.2.
 *   _Feature_: The plugin now honors the `wp_delete_file` filter when deleting files.
 *   _Change_: Requires at least PHP 7.4.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,6 +29,9 @@ module.exports = function(grunt) {
 				"!build/vendor-scoped/**/partials",
 				// Prune PNG-based RingIcon.
 				"build/vendor-scoped/splitbrain/php-ringicon/src/RingIcon.php",
+				// Prune PNG-based Jdenticon.
+				"build/vendor-scoped/jdenticon/jdenticon/src/Rendering/{ImagickRenderer.php,InternalPngRenderer.php}",
+				"build/vendor-scoped/jdenticon/jdenticon/src/Canvas",
 			],
 		},
 

--- a/avatar-privacy.php
+++ b/avatar-privacy.php
@@ -29,7 +29,7 @@
  * Description: Adds options to enhance the privacy when using avatars.
  * Author: Peter Putzer
  * Author URI: https://code.mundschenk.at
- * Version: 2.7.0-alpha.3
+ * Version: 2.7.0
  * Requires at least: 5.6
  * Requires PHP: 7.4
  * License: GNU General Public License v2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -166,6 +166,16 @@ The default avatar image is set to the mystery man if you selected one of the ne
 
 == Changelog ==
 
+= 2.7.0 (2023-05-01) =
+* _Feature_: Avatar Privacy is now compatible with PHP 8.2.
+* _Feature_: The plugin now honors the `wp_delete_file` filter when deleting files.
+* _Change_: Requires at least PHP 7.4.
+* _Change_: Upgrades `identifier` column of `avatar_privacy_hashes` table to 256 characters on supported MySQL/MariaDB versions (as it was in 2.4.0).
+* _Change_: The library `yzalis/identicon` has been removed as a dependency.
+* _Change_: Avatar Privacy now honors the `wp_delete_file` filter hook.
+* _Bugfix_: Icons from Webmentions using Gravatar will get cached now.
+* _Bugfix_: Uploading avatars for users with no role on the primary site of a Multsite network now works as expected.
+
 = 2.6.0 (2022-04-18) =
 * _Feature_: The size of uploaded images is now checked to make sure processing does not overload the server. By default, all uploaded images have to be smaller than 2000×2000 pixels. The constraints can be adjusted with these new filter hooks:
   - `avatar_privacy_upload_min_width`

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: pputzer, Ammaletu
 Tags: gravatar, avatar, privacy, caching, bbpress, buddypress
 Tested up to: 5.9
-Stable tag: 2.6.0
+Stable tag: 2.7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
- Updates version to `2.7.0`.
- Removes unused `Jdenticon` classes from build. Fixes #285.
- Updates CHANGELOG.