### PR TITLE
Enable xdebug in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          coverage: none
+          coverage: xdebug
           extensions: gd
       - name: Setup problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"


### PR DESCRIPTION
CI output in #289 says xdebug is needed.

https://github.com/mundschenk-at/avatar-privacy/blob/9922e70510c50ac7db4d955f5f015801a8af2d07/tests/avatar-privacy/components/class-comments-test.php#L562