### PR TITLE
Prevent early use of i18n functions

### DIFF
--- a/includes/avatar-privacy/core/class-settings.php
+++ b/includes/avatar-privacy/core/class-settings.php
@@ -110,13 +110,18 @@ class Settings implements API {
 	const GRAVATAR_USE_DEFAULT = 'gravatar_use_default';
 
 	/**
-	 * The defaults array.
+	 * The defaults for the options array.
 	 *
-	 * @var array
+	 * @since 2.8.0
 	 *
+	 * @var array<string,mixed>
 	 * @phpstan-var SettingsFields
 	 */
-	private array $defaults;
+	private const DEFAULTS = [
+		self::UPLOAD_CUSTOM_DEFAULT_AVATAR => [],
+		self::GRAVATAR_USE_DEFAULT         => false,
+		Options::INSTALLED_VERSION         => '',
+	];
 
 	/**
 	 * The fields definition array.
@@ -236,11 +241,10 @@ class Settings implements API {
 	 */
 	protected function load_settings() {
 		$_settings = $this->options->get( self::OPTION_NAME );
-		$_defaults = $this->get_defaults();
 		$modified  = false;
 
 		if ( \is_array( $_settings ) ) {
-			foreach ( $_defaults as $name => $default_value ) {
+			foreach ( self::DEFAULTS as $name => $default_value ) {
 				if ( ! isset( $_settings[ $name ] ) ) {
 					$_settings[ $name ] = $default_value;
 					$modified           = true;
@@ -253,7 +257,7 @@ class Settings implements API {
 			 * @phpstan-var SettingsFields $_settings
 			 */
 		} else {
-			$_settings = $_defaults;
+			$_settings = self::DEFAULTS;
 			$modified  = true;
 		}
 
@@ -354,7 +358,7 @@ class Settings implements API {
 					'erase_checkbox' => Custom_Default_Icon_Upload_Handler::CHECKBOX_ERASE,
 					'action'         => Custom_Default_Icon_Upload_Handler::ACTION_UPLOAD,
 					'nonce'          => Custom_Default_Icon_Upload_Handler::NONCE_UPLOAD,
-					'default'        => 0,
+					'default'        => self::DEFAULTS[ self::UPLOAD_CUSTOM_DEFAULT_AVATAR ],
 					'attributes'     => [ 'accept' => 'image/*' ],
 					'settings_args'  => [ 'class' => 'avatar-settings' ],
 				],
@@ -372,7 +376,7 @@ class Settings implements API {
 					/* translators: 1: checkbox HTML */
 					'label'            => \__( '%1$s Display Gravatar images by default.', 'avatar-privacy' ),
 					'help_text'        => \__( 'Checking will ensure that gravatars are displayed when there is no explicit setting for the user or mail address (e.g. for comments made before installing Avatar Privacy). Please only enable this setting after careful consideration of the privacy implications.', 'avatar-privacy' ),
-					'default'          => 0,
+					'default'          => self::DEFAULTS[ self::GRAVATAR_USE_DEFAULT ],
 					'grouped_with'     => self::INFORMATION_HEADER,
 					'outer_attributes' => [ 'class' => 'avatar-settings-enabled' ],
 				], // @codeCoverageIgnoreEnd
@@ -392,31 +396,16 @@ class Settings implements API {
 	/**
 	 * Retrieves the default settings.
 	 *
+	 * @deprecated 2.8.0
+	 *
 	 * @return array
 	 *
 	 * @phpstan-return SettingsFields
 	 */
 	public function get_defaults() {
-		if ( ! isset( $this->defaults ) ) {
-			$_defaults = [];
-			foreach ( $this->get_fields() as $index => $field ) {
-				if ( isset( $field['default'] ) ) {
-					$_defaults[ $index ] = $field['default'];
-				}
-			}
+		\_deprecated_function( __METHOD__, '2.8.0' );
 
-			// Allow detection of new installations.
-			$_defaults[ Options::INSTALLED_VERSION ] = '';
-
-			/**
-			 * PHPStan type.
-			 *
-			 * @phpstan-var SettingsFields $_defaults
-			 */
-			$this->defaults = $_defaults;
-		}
-
-		return $this->defaults;
+		return self::DEFAULTS;
 	}
 
 	/**

--- a/tests/avatar-privacy/core/class-settings-test.php
+++ b/tests/avatar-privacy/core/class-settings-test.php
@@ -232,24 +232,15 @@ class Settings_Test extends \Avatar_Privacy\Tests\TestCase {
 	 */
 	public function test_load_settings() {
 		$setting1 = 'foo';
-		$setting2 = 'baz';
 		$settings = [
 			$setting1                  => 'barfoo',
 			Options::INSTALLED_VERSION => '1.2.3',
-		];
-		$defaults = [
-			$setting1 => 'bar',
-			$setting2 => 'foobar',
 		];
 
 		$this->options->shouldReceive( 'get' )
 			->once()
 			->with( Settings::OPTION_NAME )
 			->andReturn( $settings );
-
-		$this->sut->shouldReceive( 'get_defaults' )
-			->once()
-			->andReturn( $defaults );
 
 		$this->options->shouldReceive( 'set' )
 			->once()
@@ -260,9 +251,12 @@ class Settings_Test extends \Avatar_Privacy\Tests\TestCase {
 		$this->assert_is_array( $result );
 		$this->assertArrayHasKey( $setting1, $result );
 		$this->assertSame( 'barfoo', $result[ $setting1 ] );
-		$this->assertArrayHasKey( $setting2, $result );
-		$this->assertSame( 'foobar', $result[ $setting2 ] );
+		$this->assertArrayHasKey( Settings::UPLOAD_CUSTOM_DEFAULT_AVATAR, $result );
+		$this->assertSame( [], $result[ Settings::UPLOAD_CUSTOM_DEFAULT_AVATAR ] );
+		$this->assertArrayHasKey( Settings::GRAVATAR_USE_DEFAULT, $result );
+		$this->assertSame( false, $result[ Settings::GRAVATAR_USE_DEFAULT ] );
 		$this->assertArrayHasKey( Options::INSTALLED_VERSION, $result );
+		$this->assertSame( '1.2.3', $result[ Options::INSTALLED_VERSION ] );
 	}
 
 	/**
@@ -271,25 +265,24 @@ class Settings_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @covers ::load_settings
 	 */
 	public function test_load_settings_invalid_result() {
-		$defaults = [
-			'foo' => 'bar',
-			'baz' => 'foobar',
-		];
-
 		$this->options->shouldReceive( 'get' )
 			->once()
 			->with( Settings::OPTION_NAME )
 			->andReturn( false );
 
-		$this->sut->shouldReceive( 'get_defaults' )
-			->once()
-			->andReturn( $defaults );
-
 		$this->options->shouldReceive( 'set' )
 			->once()
 			->with( Settings::OPTION_NAME, m::type( 'array' ) );
 
-		$this->assertSame( $defaults, $this->sut->load_settings() );
+		$result = $this->sut->load_settings();
+
+		$this->assert_is_array( $result );
+		$this->assertArrayHasKey( Settings::UPLOAD_CUSTOM_DEFAULT_AVATAR, $result );
+		$this->assertSame( [], $result[ Settings::UPLOAD_CUSTOM_DEFAULT_AVATAR ] );
+		$this->assertArrayHasKey( Settings::GRAVATAR_USE_DEFAULT, $result );
+		$this->assertSame( false, $result[ Settings::GRAVATAR_USE_DEFAULT ] );
+		$this->assertArrayHasKey( Options::INSTALLED_VERSION, $result );
+		$this->assertSame( '', $result[ Options::INSTALLED_VERSION ] );
 	}
 
 	/**
@@ -299,22 +292,18 @@ class Settings_Test extends \Avatar_Privacy\Tests\TestCase {
 	 */
 	public function test_load_settings_everything_in_order() {
 		$settings = [
-			'foo' => 'barfoo',
-			'baz' => 'foo',
-		];
-		$defaults = [
-			'foo' => 'bar',
-			'baz' => 'foobar',
+			Settings::UPLOAD_CUSTOM_DEFAULT_AVATAR => [
+				'file' => '/some/avatar-image.png',
+				'type' => 'image/png',
+			],
+			Settings::GRAVATAR_USE_DEFAULT         => true,
+			Options::INSTALLED_VERSION             => '9.9.9',
 		];
 
 		$this->options->shouldReceive( 'get' )
 			->once()
 			->with( Settings::OPTION_NAME )
 			->andReturn( $settings );
-
-		$this->sut->shouldReceive( 'get_defaults' )
-			->once()
-			->andReturn( $defaults );
 
 		$this->options->shouldReceive( 'set' )->never();
 
@@ -473,6 +462,8 @@ class Settings_Test extends \Avatar_Privacy\Tests\TestCase {
 	 * @uses ::get_fields
 	 */
 	public function test_get_defaults() {
+		Functions\expect( '_deprecated_function' )->once()->with( m::type( 'string' ), '2.8.0' );
+
 		$result = $this->sut->get_defaults();
 
 		$this->assert_is_array( $result );


### PR DESCRIPTION
- Replaces Settings::get_defaults() with private constant