### PR TITLE
Bump "Tested up to:" to WordPress 6.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Avatar Privacy ===
 Contributors: pputzer, Ammaletu
 Tags: gravatar, avatar, privacy, caching, bbpress, buddypress
-Tested up to: 5.9
+Tested up to: 6.2
 Stable tag: 2.7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
- Bumps `Tested up to:` version to `6.2`.